### PR TITLE
feat: sort fields based on form layout when record export

### DIFF
--- a/src/kintone/types.ts
+++ b/src/kintone/types.ts
@@ -1,5 +1,6 @@
 import {
   KintoneFormFieldProperty,
+  KintoneFormLayout,
   KintoneRecordField,
 } from "@kintone/rest-api-client";
 
@@ -32,4 +33,15 @@ export type FieldProperties = Record<string, KintoneFormFieldProperty.OneOf>;
 export type FieldsJson = {
   properties: FieldProperties;
   revision: Revision;
+};
+
+export type LayoutJson = {
+  layout: Array<
+    | KintoneFormLayout.Row<KintoneFormLayout.Field.OneOf[]>
+    | KintoneFormLayout.Subtable<KintoneFormLayout.Field.InSubtable[]>
+    | KintoneFormLayout.Group<
+        Array<KintoneFormLayout.Row<KintoneFormLayout.Field.OneOf[]>>
+      >
+  >;
+  revision: string;
 };

--- a/src/record/export/printers/index.ts
+++ b/src/record/export/printers/index.ts
@@ -23,6 +23,7 @@ export const printRecords: (options: {
       printAsCsv(
         records,
         await apiClient.app.getFormFields({ app }),
+        await apiClient.app.getFormLayout({ app }),
         useLocalFilePath
       );
       break;

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/header/file_layout.json
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/header/file_layout.json
@@ -1,0 +1,128 @@
+{
+  "revision": "29",
+  "layout": [
+    {
+      "type": "ROW",
+      "fields": [
+        {
+          "type": "RECORD_NUMBER",
+          "code": "recordNumber",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "UPDATED_TIME",
+          "code": "updatedTime",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "DROP_DOWN",
+          "code": "dropDown",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "CREATOR",
+          "code": "creator",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "MODIFIER",
+          "code": "modifier",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "RICH_TEXT",
+          "code": "richText",
+          "size": {
+            "width": "123",
+            "innerHeight": "123"
+          }
+        }
+      ]
+    },
+    {
+      "type": "ROW",
+      "fields": [
+        {
+          "type": "SINGLE_LINE_TEXT",
+          "code": "singleLineText",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "NUMBER",
+          "code": "number",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "RADIO_BUTTON",
+          "code": "radioButton",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "MULTI_LINE_TEXT",
+          "code": "multiLineText",
+          "size": {
+            "width": "123",
+            "innerHeight": "123"
+          }
+        },
+        {
+          "type": "CREATED_TIME",
+          "code": "createdTime",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "CHECK_BOX",
+          "code": "checkBox",
+          "size": {
+            "width": "123"
+          }
+        }
+      ]
+    },
+    {
+      "type": "ROW",
+      "fields": [
+        {
+          "type": "CALC",
+          "code": "calc",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "MULTI_LINE_TEXT",
+          "code": "multiSelect",
+          "size": {
+            "width": "123",
+            "innerHeight": "123"
+          }
+        },
+        {
+          "type": "FILE",
+          "code": "file",
+          "size": {
+            "width": "123"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/header/layout.json
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/header/layout.json
@@ -1,0 +1,179 @@
+{
+  "revision": "29",
+  "layout": [
+    {
+      "type": "ROW",
+      "fields": [
+        {
+          "type": "RECORD_NUMBER",
+          "code": "recordNumber",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "UPDATED_TIME",
+          "code": "updatedTime",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "DROP_DOWN",
+          "code": "dropDown",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "CREATOR",
+          "code": "creator",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "MODIFIER",
+          "code": "modifier",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "RICH_TEXT",
+          "code": "richText",
+          "size": {
+            "width": "123",
+            "innerHeight": "123"
+          }
+        }
+      ]
+    },
+    {
+      "type": "ROW",
+      "fields": [
+        {
+          "type": "SINGLE_LINE_TEXT",
+          "code": "singleLineText",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "NUMBER",
+          "code": "number",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "RADIO_BUTTON",
+          "code": "radioButton",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "MULTI_LINE_TEXT",
+          "code": "multiLineText",
+          "size": {
+            "width": "123",
+            "innerHeight": "123"
+          }
+        },
+        {
+          "type": "CREATED_TIME",
+          "code": "createdTime",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "CHECK_BOX",
+          "code": "checkBox",
+          "size": {
+            "width": "123"
+          }
+        }
+      ]
+    },
+    {
+      "type": "ROW",
+      "fields": [
+        {
+          "type": "CALC",
+          "code": "calc",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "MULTI_LINE_TEXT",
+          "code": "multiSelect",
+          "size": {
+            "width": "123",
+            "innerHeight": "123"
+          }
+        }
+      ]
+    },
+    {
+      "type": "GROUP",
+      "code": "group",
+      "layout": [
+        {
+          "type": "ROW",
+          "fields": [
+            {
+              "type": "USER_SELECT",
+              "code": "userSelect",
+              "size": {
+                "width": "123"
+              }
+            },
+            {
+              "type": "ORGANIZATION_SELECT",
+              "code": "organizationSelect",
+              "size": {
+                "width": "123"
+              }
+            },
+            {
+              "type": "GROUP_SELECT",
+              "code": "groupSelect",
+              "size": {
+                "width": "123"
+              }
+            }
+          ]
+        },
+        {
+          "type": "ROW",
+          "fields": [
+            {
+              "type": "DATE",
+              "code": "date",
+              "size": {
+                "width": "123"
+              }
+            },
+            {
+              "type": "DATETIME",
+              "code": "dateTime",
+              "size": {
+                "width": "123"
+              }
+            },
+            {
+              "type": "TIME",
+              "code": "time",
+              "size": {
+                "width": "123"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/header/subtable_layout.json
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/header/subtable_layout.json
@@ -1,0 +1,78 @@
+{
+  "revision": "29",
+  "layout": [
+    {
+      "type": "ROW",
+      "fields": [
+        { "type": "RECORD_NUMBER", "code": "recordNumber", "size": { "width": "123" } },
+        { "type": "UPDATED_TIME", "code": "updatedTime", "size": { "width": "123" } },
+        {
+          "type": "DROP_DOWN",
+          "code": "dropDown",
+          "size": { "width": "123" }
+        },
+        { "type": "CREATOR", "code": "creator", "size": { "width": "123" } }
+      ]
+    },
+    {
+      "type": "SUBTABLE",
+      "code": "subTable",
+      "fields": [
+        {
+          "type": "SINGLE_LINE_TEXT",
+          "code": "subTableText",
+          "size": { "width": "123" }
+        },
+        { "type": "CHECK_BOX", "code": "subTableCheckbox", "size": { "width": "123" } },
+        { "type": "FILE", "code": "subTableFile", "size": { "width": "123" } },
+        { "type": "USER_SELECT", "code": "userSelect", "size": { "width": "123" } },
+        {
+          "type": "ORGANIZATION_SELECT",
+          "code": "organizationSelect",
+          "size": { "width": "123" }
+        },
+        { "type": "GROUP_SELECT", "code": "groupSelect", "size": { "width": "123" } }
+      ]
+    },
+    {
+      "type": "ROW",
+      "fields": [
+        { "type": "MODIFIER", "code": "modifier", "size": { "width": "123" } },
+        {
+          "type": "RICH_TEXT",
+          "code": "richText",
+          "size": { "width": "123", "innerHeight": "123" }
+        },
+        {
+          "type": "SINGLE_LINE_TEXT",
+          "code": "singleLineText",
+          "size": { "width": "123" }
+        },
+        { "type": "NUMBER", "code": "number", "size": { "width": "123" } },
+        { "type": "RADIO_BUTTON", "code": "radioButton", "size": { "width": "123" } },
+        {
+          "type": "MULTI_LINE_TEXT",
+          "code": "multiLineText",
+          "size": { "width": "123", "innerHeight": "123" }
+        },
+        { "type": "CREATED_TIME", "code": "createdTime", "size": { "width": "123" } },
+        { "type": "CHECK_BOX", "code": "checkBox", "size": { "width": "123" } }
+      ]
+    },
+    {
+      "type": "ROW",
+      "fields": [
+        {
+          "type": "CALC",
+          "code": "calc",
+          "size": { "width": "123" }
+        },
+        {
+          "type": "MULTI_LINE_TEXT",
+          "code": "multiSelect",
+          "size": { "width": "123", "innerHeight": "123" }
+        }
+      ]
+    }
+  ]
+}

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/header/systemfields_fields.json
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/header/systemfields_fields.json
@@ -1,0 +1,252 @@
+{
+  "revision": "29",
+  "properties": {
+    "recordNumber": {
+      "type": "RECORD_NUMBER",
+      "code": "recordNumber",
+      "label": "recordNumber",
+      "noLabel": false
+    },
+    "updatedTime": {
+      "type": "UPDATED_TIME",
+      "code": "updatedTime",
+      "label": "updatedTime",
+      "noLabel": false
+    },
+    "dropDown": {
+      "type": "DROP_DOWN",
+      "code": "dropDown",
+      "label": "dropDown",
+      "noLabel": false,
+      "required": false,
+      "options": {
+        "sample1": {
+          "label": "sample1",
+          "index": "0"
+        },
+        "sample2": {
+          "label": "sample2",
+          "index": "1"
+        }
+      },
+      "defaultValue": ""
+    },
+    "creator": {
+      "type": "CREATOR",
+      "code": "creator",
+      "label": "creator",
+      "noLabel": false
+    },
+    "Assignee": {
+      "type": "STATUS_ASSIGNEE",
+      "code": "Assignee",
+      "label": "Assignee",
+      "enabled": false
+    },
+    "modifier": {
+      "type": "MODIFIER",
+      "code": "modifier",
+      "label": "modifier",
+      "noLabel": false
+    },
+    "Status": {
+      "type": "STATUS",
+      "code": "Status",
+      "label": "Status",
+      "enabled": false
+    },
+    "richText": {
+      "type": "RICH_TEXT",
+      "code": "richText",
+      "label": "richText",
+      "noLabel": false,
+      "required": false,
+      "defaultValue": ""
+    },
+    "singleLineText": {
+      "type": "SINGLE_LINE_TEXT",
+      "code": "singleLineText",
+      "label": "singleLineText",
+      "noLabel": false,
+      "required": false,
+      "minLength": "",
+      "maxLength": "",
+      "expression": "",
+      "hideExpression": false,
+      "unique": false,
+      "defaultValue": ""
+    },
+    "Categories": {
+      "type": "CATEGORY",
+      "code": "Categories",
+      "label": "Categories",
+      "enabled": false
+    },
+    "number": {
+      "type": "NUMBER",
+      "code": "number",
+      "label": "number",
+      "noLabel": false,
+      "required": false,
+      "minValue": "",
+      "maxValue": "",
+      "digit": false,
+      "unique": false,
+      "defaultValue": "",
+      "displayScale": "",
+      "unit": "",
+      "unitPosition": "BEFORE"
+    },
+    "radioButton": {
+      "type": "RADIO_BUTTON",
+      "code": "radioButton",
+      "label": "radioButton",
+      "noLabel": false,
+      "required": true,
+      "options": {
+        "sample1": {
+          "label": "sample1",
+          "index": "0"
+        },
+        "sample2": {
+          "label": "sample2",
+          "index": "1"
+        }
+      },
+      "defaultValue": "sample1",
+      "align": "HORIZONTAL"
+    },
+    "multiLineText": {
+      "type": "MULTI_LINE_TEXT",
+      "code": "multiLineText",
+      "label": "multiLineText",
+      "noLabel": false,
+      "required": false,
+      "defaultValue": ""
+    },
+    "createdTime": {
+      "type": "CREATED_TIME",
+      "code": "createdTime",
+      "label": "createdTime",
+      "noLabel": false
+    },
+    "checkBox": {
+      "type": "CHECK_BOX",
+      "code": "checkBox",
+      "label": "checkBox",
+      "noLabel": false,
+      "required": false,
+      "options": {
+        "\"sample1\"": {
+          "label": "\"sample1\"",
+          "index": "0"
+        },
+        "\"sample2\"": {
+          "label": "\"sample2\"",
+          "index": "1"
+        }
+      },
+      "defaultValue": [],
+      "align": "HORIZONTAL"
+    },
+    "calc": {
+      "type": "CALC",
+      "code": "calc",
+      "label": "calc",
+      "noLabel": false,
+      "required": false,
+      "expression": "number + number",
+      "format": "NUMBER",
+      "displayScale": "",
+      "hideExpression": false,
+      "unit": "",
+      "unitPosition": "BEFORE"
+    },
+    "multiSelect": {
+      "type": "MULTI_SELECT",
+      "code": "multiSelect",
+      "label": "multiSelect",
+      "noLabel": false,
+      "required": false,
+      "options": {
+        "sample1": {
+          "label": "sample1",
+          "index": "0"
+        },
+        "tab\ttab": {
+          "label": "tab\ttab",
+          "index": "4"
+        },
+        "\"sample2\"": {
+          "label": "\"sample2\"",
+          "index": "1"
+        },
+        "sample4,sample5": {
+          "label": "sample4,sample5",
+          "index": "3"
+        },
+        "\"sample3\"": {
+          "label": "\"sample3\"",
+          "index": "2"
+        }
+      },
+      "defaultValue": []
+    },
+    "userSelect": {
+      "type": "USER_SELECT",
+      "code": "userSelect",
+      "label": "userSelect",
+      "noLabel": false,
+      "required": false,
+      "entities": [],
+      "defaultValue": []
+    },
+    "organizationSelect": {
+      "type": "ORGANIZATION_SELECT",
+      "code": "organizationSelect",
+      "label": "organizationSelect",
+      "noLabel": false,
+      "required": false,
+      "entities": [],
+      "defaultValue": []
+    },
+    "groupSelect": {
+      "type": "GROUP_SELECT",
+      "code": "groupSelect",
+      "label": "groupSelect",
+      "noLabel": false,
+      "required": false,
+      "entities": [],
+      "defaultValue": []
+    },
+    "date": {
+      "type": "DATE",
+      "code": "date",
+      "label": "date",
+      "noLabel": false,
+      "required": false,
+      "unique": false,
+      "defaultValue": "",
+      "defaultNowValue": true
+    },
+    "dateTime": {
+      "type": "DATETIME",
+      "code": "dateTime",
+      "label": "dateTime",
+      "noLabel": false,
+      "required": false,
+      "unique": false,
+      "defaultValue": "",
+      "defaultNowValue": true
+    },
+    "time": {
+      "type": "TIME",
+      "code": "time",
+      "label": "time",
+      "noLabel": false,
+      "required": false,
+      "defaultValue": "",
+      "defaultNowValue": true
+    }
+  }
+}

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/header/systemfields_layout.json
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/header/systemfields_layout.json
@@ -1,0 +1,144 @@
+{
+  "revision": "29",
+  "layout": [
+    {
+      "type": "ROW",
+      "fields": [
+        {
+          "type": "DROP_DOWN",
+          "code": "dropDown",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "RICH_TEXT",
+          "code": "richText",
+          "size": {
+            "width": "123",
+            "innerHeight": "123"
+          }
+        }
+      ]
+    },
+    {
+      "type": "ROW",
+      "fields": [
+        {
+          "type": "SINGLE_LINE_TEXT",
+          "code": "singleLineText",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "NUMBER",
+          "code": "number",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "RADIO_BUTTON",
+          "code": "radioButton",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "MULTI_LINE_TEXT",
+          "code": "multiLineText",
+          "size": {
+            "width": "123",
+            "innerHeight": "123"
+          }
+        },
+        {
+          "type": "CHECK_BOX",
+          "code": "checkBox",
+          "size": {
+            "width": "123"
+          }
+        }
+      ]
+    },
+    {
+      "type": "ROW",
+      "fields": [
+        {
+          "type": "CALC",
+          "code": "calc",
+          "size": {
+            "width": "123"
+          }
+        },
+        {
+          "type": "MULTI_LINE_TEXT",
+          "code": "multiSelect",
+          "size": {
+            "width": "123",
+            "innerHeight": "123"
+          }
+        }
+      ]
+    },
+    {
+      "type": "GROUP",
+      "code": "group",
+      "layout": [
+        {
+          "type": "ROW",
+          "fields": [
+            {
+              "type": "USER_SELECT",
+              "code": "userSelect",
+              "size": {
+                "width": "123"
+              }
+            },
+            {
+              "type": "ORGANIZATION_SELECT",
+              "code": "organizationSelect",
+              "size": {
+                "width": "123"
+              }
+            },
+            {
+              "type": "GROUP_SELECT",
+              "code": "groupSelect",
+              "size": {
+                "width": "123"
+              }
+            }
+          ]
+        },
+        {
+          "type": "ROW",
+          "fields": [
+            {
+              "type": "DATE",
+              "code": "date",
+              "size": {
+                "width": "123"
+              }
+            },
+            {
+              "type": "DATETIME",
+              "code": "dateTime",
+              "size": {
+                "width": "123"
+              }
+            },
+            {
+              "type": "TIME",
+              "code": "time",
+              "size": {
+                "width": "123"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/common/index.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/common/index.ts
@@ -2,10 +2,12 @@ import { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { fieldsJson } from "./fields";
+import { layoutJson } from "./layout";
 
 export const pattern: TestPattern = {
   description: "should convert kintone records to csv string correctly",
   fieldsJson: fieldsJson,
+  layoutJson: layoutJson,
   input: input,
   useLocalFilePath: true,
   expected: expectedCsv,

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/common/layout.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/common/layout.ts
@@ -1,0 +1,94 @@
+import { LayoutJson } from "../../../../../../../../kintone/types";
+
+export const layoutJson: LayoutJson = {
+  revision: "29",
+  layout: [
+    {
+      type: "ROW",
+      fields: [
+        { type: "RECORD_NUMBER", code: "recordNumber", size: { width: "123" } },
+        { type: "UPDATED_TIME", code: "updatedTime", size: { width: "123" } },
+        {
+          type: "DROP_DOWN",
+          code: "dropDown",
+          size: { width: "123" },
+        },
+        { type: "CREATOR", code: "creator", size: { width: "123" } },
+        { type: "MODIFIER", code: "modifier", size: { width: "123" } },
+        {
+          type: "RICH_TEXT",
+          code: "richText",
+          size: { width: "123", innerHeight: "123" },
+        },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        {
+          type: "SINGLE_LINE_TEXT",
+          code: "singleLineText",
+          size: { width: "123" },
+        },
+        { type: "NUMBER", code: "number", size: { width: "123" } },
+        { type: "RADIO_BUTTON", code: "radioButton", size: { width: "123" } },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiLineText",
+          size: { width: "123", innerHeight: "123" },
+        },
+        { type: "CREATED_TIME", code: "createdTime", size: { width: "123" } },
+        { type: "CHECK_BOX", code: "checkBox", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        {
+          type: "CALC",
+          code: "calc",
+          size: { width: "123" },
+        },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiSelect",
+          size: { width: "123", innerHeight: "123" },
+        },
+      ],
+    },
+    {
+      type: "GROUP",
+      code: "group",
+      layout: [
+        {
+          type: "ROW",
+          fields: [
+            { type: "USER_SELECT", code: "userSelect", size: { width: "123" } },
+            {
+              type: "ORGANIZATION_SELECT",
+              code: "organizationSelect",
+              size: { width: "123" },
+            },
+            {
+              type: "GROUP_SELECT",
+              code: "groupSelect",
+              size: { width: "123" },
+            },
+          ],
+        },
+        {
+          type: "ROW",
+          fields: [
+            { type: "DATE", code: "date", size: { width: "123" } },
+            {
+              type: "DATETIME",
+              code: "dateTime",
+              size: { width: "123" },
+            },
+            { type: "TIME", code: "time", size: { width: "123" } },
+          ],
+        },
+      ],
+    },
+  ],
+};

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withEmptySubtable/index.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withEmptySubtable/index.ts
@@ -2,11 +2,13 @@ import { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { fieldsJson } from "./fields";
+import { layoutJson } from "./layout";
 
 export const pattern: TestPattern = {
   description:
     "should convert kintone records to csv string correctly when SUBTABLE value is an empty array",
   fieldsJson: fieldsJson,
+  layoutJson: layoutJson,
   input: input,
   useLocalFilePath: true,
   expected: expectedCsv,

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withEmptySubtable/layout.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withEmptySubtable/layout.ts
@@ -1,0 +1,80 @@
+import { LayoutJson } from "../../../../../../../../kintone/types";
+
+export const layoutJson: LayoutJson = {
+  revision: "29",
+  layout: [
+    {
+      type: "ROW",
+      fields: [
+        { type: "RECORD_NUMBER", code: "recordNumber", size: { width: "123" } },
+        { type: "UPDATED_TIME", code: "updatedTime", size: { width: "123" } },
+        {
+          type: "DROP_DOWN",
+          code: "dropDown",
+          size: { width: "123" },
+        },
+        { type: "CREATOR", code: "creator", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "SUBTABLE",
+      code: "subTable",
+      fields: [
+        {
+          type: "SINGLE_LINE_TEXT",
+          code: "subTableText",
+          size: { width: "123" },
+        },
+        { type: "CHECK_BOX", code: "subTableCheckbox", size: { width: "123" } },
+        { type: "FILE", code: "subTableFile", size: { width: "123" } },
+        { type: "USER_SELECT", code: "userSelect", size: { width: "123" } },
+        {
+          type: "ORGANIZATION_SELECT",
+          code: "organizationSelect",
+          size: { width: "123" },
+        },
+        { type: "GROUP_SELECT", code: "groupSelect", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        { type: "MODIFIER", code: "modifier", size: { width: "123" } },
+        {
+          type: "RICH_TEXT",
+          code: "richText",
+          size: { width: "123", innerHeight: "123" },
+        },
+        {
+          type: "SINGLE_LINE_TEXT",
+          code: "singleLineText",
+          size: { width: "123" },
+        },
+        { type: "NUMBER", code: "number", size: { width: "123" } },
+        { type: "RADIO_BUTTON", code: "radioButton", size: { width: "123" } },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiLineText",
+          size: { width: "123", innerHeight: "123" },
+        },
+        { type: "CREATED_TIME", code: "createdTime", size: { width: "123" } },
+        { type: "CHECK_BOX", code: "checkBox", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        {
+          type: "CALC",
+          code: "calc",
+          size: { width: "123" },
+        },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiSelect",
+          size: { width: "123", innerHeight: "123" },
+        },
+      ],
+    },
+  ],
+};

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withFileAndAttachmentsDir/index.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withFileAndAttachmentsDir/index.ts
@@ -2,11 +2,13 @@ import { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { fieldsJson } from "./fields";
+import { layoutJson } from "./layout";
 
 export const pattern: TestPattern = {
   description:
     "should convert kintone records to csv string correctly when FILE included and with attachmentsDir option",
   fieldsJson: fieldsJson,
+  layoutJson: layoutJson,
   input: input,
   useLocalFilePath: true,
   expected: expectedCsv,

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withFileAndAttachmentsDir/layout.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withFileAndAttachmentsDir/layout.ts
@@ -1,0 +1,61 @@
+import { LayoutJson } from "../../../../../../../../kintone/types";
+
+export const layoutJson: LayoutJson = {
+  revision: "29",
+  layout: [
+    {
+      type: "ROW",
+      fields: [
+        { type: "RECORD_NUMBER", code: "recordNumber", size: { width: "123" } },
+        { type: "UPDATED_TIME", code: "updatedTime", size: { width: "123" } },
+        {
+          type: "DROP_DOWN",
+          code: "dropDown",
+          size: { width: "123" },
+        },
+        { type: "CREATOR", code: "creator", size: { width: "123" } },
+        { type: "MODIFIER", code: "modifier", size: { width: "123" } },
+        {
+          type: "RICH_TEXT",
+          code: "richText",
+          size: { width: "123", innerHeight: "123" },
+        },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        {
+          type: "SINGLE_LINE_TEXT",
+          code: "singleLineText",
+          size: { width: "123" },
+        },
+        { type: "NUMBER", code: "number", size: { width: "123" } },
+        { type: "RADIO_BUTTON", code: "radioButton", size: { width: "123" } },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiLineText",
+          size: { width: "123", innerHeight: "123" },
+        },
+        { type: "CREATED_TIME", code: "createdTime", size: { width: "123" } },
+        { type: "CHECK_BOX", code: "checkBox", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        {
+          type: "CALC",
+          code: "calc",
+          size: { width: "123" },
+        },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiSelect",
+          size: { width: "123", innerHeight: "123" },
+        },
+        { type: "FILE", code: "file", size: { width: "123" } },
+      ],
+    },
+  ],
+};

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withFileAndNoAttachmentsDir/index.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withFileAndNoAttachmentsDir/index.ts
@@ -2,11 +2,13 @@ import { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { fieldsJson } from "./fields";
+import { layoutJson } from "./layout";
 
 export const pattern: TestPattern = {
   description:
     "should convert kintone records to csv string correctly when FILE included and without attachmentsDir option",
   fieldsJson: fieldsJson,
+  layoutJson: layoutJson,
   input: input,
   useLocalFilePath: false,
   expected: expectedCsv,

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withFileAndNoAttachmentsDir/layout.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withFileAndNoAttachmentsDir/layout.ts
@@ -1,0 +1,61 @@
+import { LayoutJson } from "../../../../../../../../kintone/types";
+
+export const layoutJson: LayoutJson = {
+  revision: "29",
+  layout: [
+    {
+      type: "ROW",
+      fields: [
+        { type: "RECORD_NUMBER", code: "recordNumber", size: { width: "123" } },
+        { type: "UPDATED_TIME", code: "updatedTime", size: { width: "123" } },
+        {
+          type: "DROP_DOWN",
+          code: "dropDown",
+          size: { width: "123" },
+        },
+        { type: "CREATOR", code: "creator", size: { width: "123" } },
+        { type: "MODIFIER", code: "modifier", size: { width: "123" } },
+        {
+          type: "RICH_TEXT",
+          code: "richText",
+          size: { width: "123", innerHeight: "123" },
+        },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        {
+          type: "SINGLE_LINE_TEXT",
+          code: "singleLineText",
+          size: { width: "123" },
+        },
+        { type: "NUMBER", code: "number", size: { width: "123" } },
+        { type: "RADIO_BUTTON", code: "radioButton", size: { width: "123" } },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiLineText",
+          size: { width: "123", innerHeight: "123" },
+        },
+        { type: "CREATED_TIME", code: "createdTime", size: { width: "123" } },
+        { type: "CHECK_BOX", code: "checkBox", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        {
+          type: "CALC",
+          code: "calc",
+          size: { width: "123" },
+        },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiSelect",
+          size: { width: "123", innerHeight: "123" },
+        },
+        { type: "FILE", code: "file", size: { width: "123" } },
+      ],
+    },
+  ],
+};

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withSubtableAndFileAndAttachmentsDir/index.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withSubtableAndFileAndAttachmentsDir/index.ts
@@ -2,11 +2,13 @@ import { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { fieldsJson } from "./fields";
+import { layoutJson } from "./layout";
 
 export const pattern: TestPattern = {
   description:
     "should convert kintone records to csv string correctly when SUBTABLE included with attachmentsDir option",
   fieldsJson: fieldsJson,
+  layoutJson: layoutJson,
   input: input,
   useLocalFilePath: true,
   expected: expectedCsv,

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withSubtableAndFileAndAttachmentsDir/layout.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withSubtableAndFileAndAttachmentsDir/layout.ts
@@ -1,0 +1,80 @@
+import { LayoutJson } from "../../../../../../../../kintone/types";
+
+export const layoutJson: LayoutJson = {
+  revision: "29",
+  layout: [
+    {
+      type: "ROW",
+      fields: [
+        { type: "RECORD_NUMBER", code: "recordNumber", size: { width: "123" } },
+        { type: "UPDATED_TIME", code: "updatedTime", size: { width: "123" } },
+        {
+          type: "DROP_DOWN",
+          code: "dropDown",
+          size: { width: "123" },
+        },
+        { type: "CREATOR", code: "creator", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "SUBTABLE",
+      code: "subTable",
+      fields: [
+        {
+          type: "SINGLE_LINE_TEXT",
+          code: "subTableText",
+          size: { width: "123" },
+        },
+        { type: "CHECK_BOX", code: "subTableCheckbox", size: { width: "123" } },
+        { type: "FILE", code: "subTableFile", size: { width: "123" } },
+        { type: "USER_SELECT", code: "userSelect", size: { width: "123" } },
+        {
+          type: "ORGANIZATION_SELECT",
+          code: "organizationSelect",
+          size: { width: "123" },
+        },
+        { type: "GROUP_SELECT", code: "groupSelect", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        { type: "MODIFIER", code: "modifier", size: { width: "123" } },
+        {
+          type: "RICH_TEXT",
+          code: "richText",
+          size: { width: "123", innerHeight: "123" },
+        },
+        {
+          type: "SINGLE_LINE_TEXT",
+          code: "singleLineText",
+          size: { width: "123" },
+        },
+        { type: "NUMBER", code: "number", size: { width: "123" } },
+        { type: "RADIO_BUTTON", code: "radioButton", size: { width: "123" } },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiLineText",
+          size: { width: "123", innerHeight: "123" },
+        },
+        { type: "CREATED_TIME", code: "createdTime", size: { width: "123" } },
+        { type: "CHECK_BOX", code: "checkBox", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        {
+          type: "CALC",
+          code: "calc",
+          size: { width: "123" },
+        },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiSelect",
+          size: { width: "123", innerHeight: "123" },
+        },
+      ],
+    },
+  ],
+};

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withSubtableAndFileAndNoAttachmentsDir/index.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withSubtableAndFileAndNoAttachmentsDir/index.ts
@@ -2,11 +2,13 @@ import { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { fieldsJson } from "./fields";
+import { layoutJson } from "./layout";
 
 export const pattern: TestPattern = {
   description:
     "should convert kintone records to csv string correctly when SUBTABLE included without attachmentsDir option",
   fieldsJson: fieldsJson,
+  layoutJson: layoutJson,
   input: input,
   useLocalFilePath: false,
   expected: expectedCsv,

--- a/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withSubtableAndFileAndNoAttachmentsDir/layout.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/fixtures/index/withSubtableAndFileAndNoAttachmentsDir/layout.ts
@@ -1,0 +1,80 @@
+import { LayoutJson } from "../../../../../../../../kintone/types";
+
+export const layoutJson: LayoutJson = {
+  revision: "29",
+  layout: [
+    {
+      type: "ROW",
+      fields: [
+        { type: "RECORD_NUMBER", code: "recordNumber", size: { width: "123" } },
+        { type: "UPDATED_TIME", code: "updatedTime", size: { width: "123" } },
+        {
+          type: "DROP_DOWN",
+          code: "dropDown",
+          size: { width: "123" },
+        },
+        { type: "CREATOR", code: "creator", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "SUBTABLE",
+      code: "subTable",
+      fields: [
+        {
+          type: "SINGLE_LINE_TEXT",
+          code: "subTableText",
+          size: { width: "123" },
+        },
+        { type: "CHECK_BOX", code: "subTableCheckbox", size: { width: "123" } },
+        { type: "FILE", code: "subTableFile", size: { width: "123" } },
+        { type: "USER_SELECT", code: "userSelect", size: { width: "123" } },
+        {
+          type: "ORGANIZATION_SELECT",
+          code: "organizationSelect",
+          size: { width: "123" },
+        },
+        { type: "GROUP_SELECT", code: "groupSelect", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        { type: "MODIFIER", code: "modifier", size: { width: "123" } },
+        {
+          type: "RICH_TEXT",
+          code: "richText",
+          size: { width: "123", innerHeight: "123" },
+        },
+        {
+          type: "SINGLE_LINE_TEXT",
+          code: "singleLineText",
+          size: { width: "123" },
+        },
+        { type: "NUMBER", code: "number", size: { width: "123" } },
+        { type: "RADIO_BUTTON", code: "radioButton", size: { width: "123" } },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiLineText",
+          size: { width: "123", innerHeight: "123" },
+        },
+        { type: "CREATED_TIME", code: "createdTime", size: { width: "123" } },
+        { type: "CHECK_BOX", code: "checkBox", size: { width: "123" } },
+      ],
+    },
+    {
+      type: "ROW",
+      fields: [
+        {
+          type: "CALC",
+          code: "calc",
+          size: { width: "123" },
+        },
+        {
+          type: "MULTI_LINE_TEXT",
+          code: "multiSelect",
+          size: { width: "123", innerHeight: "123" },
+        },
+      ],
+    },
+  ],
+};

--- a/src/record/export/printers/printAsCsv/__tests__/header.test.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/header.test.ts
@@ -2,7 +2,6 @@ import type { FieldsJson, LayoutJson } from "../../../../../kintone/types";
 
 import { buildHeaderFields } from "../header";
 import { PRIMARY_MARK } from "../constants";
-import { defaultStrategy } from "../strategies/defaultStrategy";
 
 const fieldsJson: FieldsJson = require("./fixtures/header/fields.json");
 const layoutJson: LayoutJson = require("./fixtures/header/layout.json");
@@ -14,41 +13,19 @@ const subtableLayoutJson: LayoutJson = require("./fixtures/header/subtable_layou
 describe("buildHeaderFields", () => {
   it("should generate fieldCode array correctly (data without subtable)", () => {
     expect(
-      buildHeaderFields(
-        fieldsJson,
-        layoutJson,
-        defaultStrategy(fieldsJson, layoutJson)
-      ).includes(PRIMARY_MARK)
+      buildHeaderFields(fieldsJson, layoutJson).includes(PRIMARY_MARK)
     ).toBe(false);
-    expect(
-      buildHeaderFields(
-        fieldsJson,
-        layoutJson,
-        defaultStrategy(fieldsJson, layoutJson)
-      )
-    ).toHaveLength(20);
-    expect(
-      buildHeaderFields(
-        fileFieldsJson,
-        fileLayoutJson,
-        defaultStrategy(fileFieldsJson, fileLayoutJson)
-      )
-    ).toHaveLength(15);
+    expect(buildHeaderFields(fieldsJson, layoutJson)).toHaveLength(20);
+    expect(buildHeaderFields(fileFieldsJson, fileLayoutJson)).toHaveLength(15);
   });
   it("should generate fieldCode array correctly (data with subtable)", () => {
     expect(
-      buildHeaderFields(
-        subtableFieldsJson,
-        subtableLayoutJson,
-        defaultStrategy(subtableFieldsJson, subtableLayoutJson)
-      ).includes(PRIMARY_MARK)
+      buildHeaderFields(subtableFieldsJson, subtableLayoutJson).includes(
+        PRIMARY_MARK
+      )
     ).toBe(true);
     expect(
-      buildHeaderFields(
-        subtableFieldsJson,
-        subtableLayoutJson,
-        defaultStrategy(subtableFieldsJson, subtableLayoutJson)
-      )
+      buildHeaderFields(subtableFieldsJson, subtableLayoutJson)
     ).toHaveLength(22);
   });
 });

--- a/src/record/export/printers/printAsCsv/__tests__/header.test.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/header.test.ts
@@ -7,6 +7,8 @@ const fieldsJson: FieldsJson = require("./fixtures/header/fields.json");
 const layoutJson: LayoutJson = require("./fixtures/header/layout.json");
 const fileFieldsJson: FieldsJson = require("./fixtures/header/file_fields.json");
 const fileLayoutJson: LayoutJson = require("./fixtures/header/file_layout.json");
+const systemFieldsFieldsJson: FieldsJson = require("./fixtures/header/systemfields_fields.json");
+const systemFieldsLayoutJson: LayoutJson = require("./fixtures/header/systemfields_layout.json");
 const subtableFieldsJson: FieldsJson = require("./fixtures/header/subtable_fields.json");
 const subtableLayoutJson: LayoutJson = require("./fixtures/header/subtable_layout.json");
 
@@ -15,8 +17,70 @@ describe("buildHeaderFields", () => {
     expect(
       buildHeaderFields(fieldsJson, layoutJson).includes(PRIMARY_MARK)
     ).toBe(false);
-    expect(buildHeaderFields(fieldsJson, layoutJson)).toHaveLength(20);
-    expect(buildHeaderFields(fileFieldsJson, fileLayoutJson)).toHaveLength(15);
+
+    expect(buildHeaderFields(fieldsJson, layoutJson)).toStrictEqual([
+      "recordNumber",
+      "updatedTime",
+      "dropDown",
+      "creator",
+      "modifier",
+      "richText",
+      "singleLineText",
+      "number",
+      "radioButton",
+      "multiLineText",
+      "createdTime",
+      "checkBox",
+      "calc",
+      "multiSelect",
+      "userSelect",
+      "organizationSelect",
+      "groupSelect",
+      "date",
+      "dateTime",
+      "time",
+    ]);
+    expect(buildHeaderFields(fileFieldsJson, fileLayoutJson)).toStrictEqual([
+      "recordNumber",
+      "updatedTime",
+      "dropDown",
+      "creator",
+      "modifier",
+      "richText",
+      "singleLineText",
+      "number",
+      "radioButton",
+      "multiLineText",
+      "createdTime",
+      "checkBox",
+      "calc",
+      "multiSelect",
+      "file",
+    ]);
+    expect(
+      buildHeaderFields(systemFieldsFieldsJson, systemFieldsLayoutJson)
+    ).toStrictEqual([
+      "recordNumber",
+      "dropDown",
+      "richText",
+      "singleLineText",
+      "number",
+      "radioButton",
+      "multiLineText",
+      "checkBox",
+      "calc",
+      "multiSelect",
+      "userSelect",
+      "organizationSelect",
+      "groupSelect",
+      "date",
+      "dateTime",
+      "time",
+      "creator",
+      "createdTime",
+      "modifier",
+      "updatedTime",
+    ]);
   });
   it("should generate fieldCode array correctly (data with subtable)", () => {
     expect(
@@ -26,6 +90,29 @@ describe("buildHeaderFields", () => {
     ).toBe(true);
     expect(
       buildHeaderFields(subtableFieldsJson, subtableLayoutJson)
-    ).toHaveLength(22);
+    ).toStrictEqual([
+      "*",
+      "recordNumber",
+      "updatedTime",
+      "dropDown",
+      "creator",
+      "subTable",
+      "subTableText",
+      "subTableCheckbox",
+      "subTableFile",
+      "userSelect",
+      "organizationSelect",
+      "groupSelect",
+      "modifier",
+      "richText",
+      "singleLineText",
+      "number",
+      "radioButton",
+      "multiLineText",
+      "createdTime",
+      "checkBox",
+      "calc",
+      "multiSelect",
+    ]);
   });
 });

--- a/src/record/export/printers/printAsCsv/__tests__/header.test.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/header.test.ts
@@ -1,22 +1,54 @@
-import type { FieldsJson } from "../../../../../kintone/types";
+import type { FieldsJson, LayoutJson } from "../../../../../kintone/types";
 
 import { buildHeaderFields } from "../header";
 import { PRIMARY_MARK } from "../constants";
+import { defaultStrategy } from "../strategies/defaultStrategy";
 
 const fieldsJson: FieldsJson = require("./fixtures/header/fields.json");
+const layoutJson: LayoutJson = require("./fixtures/header/layout.json");
 const fileFieldsJson: FieldsJson = require("./fixtures/header/file_fields.json");
+const fileLayoutJson: LayoutJson = require("./fixtures/header/file_layout.json");
 const subtableFieldsJson: FieldsJson = require("./fixtures/header/subtable_fields.json");
+const subtableLayoutJson: LayoutJson = require("./fixtures/header/subtable_layout.json");
 
 describe("buildHeaderFields", () => {
   it("should generate fieldCode array correctly (data without subtable)", () => {
-    expect(buildHeaderFields(fieldsJson).includes(PRIMARY_MARK)).toBe(false);
-    expect(buildHeaderFields(fieldsJson)).toHaveLength(20);
-    expect(buildHeaderFields(fileFieldsJson)).toHaveLength(15);
+    expect(
+      buildHeaderFields(
+        fieldsJson,
+        layoutJson,
+        defaultStrategy(fieldsJson, layoutJson)
+      ).includes(PRIMARY_MARK)
+    ).toBe(false);
+    expect(
+      buildHeaderFields(
+        fieldsJson,
+        layoutJson,
+        defaultStrategy(fieldsJson, layoutJson)
+      )
+    ).toHaveLength(20);
+    expect(
+      buildHeaderFields(
+        fileFieldsJson,
+        fileLayoutJson,
+        defaultStrategy(fileFieldsJson, fileLayoutJson)
+      )
+    ).toHaveLength(15);
   });
   it("should generate fieldCode array correctly (data with subtable)", () => {
-    expect(buildHeaderFields(subtableFieldsJson).includes(PRIMARY_MARK)).toBe(
-      true
-    );
-    expect(buildHeaderFields(subtableFieldsJson)).toHaveLength(22);
+    expect(
+      buildHeaderFields(
+        subtableFieldsJson,
+        subtableLayoutJson,
+        defaultStrategy(subtableFieldsJson, subtableLayoutJson)
+      ).includes(PRIMARY_MARK)
+    ).toBe(true);
+    expect(
+      buildHeaderFields(
+        subtableFieldsJson,
+        subtableLayoutJson,
+        defaultStrategy(subtableFieldsJson, subtableLayoutJson)
+      )
+    ).toHaveLength(22);
   });
 });

--- a/src/record/export/printers/printAsCsv/__tests__/index.test.ts
+++ b/src/record/export/printers/printAsCsv/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import type { FieldsJson } from "../../../../../kintone/types";
+import type { FieldsJson, LayoutJson } from "../../../../../kintone/types";
 import type { KintoneRecord } from "../../../types/record";
 
 import { stringifyAsCsv } from "../index";
@@ -13,6 +13,7 @@ import { pattern as withEmptySubtable } from "./fixtures/index/withEmptySubtable
 export type TestPattern = {
   description: string;
   fieldsJson: FieldsJson;
+  layoutJson: LayoutJson;
   input: KintoneRecord[];
   useLocalFilePath: boolean;
   expected: string;
@@ -32,6 +33,7 @@ describe("stringifyAsCsv", () => {
       stringifyAsCsv(
         pattern.input,
         pattern.fieldsJson,
+        pattern.layoutJson,
         pattern.useLocalFilePath
       )
     ).toEqual(pattern.expected);

--- a/src/record/export/printers/printAsCsv/header.ts
+++ b/src/record/export/printers/printAsCsv/header.ts
@@ -6,8 +6,9 @@ import {
   supportedFieldTypesInSubtable,
 } from "./constants";
 import { hasSubtable } from "./subtable";
+import { formLayout } from "./headerTransformers/formLayout";
 
-export type Strategy = {
+export type HeaderTransformer = {
   filter: (code: string) => boolean;
   comparator: (codeA: string, codeB: string) => number;
 };
@@ -15,7 +16,7 @@ export type Strategy = {
 export const buildHeaderFields = (
   fieldsJson: FieldsJson,
   layoutJson: LayoutJson,
-  strategy: Strategy
+  transformer: HeaderTransformer = formLayout(fieldsJson, layoutJson)
 ): string[] => {
   const headerFields: string[] = [];
 
@@ -42,5 +43,5 @@ export const buildHeaderFields = (
     }
   }
 
-  return headerFields.filter(strategy.filter).sort(strategy.comparator);
+  return headerFields.filter(transformer.filter).sort(transformer.comparator);
 };

--- a/src/record/export/printers/printAsCsv/header.ts
+++ b/src/record/export/printers/printAsCsv/header.ts
@@ -1,4 +1,4 @@
-import type { FieldsJson } from "../../../../kintone/types";
+import type { FieldsJson, LayoutJson } from "../../../../kintone/types";
 
 import {
   PRIMARY_MARK,
@@ -7,7 +7,16 @@ import {
 } from "./constants";
 import { hasSubtable } from "./subtable";
 
-export const buildHeaderFields = (fieldsJson: FieldsJson): string[] => {
+export type Strategy = {
+  filter: (code: string) => boolean;
+  comparator: (codeA: string, codeB: string) => number;
+};
+
+export const buildHeaderFields = (
+  fieldsJson: FieldsJson,
+  layoutJson: LayoutJson,
+  strategy: Strategy
+): string[] => {
   const headerFields: string[] = [];
 
   if (hasSubtable(fieldsJson)) {
@@ -15,7 +24,7 @@ export const buildHeaderFields = (fieldsJson: FieldsJson): string[] => {
   }
 
   for (const [fieldCode, field] of Object.entries(fieldsJson.properties)) {
-    if (!supportedFieldTypes.includes(fieldsJson.properties[fieldCode].type)) {
+    if (!supportedFieldTypes.includes(field.type)) {
       continue;
     }
 
@@ -32,5 +41,6 @@ export const buildHeaderFields = (fieldsJson: FieldsJson): string[] => {
       }
     }
   }
-  return headerFields;
+
+  return headerFields.filter(strategy.filter).sort(strategy.comparator);
 };

--- a/src/record/export/printers/printAsCsv/header.ts
+++ b/src/record/export/printers/printAsCsv/header.ts
@@ -8,10 +8,7 @@ import {
 import { hasSubtable } from "./subtable";
 import { formLayout } from "./headerTransformers/formLayout";
 
-export type HeaderTransformer = {
-  filter: (code: string) => boolean;
-  comparator: (codeA: string, codeB: string) => number;
-};
+export type HeaderTransformer = (headerFields: string[]) => string[];
 
 export const buildHeaderFields = (
   fieldsJson: FieldsJson,
@@ -43,5 +40,5 @@ export const buildHeaderFields = (
     }
   }
 
-  return headerFields.filter(transformer.filter).sort(transformer.comparator);
+  return transformer(headerFields);
 };

--- a/src/record/export/printers/printAsCsv/headerTransformers/formLayout.ts
+++ b/src/record/export/printers/printAsCsv/headerTransformers/formLayout.ts
@@ -4,6 +4,20 @@ import type { HeaderTransformer } from "../header";
 
 import { PRIMARY_MARK } from "../constants";
 
+/**
+ * This transformer returns all supported fields.
+ * This transformer sorts headerFields by the following rules.
+ * - based on form layout of the kintone app
+ * - the PRIMARY_MARK is always precedence.
+ * - When following fields are missing from layout,
+ *   - RECORD_NUMBER: placed at just after the PRIMARY_MARK (or head of the array)
+ *   - CREATOR      : placed at the end of the array
+ *   - CREATED_TIME : placed at the end of the array
+ *   - MODIFIER     : placed at the end of the array
+ *   - UPDATED_TIME : placed at the end of the array
+ * @param fieldsJson
+ * @param layoutJson
+ */
 export const formLayout =
   (fieldsJson: FieldsJson, layoutJson: LayoutJson): HeaderTransformer =>
   (headerFields: string[]) =>

--- a/src/record/export/printers/printAsCsv/headerTransformers/formLayout.ts
+++ b/src/record/export/printers/printAsCsv/headerTransformers/formLayout.ts
@@ -4,20 +4,15 @@ import type { HeaderTransformer } from "../header";
 
 import { PRIMARY_MARK } from "../constants";
 
-export const formLayout = (
-  fieldsJson: FieldsJson,
-  layoutJson: LayoutJson
-): HeaderTransformer => {
-  return {
-    filter: (code) => true,
-    comparator: orderByFormLayoutComparator(fieldsJson, layoutJson),
-  };
-};
+export const formLayout =
+  (fieldsJson: FieldsJson, layoutJson: LayoutJson): HeaderTransformer =>
+  (headerFields: string[]) =>
+    headerFields.sort(orderByFormLayoutComparator(fieldsJson, layoutJson));
 
 export const orderByFormLayoutComparator = (
   fieldsJson: FieldsJson,
   layoutJson: LayoutJson
-): HeaderTransformer["comparator"] => {
+): ((codeA: string, codeB: string) => number) => {
   const flatLayout = flattenLayout(layoutJson.layout);
   return (codeA, codeB) => {
     // the PRIMARY_MARK is always precedence

--- a/src/record/export/printers/printAsCsv/headerTransformers/formLayout.ts
+++ b/src/record/export/printers/printAsCsv/headerTransformers/formLayout.ts
@@ -1,13 +1,13 @@
 import type { FieldsJson, LayoutJson } from "../../../../../kintone/types";
 import type { KintoneFormFieldProperty } from "@kintone/rest-api-client";
-import type { Strategy } from "../header";
+import type { HeaderTransformer } from "../header";
 
 import { PRIMARY_MARK } from "../constants";
 
-export const defaultStrategy = (
+export const formLayout = (
   fieldsJson: FieldsJson,
   layoutJson: LayoutJson
-): Strategy => {
+): HeaderTransformer => {
   return {
     filter: (code) => true,
     comparator: orderByFormLayoutComparator(fieldsJson, layoutJson),
@@ -17,7 +17,7 @@ export const defaultStrategy = (
 export const orderByFormLayoutComparator = (
   fieldsJson: FieldsJson,
   layoutJson: LayoutJson
-): Strategy["comparator"] => {
+): HeaderTransformer["comparator"] => {
   const flatLayout = flattenLayout(layoutJson.layout);
   return (codeA, codeB) => {
     // the PRIMARY_MARK is always precedence

--- a/src/record/export/printers/printAsCsv/index.ts
+++ b/src/record/export/printers/printAsCsv/index.ts
@@ -6,7 +6,7 @@ import stringify from "csv-stringify/lib/sync";
 import { convertRecord, recordReader } from "./record";
 import { LINE_BREAK, SEPARATOR } from "./constants";
 import { buildHeaderFields } from "./header";
-import { defaultStrategy } from "./strategies/defaultStrategy";
+import { formLayout } from "./headerTransformers/formLayout";
 
 export const printAsCsv = (
   records: KintoneRecord[],
@@ -25,11 +25,7 @@ export const stringifyAsCsv = (
   layoutJson: LayoutJson,
   useLocalFilePath: boolean
 ): string => {
-  const headerFields = buildHeaderFields(
-    fieldsJson,
-    layoutJson,
-    defaultStrategy(fieldsJson, layoutJson)
-  );
+  const headerFields = buildHeaderFields(fieldsJson, layoutJson);
 
   const csvRows: CsvRow[] = [];
   for (const record of recordReader(records)) {

--- a/src/record/export/printers/printAsCsv/index.ts
+++ b/src/record/export/printers/printAsCsv/index.ts
@@ -1,26 +1,35 @@
 import type { KintoneRecord } from "../../types/record";
-import type { CsvRow, FieldsJson } from "../../../../kintone/types";
+import type { CsvRow, FieldsJson, LayoutJson } from "../../../../kintone/types";
 
 import stringify from "csv-stringify/lib/sync";
 
 import { convertRecord, recordReader } from "./record";
 import { LINE_BREAK, SEPARATOR } from "./constants";
 import { buildHeaderFields } from "./header";
+import { defaultStrategy } from "./strategies/defaultStrategy";
 
 export const printAsCsv = (
   records: KintoneRecord[],
   fieldsJson: FieldsJson,
+  layoutJson: LayoutJson,
   useLocalFilePath: boolean
 ): void => {
-  console.log(stringifyAsCsv(records, fieldsJson, useLocalFilePath));
+  console.log(
+    stringifyAsCsv(records, fieldsJson, layoutJson, useLocalFilePath)
+  );
 };
 
 export const stringifyAsCsv = (
   records: KintoneRecord[],
   fieldsJson: FieldsJson,
+  layoutJson: LayoutJson,
   useLocalFilePath: boolean
 ): string => {
-  const headerFields = buildHeaderFields(fieldsJson);
+  const headerFields = buildHeaderFields(
+    fieldsJson,
+    layoutJson,
+    defaultStrategy(fieldsJson, layoutJson)
+  );
 
   const csvRows: CsvRow[] = [];
   for (const record of recordReader(records)) {

--- a/src/record/export/printers/printAsCsv/strategies/defaultStrategy.ts
+++ b/src/record/export/printers/printAsCsv/strategies/defaultStrategy.ts
@@ -1,0 +1,100 @@
+import type { FieldsJson, LayoutJson } from "../../../../../kintone/types";
+import type { KintoneFormFieldProperty } from "@kintone/rest-api-client";
+import type { Strategy } from "../header";
+
+import { PRIMARY_MARK } from "../constants";
+
+export const defaultStrategy = (
+  fieldsJson: FieldsJson,
+  layoutJson: LayoutJson
+): Strategy => {
+  return {
+    filter: (code) => true,
+    comparator: orderByFormLayoutComparator(fieldsJson, layoutJson),
+  };
+};
+
+export const orderByFormLayoutComparator = (
+  fieldsJson: FieldsJson,
+  layoutJson: LayoutJson
+): Strategy["comparator"] => {
+  const flatLayout = flattenLayout(layoutJson.layout);
+  return (codeA, codeB) => {
+    // the PRIMARY_MARK is always precedence
+    if (codeA === PRIMARY_MARK) {
+      return -1;
+    }
+    if (codeB === PRIMARY_MARK) {
+      return 1;
+    }
+
+    // find fieldCode from layout
+    const indexA = flatLayout.findIndex((field) => field.code === codeA);
+    const indexB = flatLayout.findIndex((field) => field.code === codeB);
+
+    if (indexA !== -1 && indexB !== -1) {
+      return indexA - indexB;
+    } else if (indexA !== -1 && indexB === -1) {
+      if (fieldsJson.properties[codeB]?.type === "RECORD_NUMBER") {
+        return 1;
+      }
+      return -1;
+    } else if (indexA === -1 && indexB !== -1) {
+      if (fieldsJson.properties[codeA]?.type === "RECORD_NUMBER") {
+        return -1;
+      }
+      return 1;
+    }
+
+    const systemFieldsOrder = [
+      "RECORD_NUMBER",
+      "CREATOR",
+      "CREATED_TIME",
+      "MODIFIER",
+      "UPDATED_TIME",
+    ];
+
+    return (
+      systemFieldsOrder.indexOf(fieldsJson.properties[codeA].type) -
+      systemFieldsOrder.indexOf(fieldsJson.properties[codeB].type)
+    );
+  };
+};
+
+const flattenLayout = (
+  layout: LayoutJson["layout"]
+): Array<{
+  code: string;
+  type: KintoneFormFieldProperty.OneOf["type"];
+}> => {
+  const fields: Array<{
+    code: string;
+    type: KintoneFormFieldProperty.OneOf["type"];
+  }> = [];
+
+  for (const row of layout) {
+    switch (row.type) {
+      case "ROW":
+        for (const field of row.fields) {
+          if (
+            field.type !== "HR" &&
+            field.type !== "LABEL" &&
+            field.type !== "SPACER"
+          ) {
+            fields.push({ code: field.code, type: field.type });
+          }
+        }
+        break;
+      case "SUBTABLE":
+        fields.push({ code: row.code, type: row.type });
+        for (const field of row.fields) {
+          fields.push({ code: field.code, type: field.type });
+        }
+        break;
+      case "GROUP":
+        fields.push(...flattenLayout(row.layout));
+        break;
+    }
+  }
+  return fields;
+};


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Because it has better visibility if fields are sorted by form layout. 

## What

<!-- What is a solution you want to add? -->

- [x] sort fields based on form layout
- [x] fix and add tests

## How to test

<!-- How can we test this pull request? -->

```
yarn install
yarn build

yarn test

node cli.js record export --app $APP_ID
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
