### PR TITLE
feat: auto-discover line break represents record delimiter

### DIFF
--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withCr/expected.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withCr/expected.ts
@@ -1,0 +1,26 @@
+import type { KintoneRecord } from "../../../../../types/record";
+
+export const expected: KintoneRecord[] = [
+  {
+    singleLineText: {
+      value: '"single line text"',
+    },
+    multiLineText: {
+      value: "multi\nline\ntext",
+    },
+    multiSelect: {
+      value: ['"sample3"', "sample4,sample5"],
+    },
+  },
+  {
+    singleLineText: {
+      value: '"single line text"',
+    },
+    multiLineText: {
+      value: "multi\nline\ntext",
+    },
+    multiSelect: {
+      value: ['"sample4"', "sample5,sample6"],
+    },
+  },
+];

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withCr/index.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withCr/index.ts
@@ -1,0 +1,12 @@
+import type { TestPattern } from "../../index.test";
+
+import { csv } from "./input";
+import { schema } from "./schema";
+import { expected } from "./expected";
+
+export const pattern: TestPattern = {
+  description: "should convert csv string to JSON correctly",
+  schema: schema,
+  input: csv,
+  expected: expected,
+};

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withCr/input.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withCr/input.ts
@@ -1,0 +1,1 @@
+export const csv = `"singleLineText","multiLineText","multiSelect"\r"""single line text""","multi\nline\ntext","""sample3""\nsample4,sample5"\r"""single line text""","multi\nline\ntext","""sample4""\nsample5,sample6"\r`;

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withCr/schema.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withCr/schema.ts
@@ -1,0 +1,57 @@
+import type { RecordSchema } from "../../../../../types/schema";
+
+export const schema: RecordSchema = {
+  fields: [
+    {
+      type: "SINGLE_LINE_TEXT",
+      code: "singleLineText",
+      label: "singleLineText",
+      noLabel: false,
+      required: false,
+      minLength: "",
+      maxLength: "",
+      expression: "",
+      hideExpression: false,
+      unique: false,
+      defaultValue: "",
+    },
+    {
+      type: "MULTI_LINE_TEXT",
+      code: "multiLineText",
+      label: "multiLineText",
+      noLabel: false,
+      required: false,
+      defaultValue: "",
+    },
+    {
+      type: "MULTI_SELECT",
+      code: "multiSelect",
+      label: "multiSelect",
+      noLabel: false,
+      required: false,
+      options: {
+        sample1: {
+          label: "sample1",
+          index: "0",
+        },
+        "tab\ttab": {
+          label: "tab\ttab",
+          index: "4",
+        },
+        '"sample2"': {
+          label: '"sample2"',
+          index: "1",
+        },
+        "sample4,sample5": {
+          label: "sample4,sample5",
+          index: "3",
+        },
+        '"sample3"': {
+          label: '"sample3"',
+          index: "2",
+        },
+      },
+      defaultValue: [],
+    },
+  ],
+};

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withCrLf/expected.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withCrLf/expected.ts
@@ -1,0 +1,26 @@
+import type { KintoneRecord } from "../../../../../types/record";
+
+export const expected: KintoneRecord[] = [
+  {
+    singleLineText: {
+      value: '"single line text"',
+    },
+    multiLineText: {
+      value: "multi\nline\ntext",
+    },
+    multiSelect: {
+      value: ['"sample3"', "sample4,sample5"],
+    },
+  },
+  {
+    singleLineText: {
+      value: '"single line text"',
+    },
+    multiLineText: {
+      value: "multi\nline\ntext",
+    },
+    multiSelect: {
+      value: ['"sample4"', "sample5,sample6"],
+    },
+  },
+];

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withCrLf/index.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withCrLf/index.ts
@@ -1,0 +1,12 @@
+import type { TestPattern } from "../../index.test";
+
+import { csv } from "./input";
+import { schema } from "./schema";
+import { expected } from "./expected";
+
+export const pattern: TestPattern = {
+  description: "should convert csv string to JSON correctly",
+  schema: schema,
+  input: csv,
+  expected: expected,
+};

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withCrLf/input.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withCrLf/input.ts
@@ -1,0 +1,1 @@
+export const csv = `"singleLineText","multiLineText","multiSelect"\r\n"""single line text""","multi\nline\ntext","""sample3""\nsample4,sample5"\r\n"""single line text""","multi\nline\ntext","""sample4""\nsample5,sample6"\r\n`;

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withCrLf/schema.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withCrLf/schema.ts
@@ -1,0 +1,57 @@
+import type { RecordSchema } from "../../../../../types/schema";
+
+export const schema: RecordSchema = {
+  fields: [
+    {
+      type: "SINGLE_LINE_TEXT",
+      code: "singleLineText",
+      label: "singleLineText",
+      noLabel: false,
+      required: false,
+      minLength: "",
+      maxLength: "",
+      expression: "",
+      hideExpression: false,
+      unique: false,
+      defaultValue: "",
+    },
+    {
+      type: "MULTI_LINE_TEXT",
+      code: "multiLineText",
+      label: "multiLineText",
+      noLabel: false,
+      required: false,
+      defaultValue: "",
+    },
+    {
+      type: "MULTI_SELECT",
+      code: "multiSelect",
+      label: "multiSelect",
+      noLabel: false,
+      required: false,
+      options: {
+        sample1: {
+          label: "sample1",
+          index: "0",
+        },
+        "tab\ttab": {
+          label: "tab\ttab",
+          index: "4",
+        },
+        '"sample2"': {
+          label: '"sample2"',
+          index: "1",
+        },
+        "sample4,sample5": {
+          label: "sample4,sample5",
+          index: "3",
+        },
+        '"sample3"': {
+          label: '"sample3"',
+          index: "2",
+        },
+      },
+      defaultValue: [],
+    },
+  ],
+};

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withLf/expected.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withLf/expected.ts
@@ -1,0 +1,26 @@
+import type { KintoneRecord } from "../../../../../types/record";
+
+export const expected: KintoneRecord[] = [
+  {
+    singleLineText: {
+      value: '"single line text"',
+    },
+    multiLineText: {
+      value: "multi\nline\ntext",
+    },
+    multiSelect: {
+      value: ['"sample3"', "sample4,sample5"],
+    },
+  },
+  {
+    singleLineText: {
+      value: '"single line text"',
+    },
+    multiLineText: {
+      value: "multi\nline\ntext",
+    },
+    multiSelect: {
+      value: ['"sample4"', "sample5,sample6"],
+    },
+  },
+];

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withLf/index.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withLf/index.ts
@@ -1,0 +1,12 @@
+import type { TestPattern } from "../../index.test";
+
+import { csv } from "./input";
+import { schema } from "./schema";
+import { expected } from "./expected";
+
+export const pattern: TestPattern = {
+  description: "should convert csv string to JSON correctly",
+  schema: schema,
+  input: csv,
+  expected: expected,
+};

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withLf/input.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withLf/input.ts
@@ -1,0 +1,1 @@
+export const csv = `"singleLineText","multiLineText","multiSelect"\n"""single line text""","multi\nline\ntext","""sample3""\nsample4,sample5"\n"""single line text""","multi\nline\ntext","""sample4""\nsample5,sample6"\n`;

--- a/src/record/import/parsers/parseCsv/__tests__/fixtures/withLf/schema.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/fixtures/withLf/schema.ts
@@ -1,0 +1,57 @@
+import type { RecordSchema } from "../../../../../types/schema";
+
+export const schema: RecordSchema = {
+  fields: [
+    {
+      type: "SINGLE_LINE_TEXT",
+      code: "singleLineText",
+      label: "singleLineText",
+      noLabel: false,
+      required: false,
+      minLength: "",
+      maxLength: "",
+      expression: "",
+      hideExpression: false,
+      unique: false,
+      defaultValue: "",
+    },
+    {
+      type: "MULTI_LINE_TEXT",
+      code: "multiLineText",
+      label: "multiLineText",
+      noLabel: false,
+      required: false,
+      defaultValue: "",
+    },
+    {
+      type: "MULTI_SELECT",
+      code: "multiSelect",
+      label: "multiSelect",
+      noLabel: false,
+      required: false,
+      options: {
+        sample1: {
+          label: "sample1",
+          index: "0",
+        },
+        "tab\ttab": {
+          label: "tab\ttab",
+          index: "4",
+        },
+        '"sample2"': {
+          label: '"sample2"',
+          index: "1",
+        },
+        "sample4,sample5": {
+          label: "sample4,sample5",
+          index: "3",
+        },
+        '"sample3"': {
+          label: '"sample3"',
+          index: "2",
+        },
+      },
+      defaultValue: [],
+    },
+  ],
+};

--- a/src/record/import/parsers/parseCsv/__tests__/index.test.ts
+++ b/src/record/import/parsers/parseCsv/__tests__/index.test.ts
@@ -7,6 +7,9 @@ import { pattern as withoutSubtable } from "./fixtures/withoutSubtable";
 import { pattern as withSubtable } from "./fixtures/withSubtable";
 import { pattern as emptyCsv } from "./fixtures/emptyCsv";
 import { pattern as withNoRecord } from "./fixtures/withNoRecord";
+import { pattern as withCrLf } from "./fixtures/withCrLf";
+import { pattern as withCr } from "./fixtures/withCr";
+import { pattern as withLf } from "./fixtures/withLf";
 
 export type TestPattern = {
   description: string;
@@ -16,8 +19,18 @@ export type TestPattern = {
 };
 
 describe("parseCsv", () => {
-  const patterns = [withoutSubtable, withSubtable, emptyCsv, withNoRecord];
+  const patterns = [
+    withoutSubtable,
+    withSubtable,
+    emptyCsv,
+    withNoRecord,
+    withCrLf,
+    withCr,
+    withLf,
+  ];
   it.each(patterns)("$description", (pattern) => {
-    expect(parseCsv(pattern.input, pattern.schema)).toEqual(pattern.expected);
+    expect(parseCsv(pattern.input, pattern.schema)).toStrictEqual(
+      pattern.expected
+    );
   });
 });

--- a/src/record/import/parsers/parseCsv/constants.ts
+++ b/src/record/import/parsers/parseCsv/constants.ts
@@ -1,3 +1,4 @@
+// This LINE_BREAK represents the line break inside the cell
 export const LINE_BREAK = "\n";
 export const SEPARATOR = ",";
 export const PRIMARY_MARK = "*";

--- a/src/record/import/parsers/parseCsv/index.ts
+++ b/src/record/import/parsers/parseCsv/index.ts
@@ -5,7 +5,7 @@ import type { RecordSchema } from "../../types/schema";
 import csvParse from "csv-parse/lib/sync";
 
 import { convertRecord, recordReader } from "./record";
-import { LINE_BREAK, SEPARATOR } from "./constants";
+import { SEPARATOR } from "./constants";
 
 export const parseCsv: (
   csv: string,
@@ -15,7 +15,6 @@ export const parseCsv: (
     columns: true,
     skip_empty_lines: true,
     delimiter: SEPARATOR,
-    record_delimiter: LINE_BREAK,
   });
 
   const records: KintoneRecord[] = [];


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Because users want to import CSVs which contains various line break character.
e.g. exported from kintone, Excel, or Numbers


## What

<!-- What is a solution you want to add? -->

- When importing CSV
  - [x] cli-kintone auto-discovers line break character which represents record delimiter
    - CR(`\r`) or LF(`\n`) or CRLF(`\r\n`)
  - [x] cli-kintone always uses LF(`\n`) as the line break inside a cell

## How to test

<!-- How can we test this pull request? -->

```
yarn build

yarn test

node ./cli.js record import --app $APP_ID --file-path records.csv
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
