### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          VERSION=$(jq -r '.version' ./package.json)
           gh release upload ${{ needs.release.outputs.tag_name }} \
-            ${GITHUB_WORKSPACE}/artifacts/cli-kintone-linux.zip \
-            ${GITHUB_WORKSPACE}/artifacts/cli-kintone-macos.zip \
-            ${GITHUB_WORKSPACE}/artifacts/cli-kintone-win.zip
+            ${GITHUB_WORKSPACE}/artifacts/cli-kintone_v${VERSION}_linux.zip \
+            ${GITHUB_WORKSPACE}/artifacts/cli-kintone_v${VERSION}_macos.zip \
+            ${GITHUB_WORKSPACE}/artifacts/cli-kintone_v${VERSION}_win.zip
 
   publish:
     name: Publish release


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

In https://github.com/kintone/cli-kintone/pull/167, we added the version to the filename of the zip file.
However, we missed updating the release workflow, and it failed.

https://github.com/kintone/cli-kintone/actions/runs/3562787107/jobs/5984844158

```
Run gh release upload v1.2.0 \
stat /home/runner/work/cli-kintone/cli-kintone/artifacts/cli-kintone-linux.zip: no such file or directory
Error: Process completed with exit code 1.
```

## What

<!-- What is a solution you want to add? -->

- update the release workflow to upload correct files

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
