### PR TITLE
fix: abolish JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ A kintone record importer and exporter.
     - [Options](#options-1)
 - [Supported file formats](#supported-file-formats)
   - [CSV format](#csv-format)
-  - [JSON format](#json-format)
 - [LICENSE](#license)
 
 ## Installation
@@ -61,10 +60,10 @@ Options:
       --guest-space-id       The ID of guest space
                                       [string] [default: KINTONE_GUEST_SPACE_ID]
       --attachments-dir      Attachment file directory                  [string]
-      --file-path            The path to source file. ".csv" or ".json"
+      --file-path            The path to source file.
+                             The file extension should be ".csv"
                                                              [string] [required]
       --encoding             Character encoding
-                             (available only if the source file format is CSV)
                                      [choices: "utf8", "sjis"] [default: "utf8"]
       --update-key           The key to Bulk Update                     [string]
       --fields               The fields to be imported in comma-separated
@@ -134,10 +133,7 @@ Options:
       --guest-space-id       The ID of guest space
                                       [string] [default: KINTONE_GUEST_SPACE_ID]
       --attachments-dir      Attachment file directory                  [string]
-      --format               Output format. "csv" or "json"
-                                      [choices: "csv", "json"] [default: "csv"]
       --encoding             Character encoding
-                             (available only if the output format is CSV)
                                      [choices: "utf8", "sjis"] [default: "utf8"]
   -c, --condition            The query string                           [string]
       --order-by             The sort order as a query                  [string]
@@ -159,11 +155,13 @@ If set `--attachments-dir` option, attachment files will be downloaded to local 
 
 ## Supported file formats
 
-cli-kintone supports CSV and JSON for both import/export commands.  
-When import, it determines the format automatically by the extension of the file (specified by `--file-path` option).  
-When export, you can specify the format by specifying `--format` option.
+cli-kintone supports following formats for both import/export commands.
 
-The detailed formats of CSV / JSON files are as follows:
+- CSV
+
+When importing, it determines the format automatically by the extension of the file (specified by `--file-path` option).
+
+The detailed formats are as follows:
 
 ### CSV format
 
@@ -240,91 +238,6 @@ When export, if NOT set `--attachments-dir` option, only the file name will be o
 "fileFieldCode"
 "test.txt
 test.txt"
-```
-
-### JSON format
-
-The format of JSON file is the same as Get/Add/Update records REST API.
-
-```json
-[
-  {
-    "FieldCode1": {
-      "type": "SINGLE_LINE_TEXT",
-      "value": "foo"
-    },
-    "Created_by": {
-      "type": "CREATOR",
-      "value": {
-        "code": "Administrator",
-        "name": "Administrator"
-      }
-    },
-    ...
-  },
-  {
-    ...
-  },
-  ...
-]
-```
-
-#### Attachment field
-
-If set `--attachments-dir` option, the format of Attachment field will be changed to below.  
-(Attachment field in Table follows the same rule.)
-
-##### Export
-
-```json
-[
-  {
-     "$id": {
-      "type": "__ID__",
-      "value": "1"
-    },
-    "fileFieldCode": {
-      "type": "FILE",
-      "value": [
-        {
-          "contentType": "text/plain",
-          "fileKey": "test-file-key",
-          "name": "test.txt",
-          "localFilePath": "file-1/test.txt"
-        },
-        {
-          "contentType": "text/plain",
-          "fileKey": "test-file-key",
-          "name": "test.txt",
-          "localFilePath": "file-1/test (1).txt"
-        }
-      ]
-    },
-    ...
-  }
-  ...
-]
-```
-
-##### Import
-
-```json
-[
-  {
-    "fileFieldCode": {
-      "value": [
-        {
-          "localFilePath": "file-1/test.txt"
-        },
-        {
-          "localFilePath": "file-1/test (1).txt"
-        }
-      ]
-    },
-    ...
-  }
-  ...
-]
 ```
 
 ## LICENSE

--- a/src/cli/record/export.ts
+++ b/src/cli/record/export.ts
@@ -1,11 +1,9 @@
 import * as yargs from "yargs";
 
-import type { ExportFileFormat } from "../../record/export/stringifiers";
 import { CommandModule } from "yargs";
 
 import { ExportFileEncoding, run } from "../../record/export";
 
-const formats: ExportFileFormat[] = ["csv", "json"];
 const encodings: ExportFileEncoding[] = ["utf8", "sjis"];
 
 const command = "export";
@@ -77,15 +75,8 @@ const builder = (args: yargs.Argv) =>
       type: "string",
       requiresArg: true,
     })
-    .option("format", {
-      describe: 'Output format. "csv" or "json"',
-      default: "csv" as ExportFileFormat,
-      choices: formats,
-      requiresArg: true,
-    })
     .option("encoding", {
-      describe:
-        "Character encoding\n(available only if the output format is CSV)",
+      describe: "Character encoding",
       default: "utf8" as ExportFileEncoding,
       choices: encodings,
       requiresArg: true,
@@ -138,7 +129,6 @@ const handler = (args: Args) => {
     app: args.app,
     guestSpaceId: args["guest-space-id"],
     attachmentsDir: args["attachments-dir"],
-    format: args.format,
     encoding: args.encoding,
     condition: args.condition,
     orderBy: args["order-by"],

--- a/src/cli/record/import.ts
+++ b/src/cli/record/import.ts
@@ -76,14 +76,13 @@ const builder = (args: yargs.Argv) =>
       requiresArg: true,
     })
     .option("file-path", {
-      describe: 'The path to source file. ".csv" or ".json"',
+      describe: 'The path to source file.\nThe file extension should be ".csv"',
       type: "string",
       demandOption: true,
       requiresArg: true,
     })
     .option("encoding", {
-      describe:
-        "Character encoding\n(available only if the source file format is CSV)",
+      describe: "Character encoding",
       default: "utf8" as SupportedImportEncoding,
       choices: encoding,
       requiresArg: true,

--- a/src/record/export/index.ts
+++ b/src/record/export/index.ts
@@ -2,7 +2,7 @@ import iconv from "iconv-lite";
 
 import { buildRestAPIClient, RestAPIClientOptions } from "../../kintone/client";
 import { getRecords } from "./usecases/get";
-import { ExportFileFormat, stringifierFactory } from "./stringifiers";
+import { stringifierFactory } from "./stringifiers";
 import { createSchema } from "./schema";
 import { formLayout as defaultTransformer } from "./schema/transformers/formLayout";
 import { userSelected } from "./schema/transformers/userSelected";
@@ -12,7 +12,6 @@ export type ExportFileEncoding = "utf8" | "sjis";
 export type Options = {
   app: string;
   attachmentsDir?: string;
-  format: ExportFileFormat;
   encoding: ExportFileEncoding;
   condition?: string;
   orderBy?: string;
@@ -22,10 +21,8 @@ export type Options = {
 export const run: (
   argv: RestAPIClientOptions & Options
 ) => Promise<void> = async (options) => {
-  validateOptions(options);
   const {
     app,
-    format,
     encoding,
     condition,
     orderBy,
@@ -47,18 +44,10 @@ export const run: (
     attachmentsDir,
   });
   const stringifier = stringifierFactory({
-    format,
+    format: "csv",
     schema,
     useLocalFilePath: !!attachmentsDir,
   });
   const stringifiedRecords = stringifier(records);
   process.stdout.write(iconv.encode(stringifiedRecords, encoding));
-};
-
-const validateOptions = (options: Options): void => {
-  if (options.format === "json" && options.encoding !== "utf8") {
-    throw new Error(
-      "When the output format is JSON, the encoding MUST be UTF-8"
-    );
-  }
 };

--- a/src/record/import/parsers/index.ts
+++ b/src/record/import/parsers/index.ts
@@ -1,7 +1,6 @@
 import type { KintoneRecord } from "../types/record";
 import type { RecordSchema } from "../types/schema";
 
-import { parseJson } from "./parseJson";
 import { parseCsv } from "./parseCsv";
 
 export const parseRecords: (options: {
@@ -11,8 +10,6 @@ export const parseRecords: (options: {
 }) => Promise<KintoneRecord[]> = async (options) => {
   const { source, format, schema } = options;
   switch (format) {
-    case "json":
-      return parseJson(source); // TODO: filter fields by the schema
     case "csv":
       return parseCsv(source, schema);
     default:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

## What

<!-- What is a solution you want to add? -->

- delete `--format` option of record export command
- `--file-path` of record import command stop supporting JSON file

## How to test

<!-- How can we test this pull request? -->

```
yarn install
yarn build 

yarn test

## import
cli-kintone record import --app $APP_ID --file-path records.json
Error: Unexpected file type: json is unacceptable.

## export
cli-kintone record export --app $APP_ID --format json                  
Unknown argument: format
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
