### PR TITLE
feat: add fieldCode into the error message

### DIFF
--- a/src/record/import/usecases/__tests__/add/error.test.ts
+++ b/src/record/import/usecases/__tests__/add/error.test.ts
@@ -5,8 +5,28 @@ import {
   KintoneRestAPIError,
 } from "@kintone/rest-api-client";
 import { AddRecordsError } from "../../add/error";
+import { RecordSchema } from "../../../types/schema";
 
 const CHUNK_SIZE = 100;
+const schema: RecordSchema = {
+  fields: [
+    {
+      type: "NUMBER",
+      code: "number",
+      label: "number",
+      noLabel: false,
+      required: true,
+      minValue: "",
+      maxValue: "",
+      digit: false,
+      unique: true,
+      defaultValue: "",
+      displayScale: "",
+      unit: "",
+      unitPosition: "BEFORE",
+    },
+  ],
+};
 
 describe("AddRecordsError", () => {
   it("should return error message", () => {
@@ -35,10 +55,11 @@ describe("AddRecordsError", () => {
     const upsertRecordsError = new AddRecordsError(
       kintoneAllRecordsError,
       records,
-      numOfAlreadyImportedRecords
+      numOfAlreadyImportedRecords,
+      schema
     );
     expect(upsertRecordsError.toString()).toBe(
-      "Failed to add all records.\nRows from 1 to 41 are processed successfully.\nAn error occurred while uploading records.\n[500] [some code] some error message (some id)\n  An error occurred at row 46.\n    Cause: invalid value\n"
+      "Failed to add all records.\nRows from 1 to 41 are processed successfully.\nAn error occurred while uploading records.\n[500] [some code] some error message (some id)\n  An error occurred on number at row 46.\n    Cause: invalid value\n"
     );
   });
 });

--- a/src/record/import/usecases/__tests__/add/index.test.ts
+++ b/src/record/import/usecases/__tests__/add/index.test.ts
@@ -84,7 +84,8 @@ describe("addRecords", () => {
       new AddRecordsError(
         new Error("--attachments-dir option is required."),
         canUploadFiles.input,
-        0
+        0,
+        canUploadFiles.schema
       )
     );
   });

--- a/src/record/import/usecases/__tests__/upsert/error.test.ts
+++ b/src/record/import/usecases/__tests__/upsert/error.test.ts
@@ -1,6 +1,27 @@
 import type { KintoneRecord } from "../../../types/record";
 import { UpsertRecordsError } from "../../upsert/error";
 import { buildKintoneAllRecordsError } from "../add/error.test";
+import { RecordSchema } from "../../../types/schema";
+
+const schema: RecordSchema = {
+  fields: [
+    {
+      type: "NUMBER",
+      code: "number",
+      label: "number",
+      noLabel: false,
+      required: true,
+      minValue: "",
+      maxValue: "",
+      digit: false,
+      unique: true,
+      defaultValue: "",
+      displayScale: "",
+      unit: "",
+      unitPosition: "BEFORE",
+    },
+  ],
+};
 
 describe("UpsertRecordsError", () => {
   it("should return error message", () => {
@@ -29,10 +50,11 @@ describe("UpsertRecordsError", () => {
     const upsertRecordsError = new UpsertRecordsError(
       kintoneAllRecordsError,
       records,
-      numOfAlreadyImportedRecords
+      numOfAlreadyImportedRecords,
+      schema
     );
     expect(upsertRecordsError.toString()).toBe(
-      "Failed to upsert all records.\nRows from 1 to 41 are processed successfully.\nAn error occurred while uploading records.\n[500] [some code] some error message (some id)\n  An error occurred at row 46.\n    Cause: invalid value\n"
+      "Failed to upsert all records.\nRows from 1 to 41 are processed successfully.\nAn error occurred while uploading records.\n[500] [some code] some error message (some id)\n  An error occurred on number at row 46.\n    Cause: invalid value\n"
     );
   });
 });

--- a/src/record/import/usecases/__tests__/upsert/index.test.ts
+++ b/src/record/import/usecases/__tests__/upsert/index.test.ts
@@ -134,7 +134,8 @@ describe("upsertRecords", () => {
           new UpsertRecordsError(
             expected.failure.errorMessage,
             input.records,
-            0
+            0,
+            input.schema
           )
         );
       }

--- a/src/record/import/usecases/add.ts
+++ b/src/record/import/usecases/add.ts
@@ -51,7 +51,7 @@ export const addRecords: (
     progressLogger.done();
   } catch (e) {
     progressLogger.abort(currentIndex);
-    throw new AddRecordsError(e, records, currentIndex);
+    throw new AddRecordsError(e, records, currentIndex, schema);
   }
 };
 

--- a/src/record/import/usecases/add/error.ts
+++ b/src/record/import/usecases/add/error.ts
@@ -4,6 +4,7 @@ import {
   parseKintoneAllRecordsError,
 } from "../../utils/error";
 import { KintoneRecord } from "../../types/record";
+import { RecordSchema } from "../../types/schema";
 
 // Magic number from @kintone/rest-api-client
 // https://github.com/kintone/js-sdk/blob/master/packages/rest-api-client/src/client/RecordClient.ts#L16
@@ -15,8 +16,14 @@ export class AddRecordsError extends Error {
   private readonly records: KintoneRecord[];
   private readonly numOfSuccess: number;
   private readonly numOfTotal: number;
+  private readonly recordSchema: RecordSchema;
 
-  constructor(cause: unknown, records: KintoneRecord[], currentIndex: number) {
+  constructor(
+    cause: unknown,
+    records: KintoneRecord[],
+    currentIndex: number,
+    recordSchema: RecordSchema
+  ) {
     const message = "Failed to add all records.";
     super(message);
 
@@ -24,6 +31,7 @@ export class AddRecordsError extends Error {
     this.message = message;
     this.cause = cause;
     this.records = records;
+    this.recordSchema = recordSchema;
 
     this.numOfSuccess = currentIndex;
     this.numOfTotal = this.records.length;
@@ -55,7 +63,8 @@ export class AddRecordsError extends Error {
         this.cause,
         this.chunkSize,
         this.records,
-        this.numOfSuccess
+        this.numOfSuccess,
+        this.recordSchema
       );
     } else if (this.cause instanceof AddRecordsError) {
       errorMessage += this.cause.toString();

--- a/src/record/import/usecases/upsert.ts
+++ b/src/record/import/usecases/upsert.ts
@@ -72,7 +72,7 @@ export const upsertRecords = async (
     progressLogger.done();
   } catch (e) {
     progressLogger.abort(currentIndex);
-    throw new UpsertRecordsError(e, records, currentIndex);
+    throw new UpsertRecordsError(e, records, currentIndex, schema);
   }
 };
 

--- a/src/record/import/usecases/upsert/error.ts
+++ b/src/record/import/usecases/upsert/error.ts
@@ -4,6 +4,7 @@ import {
   parseKintoneAllRecordsError,
 } from "../../utils/error";
 import { KintoneRecord } from "../../types/record";
+import { RecordSchema } from "../../types/schema";
 
 // Magic number from @kintone/rest-api-client
 // https://github.com/kintone/js-sdk/blob/master/packages/rest-api-client/src/client/RecordClient.ts#L17
@@ -15,8 +16,14 @@ export class UpsertRecordsError extends Error {
   private readonly records: KintoneRecord[];
   private readonly numOfSuccess: number;
   private readonly numOfTotal: number;
+  private readonly recordSchema: RecordSchema;
 
-  constructor(cause: unknown, records: KintoneRecord[], currentIndex: number) {
+  constructor(
+    cause: unknown,
+    records: KintoneRecord[],
+    currentIndex: number,
+    recordSchema: RecordSchema
+  ) {
     const message = "Failed to upsert all records.";
     super(message);
 
@@ -24,6 +31,7 @@ export class UpsertRecordsError extends Error {
     this.message = message;
     this.cause = cause;
     this.records = records;
+    this.recordSchema = recordSchema;
 
     this.numOfSuccess = currentIndex;
     this.numOfTotal = this.records.length;
@@ -55,7 +63,8 @@ export class UpsertRecordsError extends Error {
         this.cause,
         this.chunkSize,
         this.records,
-        this.numOfSuccess
+        this.numOfSuccess,
+        this.recordSchema
       );
     } else if (this.cause instanceof UpsertRecordsError) {
       errorMessage += this.cause.toString();

--- a/src/record/import/utils/__tests__/error.test.ts
+++ b/src/record/import/utils/__tests__/error.test.ts
@@ -1,0 +1,119 @@
+import type { KintoneRecord } from "../../types/record";
+import {
+  KintoneAllRecordsError,
+  KintoneErrorResponse,
+  KintoneRestAPIError,
+} from "@kintone/rest-api-client";
+import { kintoneAllRecordsErrorToString } from "../error";
+import { RecordSchema } from "../../types/schema";
+
+const CHUNK_SIZE = 100;
+
+const schema: RecordSchema = {
+  fields: [
+    {
+      type: "NUMBER",
+      code: "number",
+      label: "number",
+      noLabel: false,
+      required: true,
+      minValue: "",
+      maxValue: "",
+      digit: false,
+      unique: true,
+      defaultValue: "",
+      displayScale: "",
+      unit: "",
+      unitPosition: "BEFORE",
+    },
+  ],
+};
+
+describe("kintoneAllRecordsErrorToString", () => {
+  it("should return error message", () => {
+    const numOfAllRecords = 60;
+    const numOfProcessedRecords = 40;
+    const errorIndex = 44;
+    const errorFieldCode = "number";
+    const errorRowIndex = errorIndex + 2;
+    const records: KintoneRecord[] = [...Array(numOfAllRecords).keys()].map(
+      (index) => ({
+        data: {},
+        metadata: {
+          format: {
+            type: "csv",
+            firstRowIndex: index + 1,
+            lastRowIndex: index + 1,
+          },
+        },
+      })
+    );
+    const kintoneAllRecordsError = buildKintoneAllRecordsError(
+      numOfAllRecords,
+      numOfProcessedRecords,
+      errorIndex,
+      errorFieldCode
+    );
+    const errorMessage = kintoneAllRecordsErrorToString(
+      kintoneAllRecordsError,
+      CHUNK_SIZE,
+      records,
+      numOfProcessedRecords,
+      schema
+    );
+    expect(errorMessage).toBe(
+      `An error occurred while uploading records.\n[500] [some code] some error message (some id)\n  An error occurred on ${errorFieldCode} at row ${errorRowIndex}.\n    Cause: invalid value\n`
+    );
+  });
+});
+
+export const buildKintoneRestAPIError = (
+  errorIndex: number,
+  errorFieldCode: string,
+  numOfProcessedRecords: number
+): KintoneRestAPIError => {
+  const errorIndexRelative = errorIndex - numOfProcessedRecords;
+  const errorResponse: KintoneErrorResponse = {
+    data: {
+      id: "some id",
+      code: "some code",
+      message: "some error message",
+      errors: {
+        [`records[${errorIndexRelative}].${errorFieldCode}.value`]: {
+          messages: ["invalid value"],
+        },
+      },
+    },
+    status: 500,
+    statusText: "Internal Server Error",
+    headers: {
+      "X-Some-Header": "error",
+    },
+  };
+  return new KintoneRestAPIError(errorResponse);
+};
+
+export const buildKintoneAllRecordsError = (
+  numOfAllRecords: number,
+  numOfProcessedRecords: number,
+  errorIndex: number,
+  errorFieldCode: string
+): KintoneAllRecordsError => {
+  const processedRecordsResult = {
+    records: Array(numOfProcessedRecords).map(() => ({})),
+  };
+  const numOfUnprocessedRecords = numOfAllRecords - numOfProcessedRecords;
+  const unprocessedRecords = Array(numOfUnprocessedRecords).map(() => ({}));
+  const kintoneRestAPIError = buildKintoneRestAPIError(
+    errorIndex,
+    errorFieldCode,
+    numOfProcessedRecords
+  );
+  return new KintoneAllRecordsError(
+    processedRecordsResult,
+    unprocessedRecords,
+    numOfAllRecords,
+    kintoneRestAPIError,
+    CHUNK_SIZE
+  );
+};


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

When an Error occurs during record import, It's hard to determine which columns are caused.

## What

- [x] When an Error occurs during record import, the "Field Code" information is added to the error message.

## Current behavior

```
  An error occurred at row <line of CSV>.
    Cause: <error message>
```

## Expected behavior

```
  An error occurred on <field Code> at row <line of CSV>.
    Cause: <error message>
```

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
