### PR TITLE
chore: support request over proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Options:
       --update-key           The key to Bulk Update                     [string]
       --pfx-file-path        The path to client certificate file        [string]
       --pfx-file-password    The password of client certificate file    [string]
+      --proxy                The URL of a proxy server
+                                                 [string] [default: HTTPS_PROXY]
 ```
 
 #### Import Attachment field
@@ -136,6 +138,8 @@ Options:
       --order-by             The sort order as a query                  [string]
       --pfx-file-path        The path to client certificate file        [string]
       --pfx-file-password    The password of client certificate file    [string]
+      --proxy                The URL of a proxy server
+                                                 [string] [default: HTTPS_PROXY]
 ```
 
 #### Download attachment files

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "dependencies": {
     "@kintone/rest-api-client": "^3.1.5",
     "csv-parse": "^4.16.3",
+    "https-proxy-agent": "^5.0.1",
     "iconv-lite": "^0.6.3",
     "yargs": "^17.5.1"
   }

--- a/src/cli/record/export.ts
+++ b/src/cli/record/export.ts
@@ -103,7 +103,7 @@ const builder = (args: yargs.Argv) =>
       requiresArg: true,
     })
     .option("proxy", {
-      describe: "The URL of an proxy server",
+      describe: "The URL of a proxy server",
       default: process.env.HTTPS_PROXY ?? process.env.https_proxy,
       defaultDescription: "HTTPS_PROXY",
       type: "string",

--- a/src/cli/record/export.ts
+++ b/src/cli/record/export.ts
@@ -101,6 +101,12 @@ const builder = (args: yargs.Argv) =>
       describe: "The password of client certificate file",
       type: "string",
       requiresArg: true,
+    })
+    .option("proxy", {
+      describe: "The URL of an proxy server",
+      default: process.env.HTTPS_PROXY ?? process.env.https_proxy,
+      defaultDescription: "HTTPS_PROXY",
+      type: "string",
     });
 
 type Args = yargs.Arguments<
@@ -123,6 +129,7 @@ const handler = (args: Args) => {
     orderBy: args["order-by"],
     pfxFilePath: args["pfx-file-path"],
     pfxFilePassword: args["pfx-file-password"],
+    httpsProxy: args.proxy,
   });
 };
 

--- a/src/cli/record/import.ts
+++ b/src/cli/record/import.ts
@@ -104,7 +104,7 @@ const builder = (args: yargs.Argv) =>
       requiresArg: true,
     })
     .option("proxy", {
-      describe: "The URL of an proxy server",
+      describe: "The URL of a proxy server",
       default: process.env.HTTPS_PROXY ?? process.env.https_proxy,
       defaultDescription: "HTTPS_PROXY",
       type: "string",

--- a/src/cli/record/import.ts
+++ b/src/cli/record/import.ts
@@ -102,6 +102,12 @@ const builder = (args: yargs.Argv) =>
       describe: "The password of client certificate file",
       type: "string",
       requiresArg: true,
+    })
+    .option("proxy", {
+      describe: "The URL of an proxy server",
+      default: process.env.HTTPS_PROXY ?? process.env.https_proxy,
+      defaultDescription: "HTTPS_PROXY",
+      type: "string",
     });
 
 type Args = yargs.Arguments<
@@ -124,6 +130,7 @@ const handler = (args: Args) => {
     encoding: args.encoding,
     pfxFilePath: args["pfx-file-path"],
     pfxFilePassword: args["pfx-file-password"],
+    httpsProxy: args.proxy,
   });
 };
 

--- a/src/kintone/client.ts
+++ b/src/kintone/client.ts
@@ -45,7 +45,7 @@ const buildBasicAuthParam = (options: RestAPIClientOptions) => {
 };
 
 type ProxyConfig = {
-  protocol: string;
+  protocol?: string;
   host: string;
   port: number;
   auth?: {
@@ -56,16 +56,15 @@ type ProxyConfig = {
 
 const buildProxyConfig = (proxy: string): ProxyConfig | undefined => {
   const { protocol, hostname: host, port, username, password } = new URL(proxy);
-  let auth;
-  if (username.length > 0 && password.length > 0) {
-    auth = { username, password };
+  const proxyConfig: ProxyConfig = { host, port: Number(port) };
+
+  if (protocol.length > 0) {
+    proxyConfig.protocol = protocol;
   }
-  return {
-    protocol,
-    host,
-    port: Number(port),
-    auth,
-  };
+  if (username.length > 0 && password.length > 0) {
+    proxyConfig.auth = { username, password };
+  }
+  return proxyConfig;
 };
 
 const buildHttpsAgent = (options: {

--- a/src/kintone/client.ts
+++ b/src/kintone/client.ts
@@ -15,6 +15,7 @@ export type RestAPIClientOptions = {
   pfxFilePath?: string;
   pfxFilePassword?: string;
   userAgent?: string;
+  httpsProxy?: string;
 };
 
 const buildAuthParam = (options: RestAPIClientOptions) => {
@@ -94,17 +95,17 @@ const buildHttpsAgent = (options: {
 };
 
 export const buildRestAPIClient = (options: RestAPIClientOptions) => {
-  const httpsProxy =
-    process.env.HTTPS_PROXY ?? process.env.https_proxy ?? undefined;
   return new KintoneRestAPIClient({
     baseUrl: options.baseUrl,
     auth: buildAuthParam(options),
     ...buildBasicAuthParam(options),
     ...(options.guestSpaceId ? { guestSpaceId: options.guestSpaceId } : {}),
     userAgent: `${packageJson.name}@${packageJson.version}`,
-    ...(httpsProxy ? { proxy: buildProxyConfig(httpsProxy) } : {}),
+    ...(options.httpsProxy
+      ? { proxy: buildProxyConfig(options.httpsProxy) }
+      : {}),
     httpsAgent: buildHttpsAgent({
-      proxy: httpsProxy,
+      proxy: options.httpsProxy,
       pfxFilePath: options.pfxFilePath,
       pfxFilePassword: options.pfxFilePassword,
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2978,7 +2978,7 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-https-proxy-agent@^5.0.0:
+https-proxy-agent@^5.0.0, https-proxy-agent@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
   integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Because cli-kintone v0 unofficially supports requests over proxy by setting the `HTTPS_PROXY` environment variable. 
https://developer.cybozu.io/hc/ja/community/posts/115019277543

## What

<!-- What is a solution you want to add? -->

When the `HTTPS_PROXY` environment variable is set, cli-kintone sends requests over proxy

- [x] support proxy
  - `--proxy` cli option
  - `HTTPS_PROXY` environment variable
  - `https_proxy` environment variable
- [x] fix and add tests
- [ ] update README.md

## How to test

<!-- How can we test this pull request? -->

```
yarn install
yarn build

# configure by cli option
node ./cli.js record export --app $APP_ID --proxy <protocol://server:port>

# configure by HTTPS_PROXY environment varibale
HTTPS_PROXY=<protocol://server:port> node ./cli.js record export --app $APP_ID

# configure by https_proxy environment varibale
https_proxy=<protocol://server:port> node ./cli.js record export --app $APP_ID
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
