### PR TITLE
feat: upsert records sequentially

### DIFF
--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByNumber/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByNumber/expected.ts
@@ -2,46 +2,54 @@ import { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {
-    forUpdate: {
-      app: "1",
-      records: [
-        {
-          updateKey: {
-            field: "number",
-            value: "1",
-          },
-          record: {
-            singleLineText: {
-              value: "value1",
+    requests: [
+      {
+        type: "update",
+        payload: {
+          app: "1",
+          records: [
+            {
+              updateKey: {
+                field: "number",
+                value: "1",
+              },
+              record: {
+                singleLineText: {
+                  value: "value1",
+                },
+                date: {
+                  value: "2022-03-01",
+                },
+                singleLineText_nonUnique: {
+                  value: "value1",
+                },
+              },
             },
-            date: {
-              value: "2022-03-01",
-            },
-            singleLineText_nonUnique: {
-              value: "value1",
-            },
-          },
+          ],
         },
-      ],
-    },
-    forAdd: {
-      app: "1",
-      records: [
-        {
-          singleLineText: {
-            value: "value3",
-          },
-          number: {
-            value: "3",
-          },
-          date: {
-            value: "2022-04-01",
-          },
-          singleLineText_nonUnique: {
-            value: "value1",
-          },
+      },
+      {
+        type: "add",
+        payload: {
+          app: "1",
+          records: [
+            {
+              singleLineText: {
+                value: "value3",
+              },
+              number: {
+                value: "3",
+              },
+              date: {
+                value: "2022-04-01",
+              },
+              singleLineText_nonUnique: {
+                value: "value1",
+              },
+            },
+          ],
         },
-      ],
-    },
+      },
+    ],
   },
 };

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumber/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumber/expected.ts
@@ -2,34 +2,42 @@ import { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {
-    forUpdate: {
-      app: "1",
-      records: [
-        {
-          id: "1",
-          record: {
-            number: {
-              value: "1",
+    requests: [
+      {
+        type: "update",
+        payload: {
+          app: "1",
+          records: [
+            {
+              id: "1",
+              record: {
+                number: {
+                  value: "1",
+                },
+                singleLineText: {
+                  value: "value1",
+                },
+              },
             },
-            singleLineText: {
-              value: "value1",
+          ],
+        },
+      },
+      {
+        type: "add",
+        payload: {
+          app: "1",
+          records: [
+            {
+              singleLineText: {
+                value: "value3",
+              },
+              number: {
+                value: "3",
+              },
             },
-          },
+          ],
         },
-      ],
-    },
-    forAdd: {
-      app: "1",
-      records: [
-        {
-          singleLineText: {
-            value: "value3",
-          },
-          number: {
-            value: "3",
-          },
-        },
-      ],
-    },
+      },
+    ],
   },
 };

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCode/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCode/expected.ts
@@ -2,34 +2,42 @@ import { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {
-    forUpdate: {
-      app: "1",
-      records: [
-        {
-          id: "1",
-          record: {
-            number: {
-              value: "1",
+    requests: [
+      {
+        type: "update",
+        payload: {
+          app: "1",
+          records: [
+            {
+              id: "1",
+              record: {
+                number: {
+                  value: "1",
+                },
+                singleLineText: {
+                  value: "value1",
+                },
+              },
             },
-            singleLineText: {
-              value: "value1",
+          ],
+        },
+      },
+      {
+        type: "add",
+        payload: {
+          app: "1",
+          records: [
+            {
+              singleLineText: {
+                value: "value3",
+              },
+              number: {
+                value: "3",
+              },
             },
-          },
+          ],
         },
-      ],
-    },
-    forAdd: {
-      app: "1",
-      records: [
-        {
-          singleLineText: {
-            value: "value3",
-          },
-          number: {
-            value: "3",
-          },
-        },
-      ],
-    },
+      },
+    ],
   },
 };

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCodeOnKintone/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCodeOnKintone/expected.ts
@@ -2,34 +2,42 @@ import { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {
-    forUpdate: {
-      app: "1",
-      records: [
-        {
-          id: "1",
-          record: {
-            number: {
-              value: "1",
+    requests: [
+      {
+        type: "update",
+        payload: {
+          app: "1",
+          records: [
+            {
+              id: "1",
+              record: {
+                number: {
+                  value: "1",
+                },
+                singleLineText: {
+                  value: "value1",
+                },
+              },
             },
-            singleLineText: {
-              value: "value1",
+          ],
+        },
+      },
+      {
+        type: "add",
+        payload: {
+          app: "1",
+          records: [
+            {
+              singleLineText: {
+                value: "value3",
+              },
+              number: {
+                value: "3",
+              },
             },
-          },
+          ],
         },
-      ],
-    },
-    forAdd: {
-      app: "1",
-      records: [
-        {
-          singleLineText: {
-            value: "value3",
-          },
-          number: {
-            value: "3",
-          },
-        },
-      ],
-    },
+      },
+    ],
   },
 };

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertBySingleLineText/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertBySingleLineText/expected.ts
@@ -2,46 +2,54 @@ import { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {
-    forUpdate: {
-      app: "1",
-      records: [
-        {
-          updateKey: {
-            field: "singleLineText",
-            value: "value1",
-          },
-          record: {
-            number: {
-              value: "1",
+    requests: [
+      {
+        type: "update",
+        payload: {
+          app: "1",
+          records: [
+            {
+              updateKey: {
+                field: "singleLineText",
+                value: "value1",
+              },
+              record: {
+                number: {
+                  value: "1",
+                },
+                date: {
+                  value: "2022-03-01",
+                },
+                singleLineText_nonUnique: {
+                  value: "value1",
+                },
+              },
             },
-            date: {
-              value: "2022-03-01",
-            },
-            singleLineText_nonUnique: {
-              value: "value1",
-            },
-          },
+          ],
         },
-      ],
-    },
-    forAdd: {
-      app: "1",
-      records: [
-        {
-          singleLineText: {
-            value: "value3",
-          },
-          number: {
-            value: "3",
-          },
-          date: {
-            value: "2022-04-01",
-          },
-          singleLineText_nonUnique: {
-            value: "value1",
-          },
+      },
+      {
+        type: "add",
+        payload: {
+          app: "1",
+          records: [
+            {
+              singleLineText: {
+                value: "value3",
+              },
+              number: {
+                value: "3",
+              },
+              date: {
+                value: "2022-04-01",
+              },
+              singleLineText_nonUnique: {
+                value: "value1",
+              },
+            },
+          ],
         },
-      ],
-    },
+      },
+    ],
   },
 };

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/expected.ts
@@ -1,0 +1,94 @@
+import { TestPattern } from "../../index.test";
+
+export const expected: TestPattern["expected"] = {
+  success: {
+    requests: [
+      {
+        type: "add",
+        payload: {
+          app: "1",
+          records: [
+            {
+              singleLineText: {
+                value: "value11",
+              },
+              number: {
+                value: "11",
+              },
+            },
+            {
+              singleLineText: {
+                value: "value22",
+              },
+              number: {
+                value: "22",
+              },
+            },
+            {
+              singleLineText: {
+                value: "value33",
+              },
+              number: {
+                value: "33",
+              },
+            },
+          ],
+        },
+      },
+      {
+        type: "update",
+        payload: {
+          app: "1",
+          records: [
+            {
+              id: "1",
+              record: {
+                number: {
+                  value: "1",
+                },
+                singleLineText: {
+                  value: "value1",
+                },
+              },
+            },
+            {
+              id: "2",
+              record: {
+                number: {
+                  value: "2",
+                },
+                singleLineText: {
+                  value: "value2",
+                },
+              },
+            },
+          ],
+        },
+      },
+      {
+        type: "add",
+        payload: {
+          app: "1",
+          records: [
+            {
+              singleLineText: {
+                value: "value44",
+              },
+              number: {
+                value: "44",
+              },
+            },
+            {
+              singleLineText: {
+                value: "value55",
+              },
+              number: {
+                value: "55",
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/index.ts
@@ -1,0 +1,20 @@
+import { TestPattern } from "../../index.test";
+import { records } from "./records";
+import { schema } from "./schema";
+import { expected } from "./expected";
+import { recordsOnKintone } from "./recordsOnKintone";
+
+export const pattern: TestPattern = {
+  description: "should upsert records with correct order",
+  input: {
+    records: records,
+    schema: schema,
+    updateKey: "recordNumber",
+    options: {
+      attachmentsDir: "",
+      skipMissingFields: true,
+    },
+  },
+  recordsOnKintone: recordsOnKintone,
+  expected: expected,
+};

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/records.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/records.ts
@@ -1,0 +1,81 @@
+import type { KintoneRecord } from "../../../../../types/record";
+
+export const records: KintoneRecord[] = [
+  {
+    recordNumber: {
+      value: "",
+    },
+    singleLineText: {
+      value: "value11",
+    },
+    number: {
+      value: "11",
+    },
+  },
+  {
+    recordNumber: {
+      value: "",
+    },
+    singleLineText: {
+      value: "value22",
+    },
+    number: {
+      value: "22",
+    },
+  },
+  {
+    recordNumber: {
+      value: "",
+    },
+    singleLineText: {
+      value: "value33",
+    },
+    number: {
+      value: "33",
+    },
+  },
+  {
+    recordNumber: {
+      value: "1",
+    },
+    singleLineText: {
+      value: "value1",
+    },
+    number: {
+      value: "1",
+    },
+  },
+  {
+    recordNumber: {
+      value: "2",
+    },
+    singleLineText: {
+      value: "value2",
+    },
+    number: {
+      value: "2",
+    },
+  },
+  {
+    recordNumber: {
+      value: "",
+    },
+    singleLineText: {
+      value: "value44",
+    },
+    number: {
+      value: "44",
+    },
+  },
+  {
+    recordNumber: {
+      value: "",
+    },
+    singleLineText: {
+      value: "value55",
+    },
+    number: {
+      value: "55",
+    },
+  },
+];

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/recordsOnKintone.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/recordsOnKintone.ts
@@ -1,0 +1,34 @@
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
+
+export const recordsOnKintone: Awaited<
+  ReturnType<KintoneRestAPIClient["record"]["getAllRecords"]>
+> = [
+  {
+    recordNumber: {
+      type: "RECORD_NUMBER",
+      value: "1",
+    },
+    singleLineText: {
+      type: "SINGLE_LINE_TEXT",
+      value: "value1",
+    },
+    number: {
+      type: "NUMBER",
+      value: "1",
+    },
+  },
+  {
+    recordNumber: {
+      type: "RECORD_NUMBER",
+      value: "2",
+    },
+    singleLineText: {
+      type: "SINGLE_LINE_TEXT",
+      value: "value2",
+    },
+    number: {
+      type: "NUMBER",
+      value: "2",
+    },
+  },
+];

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/schema.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/schema.ts
@@ -1,0 +1,40 @@
+import type { RecordSchema } from "../../../../../types/schema";
+
+export const schema: RecordSchema = {
+  fields: [
+    {
+      type: "RECORD_NUMBER",
+      code: "recordNumber",
+      label: "recordNumber",
+      noLabel: false,
+    },
+    {
+      type: "SINGLE_LINE_TEXT",
+      code: "singleLineText",
+      label: "singleLineText",
+      noLabel: false,
+      required: false,
+      minLength: "",
+      maxLength: "",
+      expression: "",
+      hideExpression: false,
+      unique: true,
+      defaultValue: "",
+    },
+    {
+      type: "NUMBER",
+      code: "number",
+      label: "number",
+      noLabel: false,
+      required: true,
+      minValue: "",
+      maxValue: "",
+      digit: false,
+      unique: true,
+      defaultValue: "",
+      displayScale: "",
+      unit: "",
+      unitPosition: "BEFORE",
+    },
+  ],
+};

--- a/src/record/import/usecases/__tests__/upsert/index.test.ts
+++ b/src/record/import/usecases/__tests__/upsert/index.test.ts
@@ -34,10 +34,20 @@ export type TestPattern = {
   >;
   expected: {
     success?: {
-      forUpdate: Parameters<
-        KintoneRestAPIClient["record"]["updateAllRecords"]
-      >[0];
-      forAdd: Parameters<KintoneRestAPIClient["record"]["addAllRecords"]>[0];
+      requests: Array<
+        | {
+            type: "update";
+            payload: Parameters<
+              KintoneRestAPIClient["record"]["updateAllRecords"]
+            >[0];
+          }
+        | {
+            type: "add";
+            payload: Parameters<
+              KintoneRestAPIClient["record"]["addAllRecords"]
+            >[0];
+          }
+      >;
     };
     failure?: {
       errorMessage: string;
@@ -99,10 +109,13 @@ describe("upsertRecords", () => {
           input.updateKey,
           input.options
         );
-        expect(updateAllRecordsMockFn).toBeCalledWith(
-          expected.success.forUpdate
-        );
-        expect(addAllRecordsMockFn).toBeCalledWith(expected.success.forAdd);
+        for (const request of expected.success.requests) {
+          if (request.type === "update") {
+            expect(updateAllRecordsMockFn).toBeCalledWith(request.payload);
+          } else {
+            expect(addAllRecordsMockFn).toBeCalledWith(request.payload);
+          }
+        }
       }
       if (expected.failure !== undefined) {
         await expect(

--- a/src/record/import/usecases/__tests__/upsert/index.test.ts
+++ b/src/record/import/usecases/__tests__/upsert/index.test.ts
@@ -9,6 +9,7 @@ import { pattern as upsertByRecordNumberWithAppCode } from "./fixtures/upsertByR
 import { pattern as upsertByRecordNumberWithAppCodeOnKintone } from "./fixtures/upsertByRecordNumberWithAppCodeOnKintone";
 import { pattern as upsertBySingleLineText } from "./fixtures/upsertByNumber";
 import { pattern as upsertByNumber } from "./fixtures/upsertBySingleLineText";
+import { pattern as upsertRecordsSequentially } from "./fixtures/upsertRecordsSequentially";
 import { pattern as upsertByNonUniqueKey } from "./fixtures/upsertByNonUniqueKey";
 import { pattern as upsertByUnsupportedField } from "./fixtures/upsertByUnsupportedField";
 import { pattern as upsertByNonExistentField } from "./fixtures/upsertByNonExistentField";
@@ -70,6 +71,7 @@ describe("upsertRecords", () => {
     upsertByRecordNumberWithAppCodeOnKintone,
     upsertBySingleLineText,
     upsertByNumber,
+    upsertRecordsSequentially,
     upsertByNonUniqueKey,
     upsertByUnsupportedField,
     upsertByNonExistentField,

--- a/src/record/import/usecases/upsert.ts
+++ b/src/record/import/usecases/upsert.ts
@@ -47,7 +47,7 @@ export const upsertRecords: (
   await uploadToKintone(apiClient, app, kintoneRecords);
 };
 
-type KintoneRecords = Array<
+type RecordAsRequestParameter =
   | {
       type: "add";
       record: KintoneRecordForParameter;
@@ -55,8 +55,7 @@ type KintoneRecords = Array<
   | {
       type: "update";
       record: KintoneRecordForUpdateParameter;
-    }
->;
+    };
 
 const convertRecordsToApiRequestParameter = async (
   apiClient: KintoneRestAPIClient,
@@ -68,7 +67,7 @@ const convertRecordsToApiRequestParameter = async (
     attachmentsDir?: string;
     skipMissingFields: boolean;
   }
-): Promise<KintoneRecords> => {
+): Promise<RecordAsRequestParameter[]> => {
   const { attachmentsDir, skipMissingFields } = options;
 
   const updateKey = findUpdateKeyInSchema(updateKeyCode, schema);
@@ -89,7 +88,7 @@ const convertRecordsToApiRequestParameter = async (
     })
   );
 
-  const kintoneRecords: KintoneRecords = [];
+  const kintoneRecords: RecordAsRequestParameter[] = [];
   for (const record of records) {
     const kintoneRecord = await recordReducer(
       record,
@@ -156,7 +155,7 @@ const parseUpdateKeyValue = (
 const uploadToKintone = async (
   apiClient: KintoneRestAPIClient,
   app: string,
-  kintoneRecords: KintoneRecords
+  kintoneRecords: RecordAsRequestParameter[]
 ) => {
   let recordsToUploadNext:
     | {

--- a/src/record/import/usecases/upsert.ts
+++ b/src/record/import/usecases/upsert.ts
@@ -188,4 +188,7 @@ const uploadToKintone = async (
       recordsToUploadNext.records.push(record.record as any);
     }
   }
+  if (recordsToUploadNext) {
+    await upsert(recordsToUploadNext);
+  }
 };

--- a/src/record/import/usecases/upsert.ts
+++ b/src/record/import/usecases/upsert.ts
@@ -46,6 +46,17 @@ export const upsertRecords: (
   await uploadToKintone(apiClient, app, kintoneRecords);
 };
 
+type KintoneRecords = Array<
+  | {
+      type: "add";
+      record: KintoneRecordForParameter;
+    }
+  | {
+      type: "update";
+      record: KintoneRecordForUpdateParameter;
+    }
+>;
+
 const convertRecordsToApiRequestParameter = async (
   apiClient: KintoneRestAPIClient,
   app: string,
@@ -56,10 +67,7 @@ const convertRecordsToApiRequestParameter = async (
     attachmentsDir?: string;
     skipMissingFields: boolean;
   }
-): Promise<{
-  forAdd: KintoneRecordForParameter[];
-  forUpdate: KintoneRecordForUpdateParameter[];
-}> => {
+): Promise<KintoneRecords> => {
   const { attachmentsDir, skipMissingFields } = options;
 
   const updateKey = findUpdateKeyInSchema(updateKeyCode, schema);
@@ -80,8 +88,7 @@ const convertRecordsToApiRequestParameter = async (
     })
   );
 
-  const kintoneRecordsForAdd: KintoneRecordForParameter[] = [];
-  const kintoneRecordsForUpdate: KintoneRecordForUpdateParameter[] = [];
+  const kintoneRecords: KintoneRecords = [];
   for (const record of records) {
     const kintoneRecord = await recordReducer(
       record,
@@ -109,49 +116,76 @@ const convertRecordsToApiRequestParameter = async (
               updateKey: { field: updateKey.code, value: updateKeyValue },
               record: kintoneRecord,
             };
-      kintoneRecordsForUpdate.push(recordForUpdate);
+      kintoneRecords.push({
+        type: "update",
+        record: recordForUpdate,
+      });
     } else {
       if (updateKey.type === "RECORD_NUMBER") {
         delete kintoneRecord[updateKey.code];
       }
-      kintoneRecordsForAdd.push(kintoneRecord);
+      kintoneRecords.push({
+        type: "add",
+        record: kintoneRecord,
+      });
     }
   }
-  return { forAdd: kintoneRecordsForAdd, forUpdate: kintoneRecordsForUpdate };
+  return kintoneRecords;
 };
 
 const uploadToKintone = async (
   apiClient: KintoneRestAPIClient,
   app: string,
-  kintoneRecords: {
-    forAdd: KintoneRecordForParameter[];
-    forUpdate: KintoneRecordForUpdateParameter[];
-  }
+  kintoneRecords: KintoneRecords
 ) => {
-  if (kintoneRecords.forUpdate.length > 0) {
+  let recordsToUploadNext:
+    | {
+        type: "add";
+        records: KintoneRecordForParameter[];
+      }
+    | {
+        type: "update";
+        records: KintoneRecordForUpdateParameter[];
+      }
+    | undefined;
+
+  const upsert = async (
+    recordsToUpload:
+      | { type: "add"; records: KintoneRecordForParameter[] }
+      | { type: "update"; records: KintoneRecordForUpdateParameter[] }
+  ) => {
     try {
-      await apiClient.record.updateAllRecords({
-        app,
-        records: kintoneRecords.forUpdate,
-      });
-      console.log(
-        `SUCCESS: update records[${kintoneRecords.forUpdate.length}]`
-      );
+      if (recordsToUpload.type === "update") {
+        await apiClient.record.updateAllRecords({
+          app,
+          records: recordsToUpload.records,
+        });
+      } else {
+        await apiClient.record.addAllRecords({
+          app,
+          records: recordsToUpload.records,
+        });
+      }
+      console.log(`SUCCESS: import records[${recordsToUpload.records.length}]`);
     } catch (e) {
-      console.log(`FAILED: update records[${kintoneRecords.forUpdate.length}]`);
+      console.log(`FAILED: import records[${recordsToUpload.records.length}]`);
       throw e;
     }
-  }
-  if (kintoneRecords.forAdd.length > 0) {
-    try {
-      await apiClient.record.addAllRecords({
-        app,
-        records: kintoneRecords.forAdd,
-      });
-      console.log(`SUCCESS: add records[${kintoneRecords.forAdd.length}]`);
-    } catch (e) {
-      console.log(`FAILED: add records[${kintoneRecords.forAdd.length}]`);
-      throw e;
+  };
+
+  for (const record of kintoneRecords) {
+    if (recordsToUploadNext && record.type !== recordsToUploadNext.type) {
+      await upsert(recordsToUploadNext);
+      recordsToUploadNext = undefined;
+    }
+
+    if (recordsToUploadNext === undefined) {
+      recordsToUploadNext = {
+        type: record.type,
+        records: [record.record as any],
+      };
+    } else {
+      recordsToUploadNext.records.push(record.record as any);
     }
   }
 };

--- a/src/record/import/usecases/upsert/updateKey.ts
+++ b/src/record/import/usecases/upsert/updateKey.ts
@@ -3,10 +3,15 @@ import type { KintoneFormFieldProperty } from "@kintone/rest-api-client";
 import type { FieldSchema, RecordSchema } from "../../types/schema";
 import type { KintoneRecord } from "../../types/record";
 
+export type UpdateKey = {
+  code: string;
+  type: SupportedUpdateKeyFieldType["type"];
+};
+
 export const findUpdateKeyInSchema = (
   updateKey: string,
   schema: RecordSchema
-): { code: string; type: SupportedUpdateKeyFieldType["type"] } => {
+): UpdateKey => {
   const updateKeySchema = schema.fields.find(
     (fieldSchema) => fieldSchema.code === updateKey
   );
@@ -48,7 +53,7 @@ const isSupportedUpdateKeyFieldType = (
 };
 
 export const validateUpdateKeyInRecords = (
-  updateKey: { code: string; type: SupportedUpdateKeyFieldType["type"] },
+  updateKey: UpdateKey,
   appCode: string,
   records: KintoneRecord[]
 ) => {
@@ -64,6 +69,10 @@ export const validateUpdateKeyInRecords = (
       throw new Error(
         `The value of the "Key to Bulk Update" (${updateKey.code}) on the input is invalid`
       );
+    }
+
+    if (value.length === 0) {
+      return;
     }
 
     if (updateKey.type === "RECORD_NUMBER") {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

It makes it easier to determine which lines in CSV were successful up to.

## What

<!-- What is a solution you want to add? -->

- [x] run upsert sequentially in order of CSV row.

## How to test

<!-- How can we test this pull request? -->

```
yarn install
yarn build

yarn test

node ./cli.js record import --app $APP_ID --file-path records.csv
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
