### PR TITLE
refactor: error handling of KintoneAllRecordsError

### DIFF
--- a/src/record/import/usecases/add/error.ts
+++ b/src/record/import/usecases/add/error.ts
@@ -1,8 +1,5 @@
 import { KintoneAllRecordsError } from "@kintone/rest-api-client";
-import {
-  kintoneAllRecordsErrorToString,
-  parseKintoneAllRecordsError,
-} from "../../utils/error";
+import { kintoneAllRecordsErrorToString } from "../../utils/error";
 import { KintoneRecord } from "../../types/record";
 import { RecordSchema } from "../../types/schema";
 
@@ -36,8 +33,7 @@ export class AddRecordsError extends Error {
     this.numOfSuccess = currentIndex;
     this.numOfTotal = this.records.length;
     if (this.cause instanceof KintoneAllRecordsError) {
-      const { numOfSuccess } = parseKintoneAllRecordsError(this.cause);
-      this.numOfSuccess += numOfSuccess;
+      this.numOfSuccess += this.cause.numOfProcessedRecords;
     }
 
     // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work

--- a/src/record/import/usecases/upsert/error.ts
+++ b/src/record/import/usecases/upsert/error.ts
@@ -1,8 +1,5 @@
 import { KintoneAllRecordsError } from "@kintone/rest-api-client";
-import {
-  kintoneAllRecordsErrorToString,
-  parseKintoneAllRecordsError,
-} from "../../utils/error";
+import { kintoneAllRecordsErrorToString } from "../../utils/error";
 import { KintoneRecord } from "../../types/record";
 import { RecordSchema } from "../../types/schema";
 
@@ -36,8 +33,7 @@ export class UpsertRecordsError extends Error {
     this.numOfSuccess = currentIndex;
     this.numOfTotal = this.records.length;
     if (this.cause instanceof KintoneAllRecordsError) {
-      const { numOfSuccess } = parseKintoneAllRecordsError(this.cause);
-      this.numOfSuccess += numOfSuccess;
+      this.numOfSuccess += this.cause.numOfProcessedRecords;
     }
 
     // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work

--- a/src/record/import/utils/error.ts
+++ b/src/record/import/utils/error.ts
@@ -5,17 +5,6 @@ import {
 import { KintoneRecord } from "../types/record";
 import { RecordSchema } from "../types/schema";
 
-export const parseKintoneAllRecordsError = (
-  e: KintoneAllRecordsError
-): { numOfSuccess: number; numOfTotal: number } => {
-  const totalMatch = e.message.match(
-    /(?<numOfSuccess>\d+)\/(?<numOfTotal>\d+) records are processed successfully/
-  );
-  const numOfSuccess = Number(totalMatch?.groups?.numOfSuccess);
-  const numOfTotal = Number(totalMatch?.groups?.numOfTotal);
-  return { numOfSuccess, numOfTotal };
-};
-
 export const kintoneAllRecordsErrorToString = (
   e: KintoneAllRecordsError,
   chunkSize: number,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

In [kintone/js-sdk#1816](https://github.com/kintone/js-sdk/pull/1816), numOfProcessedRecords and numOfAllRecords are added to KintoneAllRecordsError.

We can use these properties in cli-kintone, and remove some regex processes.

## What

- [x] Replace some regex by using numOfProcessedRecords and numOfAllRecords properties in cli-kintone

## How to test

```
yarn build

yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
