### PR TITLE
chore: enforce type imports as lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,12 @@ const config = {
         },
       },
     ],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        prefer: "type-imports",
+      },
+    ],
   },
 };
 module.exports = config;

--- a/src/cli/record.ts
+++ b/src/cli/record.ts
@@ -1,4 +1,5 @@
-import yargs, { CommandModule } from "yargs";
+import type { CommandModule } from "yargs";
+import type yargs from "yargs";
 import { exportCommand } from "./record/export";
 import { importCommand } from "./record/import";
 

--- a/src/cli/record/export.ts
+++ b/src/cli/record/export.ts
@@ -1,8 +1,7 @@
-import * as yargs from "yargs";
-
-import { CommandModule } from "yargs";
-
-import { ExportFileEncoding, run } from "../../record/export";
+import type yargs from "yargs";
+import type { CommandModule } from "yargs";
+import type { ExportFileEncoding } from "../../record/export";
+import { run } from "../../record/export";
 
 const encodings: ExportFileEncoding[] = ["utf8", "sjis"];
 

--- a/src/cli/record/import.ts
+++ b/src/cli/record/import.ts
@@ -1,8 +1,7 @@
-import * as yargs from "yargs";
-
+import type yargs from "yargs";
 import { run } from "../../record/import";
-import { SupportedImportEncoding } from "../../record/import/utils/file";
-import { CommandModule } from "yargs";
+import type { SupportedImportEncoding } from "../../record/import/utils/file";
+import type { CommandModule } from "yargs";
 
 const command = "import";
 

--- a/src/kintone/types.ts
+++ b/src/kintone/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   KintoneFormFieldProperty,
   KintoneFormLayout,
   KintoneRecordField,

--- a/src/record/export/index.ts
+++ b/src/record/export/index.ts
@@ -1,6 +1,7 @@
 import iconv from "iconv-lite";
 
-import { buildRestAPIClient, RestAPIClientOptions } from "../../kintone/client";
+import type { RestAPIClientOptions } from "../../kintone/client";
+import { buildRestAPIClient } from "../../kintone/client";
 import { getRecords } from "./usecases/get";
 import { stringifierFactory } from "./stringifiers";
 import { createSchema } from "./schema";

--- a/src/record/export/schema/__tests__/fixtures/formLayout/input.ts
+++ b/src/record/export/schema/__tests__/fixtures/formLayout/input.ts
@@ -1,4 +1,4 @@
-import { FieldsJson } from "../../../../../../kintone/types";
+import type { FieldsJson } from "../../../../../../kintone/types";
 
 export const input: FieldsJson = {
   revision: "29",

--- a/src/record/export/schema/__tests__/fixtures/formLayout/layout.ts
+++ b/src/record/export/schema/__tests__/fixtures/formLayout/layout.ts
@@ -1,4 +1,4 @@
-import { LayoutJson } from "../../../../../../kintone/types";
+import type { LayoutJson } from "../../../../../../kintone/types";
 
 export const layoutJson: LayoutJson = {
   revision: "29",

--- a/src/record/export/schema/__tests__/fixtures/formLayoutNoSystemFields/input.ts
+++ b/src/record/export/schema/__tests__/fixtures/formLayoutNoSystemFields/input.ts
@@ -1,4 +1,4 @@
-import { FieldsJson } from "../../../../../../kintone/types";
+import type { FieldsJson } from "../../../../../../kintone/types";
 
 export const input: FieldsJson = {
   revision: "29",

--- a/src/record/export/schema/__tests__/fixtures/formLayoutNoSystemFields/layout.ts
+++ b/src/record/export/schema/__tests__/fixtures/formLayoutNoSystemFields/layout.ts
@@ -1,4 +1,4 @@
-import { LayoutJson } from "../../../../../../kintone/types";
+import type { LayoutJson } from "../../../../../../kintone/types";
 
 export const layoutJson: LayoutJson = {
   revision: "29",

--- a/src/record/export/schema/__tests__/fixtures/userSelected/input.ts
+++ b/src/record/export/schema/__tests__/fixtures/userSelected/input.ts
@@ -1,4 +1,4 @@
-import { FieldsJson } from "../../../../../../kintone/types";
+import type { FieldsJson } from "../../../../../../kintone/types";
 
 export const input: FieldsJson = {
   revision: "29",

--- a/src/record/export/schema/__tests__/index.test.ts
+++ b/src/record/export/schema/__tests__/index.test.ts
@@ -1,6 +1,7 @@
-import { createSchema, SchemaTransformer } from "../index";
-import { FieldsJson } from "../../../../kintone/types";
-import { RecordSchema } from "../../types/schema";
+import type { SchemaTransformer } from "../index";
+import { createSchema } from "../index";
+import type { FieldsJson } from "../../../../kintone/types";
+import type { RecordSchema } from "../../types/schema";
 
 import { pattern as formLayout } from "./fixtures/formLayout";
 import { pattern as formLayoutNoSystemFields } from "./fixtures/formLayoutNoSystemFields";

--- a/src/record/export/schema/index.ts
+++ b/src/record/export/schema/index.ts
@@ -1,5 +1,5 @@
-import { FieldsJson } from "../../../kintone/types";
-import { FieldSchema, RecordSchema } from "../types/schema";
+import type { FieldsJson } from "../../../kintone/types";
+import type { FieldSchema, RecordSchema } from "../types/schema";
 import { isSupportedField, isSupportedFieldInSubtable } from "./constants";
 
 export type SchemaTransformer = (

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/header/file_schema.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/header/file_schema.ts
@@ -1,4 +1,4 @@
-import { RecordSchema } from "../../../../../types/schema";
+import type { RecordSchema } from "../../../../../types/schema";
 
 export const schema: RecordSchema = {
   hasSubtable: false,

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/common/index.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/common/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../../index.test";
+import type { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { schema } from "./schema";

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/common/input.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/common/input.ts
@@ -1,4 +1,4 @@
-import { KintoneRecord } from "../../../../../../types/record";
+import type { KintoneRecord } from "../../../../../../types/record";
 
 export const input: KintoneRecord[] = [
   {

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withEmptySubtable/index.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withEmptySubtable/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../../index.test";
+import type { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { schema } from "./schema";

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withEmptySubtable/input.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withEmptySubtable/input.ts
@@ -1,4 +1,4 @@
-import { KintoneRecord } from "../../../../../../types/record";
+import type { KintoneRecord } from "../../../../../../types/record";
 
 export const input: KintoneRecord[] = [
   {

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withFileAndAttachmentsDir/index.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withFileAndAttachmentsDir/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../../index.test";
+import type { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { schema } from "./schema";

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withFileAndAttachmentsDir/input.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withFileAndAttachmentsDir/input.ts
@@ -1,4 +1,4 @@
-import { KintoneRecord } from "../../../../../../types/record";
+import type { KintoneRecord } from "../../../../../../types/record";
 
 export const input: KintoneRecord[] = [
   {

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withFileAndNoAttachmentsDir/index.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withFileAndNoAttachmentsDir/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../../index.test";
+import type { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { schema } from "./schema";

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withFileAndNoAttachmentsDir/input.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withFileAndNoAttachmentsDir/input.ts
@@ -1,4 +1,4 @@
-import { KintoneRecord } from "../../../../../../types/record";
+import type { KintoneRecord } from "../../../../../../types/record";
 
 export const input: KintoneRecord[] = [
   {

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withSubtableAndFileAndAttachmentsDir/index.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withSubtableAndFileAndAttachmentsDir/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../../index.test";
+import type { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { schema } from "./schema";

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withSubtableAndFileAndAttachmentsDir/input.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withSubtableAndFileAndAttachmentsDir/input.ts
@@ -1,4 +1,4 @@
-import { KintoneRecord } from "../../../../../../types/record";
+import type { KintoneRecord } from "../../../../../../types/record";
 
 export const input: KintoneRecord[] = [
   {

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withSubtableAndFileAndNoAttachmentsDir/index.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withSubtableAndFileAndNoAttachmentsDir/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../../index.test";
+import type { TestPattern } from "../../../index.test";
 import { expectedCsv } from "./expected";
 import { input } from "./input";
 import { schema } from "./schema";

--- a/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withSubtableAndFileAndNoAttachmentsDir/input.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/__tests__/fixtures/index/withSubtableAndFileAndNoAttachmentsDir/input.ts
@@ -1,4 +1,4 @@
-import { KintoneRecord } from "../../../../../../types/record";
+import type { KintoneRecord } from "../../../../../../types/record";
 
 export const input: KintoneRecord[] = [
   {

--- a/src/record/export/stringifiers/stringifyAsCsv/record.ts
+++ b/src/record/export/stringifiers/stringifyAsCsv/record.ts
@@ -4,7 +4,7 @@ import type { KintoneRecord } from "../../types/record";
 import { convertField, fieldReader } from "./field";
 import { convertSubtableField, subtableFieldReader } from "./subtable";
 import { PRIMARY_MARK } from "./constants";
-import { RecordSchema } from "../../types/schema";
+import type { RecordSchema } from "../../types/schema";
 
 export type RecordAsCsvRows = CsvRow[];
 

--- a/src/record/export/types/field.ts
+++ b/src/record/export/types/field.ts
@@ -1,4 +1,4 @@
-import { KintoneRecordField } from "@kintone/rest-api-client";
+import type { KintoneRecordField } from "@kintone/rest-api-client";
 
 type FieldWith<T extends string, V> = {
   type: T;

--- a/src/record/export/types/record.ts
+++ b/src/record/export/types/record.ts
@@ -1,4 +1,4 @@
-import { OneOf } from "./field";
+import type { OneOf } from "./field";
 
 export type KintoneRecord = {
   [fieldCode: string]: OneOf;

--- a/src/record/export/types/schema.ts
+++ b/src/record/export/types/schema.ts
@@ -1,4 +1,4 @@
-import { KintoneFormFieldProperty } from "@kintone/rest-api-client";
+import type { KintoneFormFieldProperty } from "@kintone/rest-api-client";
 
 export type RecordSchema = {
   fields: FieldSchema[];

--- a/src/record/export/usecases/__tests__/get/fixtures/can_download_files.ts
+++ b/src/record/export/usecases/__tests__/get/fixtures/can_download_files.ts
@@ -1,7 +1,7 @@
-import { KintoneRecordForResponse } from "../../../../../../kintone/types";
+import type { KintoneRecordForResponse } from "../../../../../../kintone/types";
 import path from "path";
-import { KintoneRecord } from "../../../../types/record";
-import { RecordSchema } from "../../../../types/schema";
+import type { KintoneRecord } from "../../../../types/record";
+import type { RecordSchema } from "../../../../types/schema";
 
 const fileInfo = {
   contentType: "text/plain",

--- a/src/record/export/usecases/__tests__/get/fixtures/can_download_files_in_subtable.ts
+++ b/src/record/export/usecases/__tests__/get/fixtures/can_download_files_in_subtable.ts
@@ -1,7 +1,7 @@
-import { KintoneRecordForResponse } from "../../../../../../kintone/types";
+import type { KintoneRecordForResponse } from "../../../../../../kintone/types";
 import path from "path";
-import { KintoneRecord } from "../../../../types/record";
-import { RecordSchema } from "../../../../types/schema";
+import type { KintoneRecord } from "../../../../types/record";
+import type { RecordSchema } from "../../../../types/schema";
 
 const fileInfo = {
   contentType: "text/plain",

--- a/src/record/export/usecases/__tests__/get/fixtures/can_get_records.ts
+++ b/src/record/export/usecases/__tests__/get/fixtures/can_get_records.ts
@@ -1,6 +1,6 @@
-import { KintoneRecordForResponse } from "../../../../../../kintone/types";
-import { KintoneRecord } from "../../../../types/record";
-import { RecordSchema } from "../../../../types/schema";
+import type { KintoneRecordForResponse } from "../../../../../../kintone/types";
+import type { KintoneRecord } from "../../../../types/record";
+import type { RecordSchema } from "../../../../types/schema";
 
 export const input: KintoneRecordForResponse[] = [
   {

--- a/src/record/import/index.ts
+++ b/src/record/import/index.ts
@@ -1,5 +1,7 @@
-import { buildRestAPIClient, RestAPIClientOptions } from "../../kintone/client";
-import { SupportedImportEncoding, readFile } from "./utils/file";
+import type { RestAPIClientOptions } from "../../kintone/client";
+import { buildRestAPIClient } from "../../kintone/client";
+import type { SupportedImportEncoding } from "./utils/file";
+import { readFile } from "./utils/file";
 import { parseRecords } from "./parsers";
 import { addRecords } from "./usecases/add";
 import { upsertRecords } from "./usecases/upsert";

--- a/src/record/import/schema/transformers/userSelected.ts
+++ b/src/record/import/schema/transformers/userSelected.ts
@@ -1,6 +1,6 @@
-import { FieldsJson } from "../../../../kintone/types";
-import { SchemaTransformer } from "../index";
-import { FieldSchema } from "../../types/schema";
+import type { FieldsJson } from "../../../../kintone/types";
+import type { SchemaTransformer } from "../index";
+import type { FieldSchema } from "../../types/schema";
 import { isSupportedField } from "../constants";
 
 /**

--- a/src/record/import/types/record.ts
+++ b/src/record/import/types/record.ts
@@ -1,4 +1,4 @@
-import { OneOf } from "./field";
+import type { OneOf } from "./field";
 
 export type KintoneRecord = {
   data: { [fieldCode: string]: OneOf };

--- a/src/record/import/usecases/__tests__/add/error.test.ts
+++ b/src/record/import/usecases/__tests__/add/error.test.ts
@@ -1,11 +1,11 @@
 import type { KintoneRecord } from "../../../types/record";
+import type { KintoneErrorResponse } from "@kintone/rest-api-client";
 import {
   KintoneAllRecordsError,
-  KintoneErrorResponse,
   KintoneRestAPIError,
 } from "@kintone/rest-api-client";
 import { AddRecordsError } from "../../add/error";
-import { RecordSchema } from "../../../types/schema";
+import type { RecordSchema } from "../../../types/schema";
 
 const CHUNK_SIZE = 100;
 const schema: RecordSchema = {

--- a/src/record/import/usecases/__tests__/upsert/error.test.ts
+++ b/src/record/import/usecases/__tests__/upsert/error.test.ts
@@ -1,7 +1,7 @@
 import type { KintoneRecord } from "../../../types/record";
 import { UpsertRecordsError } from "../../upsert/error";
 import { buildKintoneAllRecordsError } from "../add/error.test";
-import { RecordSchema } from "../../../types/schema";
+import type { RecordSchema } from "../../../types/schema";
 
 const schema: RecordSchema = {
   fields: [

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByNonExistentField/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByNonExistentField/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "../schema";
 import { recordsOnKintone } from "../recordsOnKintone";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByNonUniqueKey/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByNonUniqueKey/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "../schema";
 import { recordsOnKintone } from "../recordsOnKintone";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByNumber/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByNumber/expected.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByNumber/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByNumber/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "../schema";
 import { expected } from "./expected";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumber/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumber/expected.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumber/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumber/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "./schema";
 import { expected } from "./expected";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCode/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCode/expected.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCode/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCode/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "./schema";
 import { expected } from "./expected";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCodeOnKintone/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCodeOnKintone/expected.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCodeOnKintone/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithAppCodeOnKintone/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "./schema";
 import { expected } from "./expected";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithInvalidRecordNumber/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithInvalidRecordNumber/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "./schema";
 import { recordsOnKintone } from "./recordsOnKintone";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithMixedRecordNumber/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByRecordNumberWithMixedRecordNumber/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "./schema";
 import { recordsOnKintone } from "./recordsOnKintone";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertBySingleLineText/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertBySingleLineText/expected.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertBySingleLineText/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertBySingleLineText/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "../schema";
 import { expected } from "./expected";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertByUnsupportedField/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertByUnsupportedField/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "../schema";
 import { recordsOnKintone } from "../recordsOnKintone";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/expected.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 
 export const expected: TestPattern["expected"] = {
   success: {

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertRecordsSequentially/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "./schema";
 import { expected } from "./expected";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithMissingFieldFromRecord/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithMissingFieldFromRecord/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "../schema";
 import { recordsOnKintone } from "../recordsOnKintone";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithMissingFieldInTableFromRecord/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithMissingFieldInTableFromRecord/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "./schema";
 import { recordsOnKintone } from "./recordsOnKintone";

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithMissingKeyFromRecord/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithMissingKeyFromRecord/index.ts
@@ -1,4 +1,4 @@
-import { TestPattern } from "../../index.test";
+import type { TestPattern } from "../../index.test";
 import { records } from "./records";
 import { schema } from "../schema";
 import { recordsOnKintone } from "../recordsOnKintone";

--- a/src/record/import/usecases/add/error.ts
+++ b/src/record/import/usecases/add/error.ts
@@ -1,7 +1,7 @@
 import { KintoneAllRecordsError } from "@kintone/rest-api-client";
 import { kintoneAllRecordsErrorToString } from "../../utils/error";
-import { KintoneRecord } from "../../types/record";
-import { RecordSchema } from "../../types/schema";
+import type { KintoneRecord } from "../../types/record";
+import type { RecordSchema } from "../../types/schema";
 
 // Magic number from @kintone/rest-api-client
 // https://github.com/kintone/js-sdk/blob/master/packages/rest-api-client/src/client/RecordClient.ts#L16

--- a/src/record/import/usecases/upsert/error.ts
+++ b/src/record/import/usecases/upsert/error.ts
@@ -1,7 +1,7 @@
 import { KintoneAllRecordsError } from "@kintone/rest-api-client";
 import { kintoneAllRecordsErrorToString } from "../../utils/error";
-import { KintoneRecord } from "../../types/record";
-import { RecordSchema } from "../../types/schema";
+import type { KintoneRecord } from "../../types/record";
+import type { RecordSchema } from "../../types/schema";
 
 // Magic number from @kintone/rest-api-client
 // https://github.com/kintone/js-sdk/blob/master/packages/rest-api-client/src/client/RecordClient.ts#L17

--- a/src/record/import/usecases/upsert/updateKey.ts
+++ b/src/record/import/usecases/upsert/updateKey.ts
@@ -1,8 +1,10 @@
-import type { KintoneFormFieldProperty } from "@kintone/rest-api-client";
+import type {
+  KintoneFormFieldProperty,
+  KintoneRestAPIClient,
+} from "@kintone/rest-api-client";
 
 import type { FieldSchema, RecordSchema } from "../../types/schema";
 import type { KintoneRecord } from "../../types/record";
-import { KintoneRestAPIClient } from "@kintone/rest-api-client";
 
 type UpdateKeyField = {
   code: string;

--- a/src/record/import/utils/__tests__/error.test.ts
+++ b/src/record/import/utils/__tests__/error.test.ts
@@ -1,11 +1,11 @@
 import type { KintoneRecord } from "../../types/record";
+import type { KintoneErrorResponse } from "@kintone/rest-api-client";
 import {
   KintoneAllRecordsError,
-  KintoneErrorResponse,
   KintoneRestAPIError,
 } from "@kintone/rest-api-client";
 import { kintoneAllRecordsErrorToString } from "../error";
-import { RecordSchema } from "../../types/schema";
+import type { RecordSchema } from "../../types/schema";
 
 const CHUNK_SIZE = 100;
 

--- a/src/record/import/utils/__tests__/file.test.ts
+++ b/src/record/import/utils/__tests__/file.test.ts
@@ -1,4 +1,5 @@
-import { readFile, SupportedImportEncoding } from "../file";
+import type { SupportedImportEncoding } from "../file";
+import { readFile } from "../file";
 import { expected } from "./fixtures/expected";
 
 import path from "path";

--- a/src/record/import/utils/error.ts
+++ b/src/record/import/utils/error.ts
@@ -1,9 +1,9 @@
-import {
+import type {
   KintoneAllRecordsError,
   KintoneRestAPIError,
 } from "@kintone/rest-api-client";
-import { KintoneRecord } from "../types/record";
-import { RecordSchema } from "../types/schema";
+import type { KintoneRecord } from "../types/record";
+import type { RecordSchema } from "../types/schema";
 
 export const kintoneAllRecordsErrorToString = (
   e: KintoneAllRecordsError,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Fixes https://github.com/kintone/cli-kintone/issues/119

## What

- [x] lint rule [consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports) is added
- [x] Related files are updated following by this rule

## How to test

```
yarn build
yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
