### PR TITLE
ci: replace usage of `--immutable` to `--frozen-lockfile`

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Node modules
-        run: yarn install --immutable
+        run: yarn install --frozen-lockfile
 
       - name: Check licenses
         run: license_finder --decisions-file=license-finder-decisions.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,6 @@ jobs:
       with:
         node-version: 16.x
         cache: yarn
-    - run:  yarn install --immutable
+    - run:  yarn install --frozen-lockfile
     - run:  yarn build
     - run:  yarn lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           node-version: 16.x
           cache: yarn
-      - run: yarn install --immutable
+      - run: yarn install --frozen-lockfile
       - run: yarn build
       - name: Archive executables to zip
         working-directory: /tmp

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: yarn
-    - run: yarn install --immutable
+    - run: yarn install --frozen-lockfile
     - run: yarn build
     - run: yarn test:ci


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Because `--immutable` option is for yarn v3.

## What

<!-- What is a solution you want to add? -->

- [x] replace usage of  `--immutable` to `--frozen-lockfile`

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/js-sdk/blob/master/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
