### PR TITLE
chore: add version into the filename of zipfile

### DIFF
--- a/scripts/compress-to-zip-file.mjs
+++ b/scripts/compress-to-zip-file.mjs
@@ -6,6 +6,7 @@ import os from "os";
 import rimraf from "rimraf";
 import { promisify } from "util";
 import { fileURLToPath } from "url";
+import packageJson from "../package.json" assert { type: "json" };
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.join(dirname, "../");
@@ -78,7 +79,7 @@ for (const recipe of recipes) {
   await $`cp ${licenseFile} ${assetsDir}/LICENSE`;
   await $`cp ${thirdPartyNoticeFile} ${assetsDir}/NOTICE`;
 
-  const zipFile = `cli-kintone-${recipe.type}.zip`;
+  const zipFile = `cli-kintone_v${packageJson.version}_${recipe.type}.zip`;
   await $`zip -r ${zipFile} ${assetsDir}`;
   await $`cp ${zipFile} ${artifactsDir}`;
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Currently, it is difficult to distinguish between different versions of archives because they have the same file name.

## What

- [x] Adding version info into the filename of the zipfile, e.g. `cli-kintone_v1.1.0_linux.zip`

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
