### PR TITLE
fix: send request over HTTP tunneling

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -97,6 +97,7 @@ describe("api", () => {
       },
       userAgent: expectedUa,
       httpsAgent: new https.Agent(),
+      proxy: false,
     });
   });
 
@@ -119,6 +120,7 @@ describe("api", () => {
       guestSpaceId: GUEST_SPACE_ID,
       userAgent: expectedUa,
       httpsAgent: new https.Agent(),
+      proxy: false,
     });
   });
 
@@ -133,6 +135,7 @@ describe("api", () => {
       auth: { apiToken: API_TOKEN },
       userAgent: expectedUa,
       httpsAgent: new https.Agent(),
+      proxy: false,
     });
   });
 
@@ -152,6 +155,7 @@ describe("api", () => {
       },
       userAgent: expectedUa,
       httpsAgent: new https.Agent(),
+      proxy: false,
     });
   });
 
@@ -178,6 +182,7 @@ describe("api", () => {
       },
       userAgent: expectedUa,
       httpsAgent: new https.Agent(),
+      proxy: false,
     });
   });
   it("should pass information of client certificate to the apiClient correctly", () => {
@@ -200,6 +205,7 @@ describe("api", () => {
         pfx: "dummy",
         passphrase: PFX_FILE_PASSWORD,
       }),
+      proxy: false,
     });
   });
   it("should pass information of proxy server to the apiClient correctly", () => {
@@ -222,11 +228,7 @@ describe("api", () => {
         host: "proxy.example.com",
         port: "3128",
       }),
-      proxy: {
-        protocol: "http:",
-        host: "proxy.example.com",
-        port: 3128,
-      },
+      proxy: false,
     });
   });
   it("should pass information of client certificate and proxy server to the apiClient correctly", () => {
@@ -253,11 +255,7 @@ describe("api", () => {
         pfx: "dummy",
         passphrase: PFX_FILE_PASSWORD,
       }),
-      proxy: {
-        protocol: "http:",
-        host: "proxy.example.com",
-        port: 3128,
-      },
+      proxy: false,
     });
   });
 });

--- a/src/kintone/client.ts
+++ b/src/kintone/client.ts
@@ -44,29 +44,6 @@ const buildBasicAuthParam = (options: RestAPIClientOptions) => {
     : {};
 };
 
-type ProxyConfig = {
-  protocol?: string;
-  host: string;
-  port: number;
-  auth?: {
-    username: string;
-    password: string;
-  };
-};
-
-const buildProxyConfig = (proxy: string): ProxyConfig | undefined => {
-  const { protocol, hostname: host, port, username, password } = new URL(proxy);
-  const proxyConfig: ProxyConfig = { host, port: Number(port) };
-
-  if (protocol.length > 0) {
-    proxyConfig.protocol = protocol;
-  }
-  if (username.length > 0 && password.length > 0) {
-    proxyConfig.auth = { username, password };
-  }
-  return proxyConfig;
-};
-
 const buildHttpsAgent = (options: {
   proxy?: string;
   pfxFilePath?: string;
@@ -100,9 +77,9 @@ export const buildRestAPIClient = (options: RestAPIClientOptions) => {
     ...buildBasicAuthParam(options),
     ...(options.guestSpaceId ? { guestSpaceId: options.guestSpaceId } : {}),
     userAgent: `${packageJson.name}@${packageJson.version}`,
-    ...(options.httpsProxy
-      ? { proxy: buildProxyConfig(options.httpsProxy) }
-      : {}),
+    // TODO: fix type definition of @kintone/rest-api-client
+    // Currently, the proxy property doesn't accept false
+    proxy: false as any,
     httpsAgent: buildHttpsAgent({
       proxy: options.httpsProxy,
       pfxFilePath: options.pfxFilePath,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

When the proxy is enabled, cli-kintone v1 should request over HTTP tunneling.
However, current implementation requests without HTTP tunneling.

This is related to https://github.com/axios/axios/issues/4531, 
Axios try to request with the absolute-form without CONNECT method.

We have to disable `proxy` config of Axios when initializing @kintone/rest-api-client.

## What

<!-- What is a solution you want to add? -->

- [x] fix implementation

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
