### PR TITLE
feat: show progress log while importing

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@kintone/rest-api-client": "^3.1.11",
+    "chalk": "4",
     "csv-parse": "^4.16.3",
     "csv-stringify": "5.6.5",
     "https-proxy-agent": "^5.0.1",

--- a/src/record/import/index.ts
+++ b/src/record/import/index.ts
@@ -6,7 +6,7 @@ import { upsertRecords } from "./usecases/upsert";
 import { createSchema } from "./schema";
 import { noop as defaultTransformer } from "./schema/transformers/noop";
 import { userSelected } from "./schema/transformers/userSelected";
-import { printError } from "./utils/log";
+import { logger } from "./utils/log";
 
 export type Options = {
   app: string;
@@ -47,7 +47,7 @@ export const run: (
       schema,
     });
     if (records.length === 0) {
-      console.log("The input file does not have any records");
+      logger.warn("The input file does not have any records");
       return;
     }
     const skipMissingFields = !fields;
@@ -63,7 +63,7 @@ export const run: (
       });
     }
   } catch (e) {
-    printError(e);
+    logger.error(e);
     // eslint-disable-next-line no-process-exit
     process.exit(1);
   }

--- a/src/record/import/usecases/__tests__/add/progress.test.ts
+++ b/src/record/import/usecases/__tests__/add/progress.test.ts
@@ -1,0 +1,85 @@
+import { ProgressLogger } from "../../add/progress";
+import chalk from "chalk";
+
+const info = chalk.blue("INFO");
+
+describe("ProgressLogger", () => {
+  const date = new Date(1664258017505);
+  const dateMock = jest
+    .spyOn(global, "Date")
+    .mockImplementation(() => date as unknown as string);
+
+  afterAll(() => {
+    dateMock.mockRestore();
+  });
+
+  it("should show progress logs correctly", () => {
+    const consoleErrorMock = jest.spyOn(console, "error").mockImplementation();
+    const progressLogger = new ProgressLogger(5000);
+    expect(consoleErrorMock).not.toHaveBeenCalled();
+
+    progressLogger.update(100);
+    expect(consoleErrorMock).not.toHaveBeenCalled();
+
+    progressLogger.update(2000);
+    expect(consoleErrorMock).toHaveBeenCalledTimes(2);
+    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+      1,
+      `[${date.toISOString()}] ${info}: Imported 1000 of 5000 records`
+    );
+    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+      2,
+      `[${date.toISOString()}] ${info}: Imported 2000 of 5000 records`
+    );
+
+    progressLogger.update(4100);
+    expect(consoleErrorMock).toHaveBeenCalledTimes(4);
+    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+      3,
+      `[${date.toISOString()}] ${info}: Imported 3000 of 5000 records`
+    );
+    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+      4,
+      `[${date.toISOString()}] ${info}: Imported 4000 of 5000 records`
+    );
+
+    progressLogger.done();
+    expect(consoleErrorMock).toHaveBeenCalledTimes(5);
+    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+      5,
+      `[${date.toISOString()}] ${info}: Imported 5000 records successfully`
+    );
+
+    consoleErrorMock.mockRestore();
+  });
+
+  it("should show progress logs correctly with aborting", () => {
+    const consoleErrorMock = jest.spyOn(console, "error").mockImplementation();
+
+    const progressLogger = new ProgressLogger(3000);
+    expect(consoleErrorMock).not.toHaveBeenCalled();
+
+    progressLogger.update(100);
+    expect(consoleErrorMock).not.toHaveBeenCalled();
+
+    progressLogger.update(2100);
+    expect(consoleErrorMock).toHaveBeenCalledTimes(2);
+    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+      1,
+      `[${date.toISOString()}] ${info}: Imported 1000 of 3000 records`
+    );
+    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+      2,
+      `[${date.toISOString()}] ${info}: Imported 2000 of 3000 records`
+    );
+
+    progressLogger.abort(2500);
+    expect(consoleErrorMock).toHaveBeenCalledTimes(3);
+    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+      3,
+      `[${date.toISOString()}] ${info}: Imported 2500 of 3000 records successfully`
+    );
+
+    consoleErrorMock.mockRestore();
+  });
+});

--- a/src/record/import/usecases/__tests__/add/progress.test.ts
+++ b/src/record/import/usecases/__tests__/add/progress.test.ts
@@ -1,85 +1,75 @@
-import { ProgressLogger } from "../../add/progress";
-import chalk from "chalk";
+import type { Logger } from "../../../utils/log";
 
-const info = chalk.blue("INFO");
+import { ProgressLogger } from "../../add/progress";
+
+const mockLogger: Logger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
 
 describe("ProgressLogger", () => {
-  const date = new Date(1664258017505);
-  const dateMock = jest
-    .spyOn(global, "Date")
-    .mockImplementation(() => date as unknown as string);
-
-  afterAll(() => {
-    dateMock.mockRestore();
-  });
-
   it("should show progress logs correctly", () => {
-    const consoleErrorMock = jest.spyOn(console, "error").mockImplementation();
-    const progressLogger = new ProgressLogger(5000);
-    expect(consoleErrorMock).not.toHaveBeenCalled();
+    const progressLogger = new ProgressLogger(mockLogger, 5000);
+    expect(mockLogger.info).not.toHaveBeenCalled();
 
     progressLogger.update(100);
-    expect(consoleErrorMock).not.toHaveBeenCalled();
+    expect(mockLogger.info).not.toHaveBeenCalled();
 
     progressLogger.update(2000);
-    expect(consoleErrorMock).toHaveBeenCalledTimes(2);
-    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+    expect(mockLogger.info).toHaveBeenCalledTimes(2);
+    expect(mockLogger.info).toHaveBeenNthCalledWith(
       1,
-      `[${date.toISOString()}] ${info}: Imported 1000 of 5000 records`
+      "Imported 1000 of 5000 records"
     );
-    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+    expect(mockLogger.info).toHaveBeenNthCalledWith(
       2,
-      `[${date.toISOString()}] ${info}: Imported 2000 of 5000 records`
+      "Imported 2000 of 5000 records"
     );
 
     progressLogger.update(4100);
-    expect(consoleErrorMock).toHaveBeenCalledTimes(4);
-    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+    expect(mockLogger.info).toHaveBeenCalledTimes(4);
+    expect(mockLogger.info).toHaveBeenNthCalledWith(
       3,
-      `[${date.toISOString()}] ${info}: Imported 3000 of 5000 records`
+      "Imported 3000 of 5000 records"
     );
-    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+    expect(mockLogger.info).toHaveBeenNthCalledWith(
       4,
-      `[${date.toISOString()}] ${info}: Imported 4000 of 5000 records`
+      "Imported 4000 of 5000 records"
     );
 
     progressLogger.done();
-    expect(consoleErrorMock).toHaveBeenCalledTimes(5);
-    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+    expect(mockLogger.info).toHaveBeenCalledTimes(5);
+    expect(mockLogger.info).toHaveBeenNthCalledWith(
       5,
-      `[${date.toISOString()}] ${info}: Imported 5000 records successfully`
+      "Imported 5000 records successfully"
     );
-
-    consoleErrorMock.mockRestore();
   });
 
   it("should show progress logs correctly with aborting", () => {
-    const consoleErrorMock = jest.spyOn(console, "error").mockImplementation();
-
-    const progressLogger = new ProgressLogger(3000);
-    expect(consoleErrorMock).not.toHaveBeenCalled();
+    const progressLogger = new ProgressLogger(mockLogger, 3000);
+    expect(mockLogger.info).not.toHaveBeenCalled();
 
     progressLogger.update(100);
-    expect(consoleErrorMock).not.toHaveBeenCalled();
+    expect(mockLogger.info).not.toHaveBeenCalled();
 
     progressLogger.update(2100);
-    expect(consoleErrorMock).toHaveBeenCalledTimes(2);
-    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+    expect(mockLogger.info).toHaveBeenCalledTimes(2);
+    expect(mockLogger.info).toHaveBeenNthCalledWith(
       1,
-      `[${date.toISOString()}] ${info}: Imported 1000 of 3000 records`
+      "Imported 1000 of 3000 records"
     );
-    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+    expect(mockLogger.info).toHaveBeenNthCalledWith(
       2,
-      `[${date.toISOString()}] ${info}: Imported 2000 of 3000 records`
+      "Imported 2000 of 3000 records"
     );
 
     progressLogger.abort(2500);
-    expect(consoleErrorMock).toHaveBeenCalledTimes(3);
-    expect(consoleErrorMock).toHaveBeenNthCalledWith(
+    expect(mockLogger.info).toHaveBeenCalledTimes(3);
+    expect(mockLogger.info).toHaveBeenNthCalledWith(
       3,
-      `[${date.toISOString()}] ${info}: Imported 2500 of 3000 records successfully`
+      "Imported 2500 of 3000 records successfully"
     );
-
-    consoleErrorMock.mockRestore();
   });
 });

--- a/src/record/import/usecases/__tests__/add/progress.test.ts
+++ b/src/record/import/usecases/__tests__/add/progress.test.ts
@@ -11,64 +11,52 @@ const mockLogger: Logger = {
 
 describe("ProgressLogger", () => {
   it("should show progress logs correctly", () => {
-    const progressLogger = new ProgressLogger(mockLogger, 5000);
+    const progressLogger = new ProgressLogger(mockLogger, 5000, 2000);
     expect(mockLogger.info).not.toHaveBeenCalled();
 
     progressLogger.update(100);
     expect(mockLogger.info).not.toHaveBeenCalled();
 
     progressLogger.update(2000);
-    expect(mockLogger.info).toHaveBeenCalledTimes(2);
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
     expect(mockLogger.info).toHaveBeenNthCalledWith(
       1,
-      "Imported 1000 of 5000 records"
-    );
-    expect(mockLogger.info).toHaveBeenNthCalledWith(
-      2,
       "Imported 2000 of 5000 records"
     );
 
     progressLogger.update(4100);
-    expect(mockLogger.info).toHaveBeenCalledTimes(4);
+    expect(mockLogger.info).toHaveBeenCalledTimes(2);
     expect(mockLogger.info).toHaveBeenNthCalledWith(
-      3,
-      "Imported 3000 of 5000 records"
-    );
-    expect(mockLogger.info).toHaveBeenNthCalledWith(
-      4,
+      2,
       "Imported 4000 of 5000 records"
     );
 
     progressLogger.done();
-    expect(mockLogger.info).toHaveBeenCalledTimes(5);
+    expect(mockLogger.info).toHaveBeenCalledTimes(3);
     expect(mockLogger.info).toHaveBeenNthCalledWith(
-      5,
+      3,
       "Imported 5000 records successfully"
     );
   });
 
   it("should show progress logs correctly with aborting", () => {
-    const progressLogger = new ProgressLogger(mockLogger, 3000);
+    const progressLogger = new ProgressLogger(mockLogger, 3000, 2000);
     expect(mockLogger.info).not.toHaveBeenCalled();
 
     progressLogger.update(100);
     expect(mockLogger.info).not.toHaveBeenCalled();
 
     progressLogger.update(2100);
-    expect(mockLogger.info).toHaveBeenCalledTimes(2);
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
     expect(mockLogger.info).toHaveBeenNthCalledWith(
       1,
-      "Imported 1000 of 3000 records"
-    );
-    expect(mockLogger.info).toHaveBeenNthCalledWith(
-      2,
       "Imported 2000 of 3000 records"
     );
 
     progressLogger.abort(2500);
-    expect(mockLogger.info).toHaveBeenCalledTimes(3);
+    expect(mockLogger.info).toHaveBeenCalledTimes(2);
     expect(mockLogger.info).toHaveBeenNthCalledWith(
-      3,
+      2,
       "Imported 2500 of 3000 records successfully"
     );
   });

--- a/src/record/import/usecases/add.ts
+++ b/src/record/import/usecases/add.ts
@@ -5,6 +5,7 @@ import type { RecordSchema } from "../types/schema";
 
 import { fieldProcessor, recordReducer } from "./add/record";
 import { AddRecordsError } from "./add/error";
+import { logger } from "../utils/log";
 
 export const addRecords: (
   apiClient: KintoneRestAPIClient,
@@ -79,9 +80,9 @@ const uploadToKintone = async (
         app,
         records: kintoneRecords,
       });
-      console.log(`SUCCESS: add records[${kintoneRecords.length}]`);
+      logger.info(`SUCCESS to add records[${kintoneRecords.length}]`);
     } catch (e) {
-      console.error(`FAILED: add records[${kintoneRecords.length}]`);
+      logger.error(`FAILED to add records[${kintoneRecords.length}]`);
       throw e;
     }
   }

--- a/src/record/import/usecases/add.ts
+++ b/src/record/import/usecases/add.ts
@@ -27,7 +27,7 @@ export const addRecords: (
   { attachmentsDir, skipMissingFields = true }
 ) => {
   let currentIndex = 0;
-  const progressLogger = new ProgressLogger(records.length);
+  const progressLogger = new ProgressLogger(logger, records.length);
   try {
     logger.info("Starting to import records...");
     progressLogger.start();

--- a/src/record/import/usecases/add.ts
+++ b/src/record/import/usecases/add.ts
@@ -30,7 +30,6 @@ export const addRecords: (
   const progressLogger = new ProgressLogger(logger, records.length);
   try {
     logger.info("Starting to import records...");
-    progressLogger.start();
     for (const [recordsNext, index] of recordReader(records)) {
       currentIndex = index;
       const recordsToUpload = await convertRecordsToApiRequestParameter(

--- a/src/record/import/usecases/add.ts
+++ b/src/record/import/usecases/add.ts
@@ -29,7 +29,7 @@ export const addRecords: (
   let currentIndex = 0;
   const progressLogger = new ProgressLogger(records.length);
   try {
-    logger.info("Upload all records to kintone");
+    logger.info("Starting to import records...");
     progressLogger.start();
     for (const [recordsNext, index] of recordReader(records)) {
       currentIndex = index;

--- a/src/record/import/usecases/add.ts
+++ b/src/record/import/usecases/add.ts
@@ -27,10 +27,10 @@ export const addRecords: (
   { attachmentsDir, skipMissingFields = true }
 ) => {
   let currentIndex = 0;
+  const progressLogger = new ProgressLogger(records.length);
   try {
     logger.info("Upload all records to kintone");
-    const progressLogger = new ProgressLogger(records.length);
-    progressLogger.update(0);
+    progressLogger.start();
     for (const [recordsNext, index] of recordReader(records)) {
       currentIndex = index;
       const recordsToUpload = await convertRecordsToApiRequestParameter(
@@ -51,6 +51,7 @@ export const addRecords: (
     }
     progressLogger.done();
   } catch (e) {
+    progressLogger.abort(currentIndex);
     throw new AddRecordsError(e, records, currentIndex);
   }
 };

--- a/src/record/import/usecases/add/progress.ts
+++ b/src/record/import/usecases/add/progress.ts
@@ -3,23 +3,37 @@ import { logger } from "../../utils/log";
 export class ProgressLogger {
   private readonly length: number;
   private readonly interval: number;
-  private nextInterval: number;
+  private next: number;
+  private last: number = -1;
 
   constructor(length: number, interval: number = 1000) {
     this.length = length;
     this.interval = interval;
-    this.nextInterval = 0;
+    this.next = this.interval;
   }
 
-  update(current: number) {
-    while (current >= this.nextInterval) {
-      printProgress(this.nextInterval, this.length);
-      this.nextInterval += this.interval;
+  start() {
+    printProgress(0, this.length);
+  }
+
+  update(succeededCount: number) {
+    while (succeededCount >= this.next) {
+      printProgress(this.next, this.length);
+      this.last = this.next;
+      this.next += this.interval;
+    }
+  }
+
+  abort(succeededCount: number) {
+    if (succeededCount > 0 && succeededCount !== this.last) {
+      printProgress(succeededCount, this.length);
     }
   }
 
   done() {
-    printProgress(this.length, this.length);
+    if (this.last !== this.length) {
+      printProgress(this.length, this.length);
+    }
   }
 }
 

--- a/src/record/import/usecases/add/progress.ts
+++ b/src/record/import/usecases/add/progress.ts
@@ -1,0 +1,24 @@
+import { logger } from "../../utils/log";
+
+export class ProgressLogger {
+  private readonly length: number;
+  private readonly interval: number;
+  private nextInterval: number;
+
+  constructor(length: number, interval: number = 1000) {
+    this.length = length;
+    this.interval = interval;
+    this.nextInterval = 0;
+  }
+
+  update(current: number) {
+    while (current >= this.nextInterval) {
+      printProgress(this.nextInterval, this.length);
+      this.nextInterval += this.interval;
+    }
+  }
+}
+
+const printProgress = (current: number, length: number): void => {
+  logger.info(`Success to import ${current}/${length} records`);
+};

--- a/src/record/import/usecases/add/progress.ts
+++ b/src/record/import/usecases/add/progress.ts
@@ -15,10 +15,6 @@ export class ProgressLogger {
     this.next = this.interval;
   }
 
-  start() {
-    printProgress(this.logger, 0, this.length);
-  }
-
   update(succeededCount: number) {
     while (succeededCount >= this.next) {
       printProgress(this.logger, this.next, this.length);

--- a/src/record/import/usecases/add/progress.ts
+++ b/src/record/import/usecases/add/progress.ts
@@ -1,40 +1,47 @@
-import { logger } from "../../utils/log";
+import type { Logger } from "../../utils/log";
 
 export class ProgressLogger {
+  private readonly logger: Logger;
+
   private readonly length: number;
   private readonly interval: number;
   private next: number;
   private last: number = -1;
 
-  constructor(length: number, interval: number = 1000) {
+  constructor(logger: Logger, length: number, interval: number = 1000) {
+    this.logger = logger;
     this.length = length;
     this.interval = interval;
     this.next = this.interval;
   }
 
   start() {
-    printProgress(0, this.length);
+    printProgress(this.logger, 0, this.length);
   }
 
   update(succeededCount: number) {
     while (succeededCount >= this.next) {
-      printProgress(this.next, this.length);
+      printProgress(this.logger, this.next, this.length);
       this.last = this.next;
       this.next += this.interval;
     }
   }
 
   abort(succeededCount: number) {
-    logger.info(
+    this.logger.info(
       `Imported ${succeededCount} of ${this.length} records successfully`
     );
   }
 
   done() {
-    logger.info(`Imported ${this.length} records successfully`);
+    this.logger.info(`Imported ${this.length} records successfully`);
   }
 }
 
-const printProgress = (current: number, length: number): void => {
+const printProgress = (
+  logger: Logger,
+  current: number,
+  length: number
+): void => {
   logger.info(`Imported ${current} of ${length} records`);
 };

--- a/src/record/import/usecases/add/progress.ts
+++ b/src/record/import/usecases/add/progress.ts
@@ -8,7 +8,7 @@ export class ProgressLogger {
   private next: number;
   private last: number = -1;
 
-  constructor(logger: Logger, length: number, interval: number = 1000) {
+  constructor(logger: Logger, length: number, interval: number = 2000) {
     this.logger = logger;
     this.length = length;
     this.interval = interval;

--- a/src/record/import/usecases/add/progress.ts
+++ b/src/record/import/usecases/add/progress.ts
@@ -25,18 +25,16 @@ export class ProgressLogger {
   }
 
   abort(succeededCount: number) {
-    if (succeededCount > 0 && succeededCount !== this.last) {
-      printProgress(succeededCount, this.length);
-    }
+    logger.info(
+      `Imported ${succeededCount} of ${this.length} records successfully`
+    );
   }
 
   done() {
-    if (this.last !== this.length) {
-      printProgress(this.length, this.length);
-    }
+    logger.info(`Imported ${this.length} records successfully`);
   }
 }
 
 const printProgress = (current: number, length: number): void => {
-  logger.info(`Succeeded to import ${current}/${length} records`);
+  logger.info(`Imported ${current} of ${length} records`);
 };

--- a/src/record/import/usecases/add/progress.ts
+++ b/src/record/import/usecases/add/progress.ts
@@ -17,8 +17,12 @@ export class ProgressLogger {
       this.nextInterval += this.interval;
     }
   }
+
+  done() {
+    printProgress(this.length, this.length);
+  }
 }
 
 const printProgress = (current: number, length: number): void => {
-  logger.info(`Success to import ${current}/${length} records`);
+  logger.info(`Succeeded to import ${current}/${length} records`);
 };

--- a/src/record/import/usecases/upsert.ts
+++ b/src/record/import/usecases/upsert.ts
@@ -28,7 +28,7 @@ export const upsertRecords = async (
   let currentIndex = 0;
   const progressLogger = new ProgressLogger(records.length);
   try {
-    logger.info("Download all existing records from kintone");
+    logger.info("Preparing to import records...");
     const updateKey = await UpdateKey.build(
       apiClient,
       app,
@@ -37,7 +37,7 @@ export const upsertRecords = async (
     );
     updateKey.validateUpdateKeyInRecords(records);
 
-    logger.info("Upload all records to kintone");
+    logger.info("Starting to import records...");
     progressLogger.start();
     for (const [recordsNext, index] of recordReader(records, updateKey)) {
       currentIndex = index;

--- a/src/record/import/usecases/upsert.ts
+++ b/src/record/import/usecases/upsert.ts
@@ -26,7 +26,7 @@ export const upsertRecords = async (
   }: { attachmentsDir?: string; skipMissingFields?: boolean }
 ): Promise<void> => {
   let currentIndex = 0;
-  const progressLogger = new ProgressLogger(records.length);
+  const progressLogger = new ProgressLogger(logger, records.length);
   try {
     logger.info("Preparing to import records...");
     const updateKey = await UpdateKey.build(

--- a/src/record/import/usecases/upsert.ts
+++ b/src/record/import/usecases/upsert.ts
@@ -38,7 +38,6 @@ export const upsertRecords = async (
     updateKey.validateUpdateKeyInRecords(records);
 
     logger.info("Starting to import records...");
-    progressLogger.start();
     for (const [recordsNext, index] of recordReader(records, updateKey)) {
       currentIndex = index;
       if (recordsNext.type === "update") {

--- a/src/record/import/usecases/upsert.ts
+++ b/src/record/import/usecases/upsert.ts
@@ -9,6 +9,7 @@ import type { RecordSchema } from "../types/schema";
 import { fieldProcessor, recordReducer } from "./add/record";
 import { UpdateKey } from "./upsert/updateKey";
 import { UpsertRecordsError } from "./upsert/error";
+import { logger } from "../utils/log";
 
 export const upsertRecords = async (
   apiClient: KintoneRestAPIClient,
@@ -60,7 +61,7 @@ export const upsertRecords = async (
           records: recordsToUpload,
         });
       }
-      console.log(`SUCCESS: import records[${recordsNext.records.length}]`);
+      logger.info(`SUCCESS to import records[${recordsNext.records.length}]`);
     }
   } catch (e) {
     throw new UpsertRecordsError(e, records, currentIndex);

--- a/src/record/import/utils/log.ts
+++ b/src/record/import/utils/log.ts
@@ -8,7 +8,7 @@ const currentISOString = () => new Date().toISOString();
 export const logger = {
   info: (message: any) => {
     const prefix = `[${currentISOString()}] ${chalk.blue("INFO")}:`;
-    console.error(addPrefixEachLine(message, prefix));
+    console.log(addPrefixEachLine(message, prefix));
   },
 
   warn: (message: any) => {
@@ -25,7 +25,7 @@ export const logger = {
   debug: (message: any) => {
     return; // TODO: Decide how enable debug log
     const prefix = `[${currentISOString()}] ${chalk.yellow("DEBUG")}:`;
-    console.error(addPrefixEachLine(message, prefix));
+    console.log(addPrefixEachLine(message, prefix));
   },
 };
 

--- a/src/record/import/utils/log.ts
+++ b/src/record/import/utils/log.ts
@@ -5,7 +5,14 @@ import chalk from "chalk";
 
 const currentISOString = () => new Date().toISOString();
 
-export const logger = {
+export type Logger = {
+  info: (message: any) => void;
+  warn: (message: any) => void;
+  error: (message: any) => void;
+  debug: (message: any) => void;
+};
+
+export const logger: Logger = {
   info: (message: any) => {
     const prefix = `[${currentISOString()}] ${chalk.blue("INFO")}:`;
     console.error(addPrefixEachLine(message, prefix));

--- a/src/record/import/utils/log.ts
+++ b/src/record/import/utils/log.ts
@@ -8,7 +8,7 @@ const currentISOString = () => new Date().toISOString();
 export const logger = {
   info: (message: any) => {
     const prefix = `[${currentISOString()}] ${chalk.blue("INFO")}:`;
-    console.log(addPrefixEachLine(message, prefix));
+    console.error(addPrefixEachLine(message, prefix));
   },
 
   warn: (message: any) => {
@@ -25,7 +25,7 @@ export const logger = {
   debug: (message: any) => {
     return; // TODO: Decide how enable debug log
     const prefix = `[${currentISOString()}] ${chalk.yellow("DEBUG")}:`;
-    console.log(addPrefixEachLine(message, prefix));
+    console.error(addPrefixEachLine(message, prefix));
   },
 };
 

--- a/src/record/import/utils/log.ts
+++ b/src/record/import/utils/log.ts
@@ -1,21 +1,51 @@
 import { AddRecordsError } from "../usecases/add/error";
 import { UpsertRecordsError } from "../usecases/upsert/error";
 import { ParserError } from "../parsers/error";
+import chalk from "chalk";
 
-const logger = console.error;
+const currentISOString = () => new Date().toISOString();
 
-export const printError = (error: unknown): void => {
+export const logger = {
+  info: (message: any) => {
+    const prefix = `[${currentISOString()}] ${chalk.blue("INFO")}:`;
+    console.error(addPrefixEachLine(message, prefix));
+  },
+
+  warn: (message: any) => {
+    const prefix = `[${currentISOString()}] ${chalk.yellow("WARN")}:`;
+    console.error(addPrefixEachLine(message, prefix));
+  },
+
+  error: (message: any) => {
+    const parsedMessage = parseErrorMessage(message);
+    const prefix = `[${currentISOString()}] ${chalk.red("ERROR")}:`;
+    console.error(addPrefixEachLine(parsedMessage, prefix));
+  },
+
+  debug: (message: any) => {
+    return; // TODO: Decide how enable debug log
+    const prefix = `[${currentISOString()}] ${chalk.yellow("DEBUG")}:`;
+    console.error(addPrefixEachLine(message, prefix));
+  },
+};
+
+const addPrefixEachLine = (message: any, prefix: string): string =>
+  ("" + message)
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => `${prefix} ${line}`)
+    .join("\n");
+
+const parseErrorMessage = (error: unknown): string => {
   if (error instanceof Error) {
     if (error instanceof AddRecordsError) {
-      logger(error.toString());
+      return error.toString();
     } else if (error instanceof UpsertRecordsError) {
-      logger(error.toString());
+      return error.toString();
     } else if (error instanceof ParserError) {
-      logger(error.toString());
-    } else {
-      logger(error);
+      return error.toString();
     }
-  } else {
-    logger(error);
+    return "" + error;
   }
+  return "" + error;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2250,6 +2250,14 @@ caniuse-lite@^1.0.30001370:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz#1bf994ca375d7f33f8d01ce03b7d5139e8587873"
   integrity sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==
 
+chalk@4, chalk@^4.0.0, chalk@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chalk@^2.0.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -2258,14 +2266,6 @@ chalk@^2.0.0, chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^4.0.0, chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 char-regex@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Currently, cli-kintone does not show any logs while record importing.
Users cannot determine whether cli-kintone is continuing or stopping processing.

## What

<!-- What is a solution you want to add? -->

- [x] show progress log while adding or upserting records.

## How to test

<!-- How can we test this pull request? -->

```
yarn build
yarn test

node ./cli.js record import --app $APP_ID --file-path ./records.csv
node ./cli.js record import --app $APP_ID --file-path ./records.csv --update-key updateKey
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
