### PR TITLE
fix: show help message when incorrect argv

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -2,9 +2,4 @@ import yargs from "yargs";
 import { recordCommand } from "./record";
 
 // eslint-disable-next-line no-unused-expressions
-yargs
-  .command(recordCommand)
-  .demandCommand()
-  .strict()
-  .help()
-  .showHelpOnFail(false).argv;
+yargs.command(recordCommand).demandCommand().strict().help().argv;

--- a/src/record/import/index.ts
+++ b/src/record/import/index.ts
@@ -6,7 +6,7 @@ import { upsertRecords } from "./usecases/upsert";
 import { createSchema } from "./schema";
 import { noop as defaultTransformer } from "./schema/transformers/noop";
 import { userSelected } from "./schema/transformers/userSelected";
-import { logger } from "./utils/log";
+import { logger } from "../../utils/log";
 
 export type Options = {
   app: string;
@@ -20,19 +20,19 @@ export type Options = {
 export const run: (
   argv: RestAPIClientOptions & Options
 ) => Promise<void> = async (argv) => {
-  const {
-    app,
-    filePath,
-    encoding,
-    attachmentsDir,
-    updateKey,
-    fields,
-    ...restApiClientOptions
-  } = argv;
-
-  const apiClient = buildRestAPIClient(restApiClientOptions);
-
   try {
+    const {
+      app,
+      filePath,
+      encoding,
+      attachmentsDir,
+      updateKey,
+      fields,
+      ...restApiClientOptions
+    } = argv;
+
+    const apiClient = buildRestAPIClient(restApiClientOptions);
+
     const fieldsJson = await apiClient.app.getFormFields({ app });
     const schema = createSchema(
       fieldsJson,

--- a/src/record/import/usecases/__tests__/add/progress.test.ts
+++ b/src/record/import/usecases/__tests__/add/progress.test.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "../../../utils/log";
+import type { Logger } from "../../../../../utils/log";
 
 import { ProgressLogger } from "../../add/progress";
 

--- a/src/record/import/usecases/add.ts
+++ b/src/record/import/usecases/add.ts
@@ -5,7 +5,7 @@ import type { RecordSchema } from "../types/schema";
 
 import { fieldProcessor, recordReducer } from "./add/record";
 import { AddRecordsError } from "./add/error";
-import { logger } from "../utils/log";
+import { logger } from "../../../utils/log";
 import { ProgressLogger } from "./add/progress";
 
 const CHUNK_SIZE = 2000;

--- a/src/record/import/usecases/add/progress.ts
+++ b/src/record/import/usecases/add/progress.ts
@@ -1,4 +1,4 @@
-import type { Logger } from "../../utils/log";
+import type { Logger } from "../../../../utils/log";
 
 export class ProgressLogger {
   private readonly logger: Logger;

--- a/src/record/import/usecases/upsert.ts
+++ b/src/record/import/usecases/upsert.ts
@@ -9,7 +9,7 @@ import type { RecordSchema } from "../types/schema";
 import { fieldProcessor, recordReducer } from "./add/record";
 import { UpdateKey } from "./upsert/updateKey";
 import { UpsertRecordsError } from "./upsert/error";
-import { logger } from "../utils/log";
+import { logger } from "../../../utils/log";
 import { ProgressLogger } from "./add/progress";
 
 const CHUNK_SIZE = 2000;

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,6 +1,6 @@
-import { AddRecordsError } from "../usecases/add/error";
-import { UpsertRecordsError } from "../usecases/upsert/error";
-import { ParserError } from "../parsers/error";
+import { AddRecordsError } from "../record/import/usecases/add/error";
+import { UpsertRecordsError } from "../record/import/usecases/upsert/error";
+import { ParserError } from "../record/import/parsers/error";
 import chalk from "chalk";
 
 const currentISOString = () => new Date().toISOString();


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

```
As a <cli-kintone user>,
I want <to show usage on incorrect sub-command>
so that <reduce inquiry about command usage>
```

## What

<!-- What is a solution you want to add? -->

- [x] show help message on the yargs failed to parse argv.
- [x] use logger on record export

## How to test

<!-- How can we test this pull request? -->

```
yarn build
yarn test

## failed while parsing argv
$ node ./cli.js record export --app 

## failed while subcommand processing
$ node ./cli.js record export --app 100                           
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
