### PR TITLE
feat: adding the delete permission verification

### DIFF
--- a/src/record/delete/index.ts
+++ b/src/record/delete/index.ts
@@ -13,7 +13,9 @@ export const run: (
   try {
     const { app, ...restApiClientOptions } = options;
     const apiClient = buildRestAPIClient(restApiClientOptions);
-    await deleteAllRecords(apiClient, app);
+    const isCheckPermission =
+      typeof restApiClientOptions.username !== "undefined";
+    await deleteAllRecords(apiClient, app, isCheckPermission);
   } catch (e) {
     logger.error(e);
     // eslint-disable-next-line no-process-exit

--- a/src/record/delete/usecases/__tests__/delete.test.ts
+++ b/src/record/delete/usecases/__tests__/delete.test.ts
@@ -19,8 +19,22 @@ describe("deleteAllRecords", () => {
         },
       },
     ]);
+    apiClient.app.evaluateRecordsAcl = jest.fn().mockResolvedValue({
+      rights: [
+        {
+          id: 1,
+          record: {
+            viewable: true,
+            editable: true,
+            deletable: true,
+          },
+        },
+      ],
+    });
     apiClient.record.deleteAllRecords = jest.fn().mockResolvedValue([{}]);
-    return expect(deleteAllRecords(apiClient, "1")).resolves.not.toThrow();
+    return expect(
+      deleteAllRecords(apiClient, "1", true)
+    ).resolves.not.toThrow();
   });
 
   it("should pass parameters to the apiClient correctly", async () => {
@@ -32,11 +46,23 @@ describe("deleteAllRecords", () => {
         },
       },
     ]);
+    apiClient.app.evaluateRecordsAcl = jest.fn().mockResolvedValue({
+      rights: [
+        {
+          id: 1,
+          record: {
+            viewable: true,
+            editable: true,
+            deletable: true,
+          },
+        },
+      ],
+    });
     const deleteAllRecordsMockFn = jest.fn().mockResolvedValue([{}]);
     apiClient.record.deleteAllRecords = deleteAllRecordsMockFn;
     const APP_ID = "1";
 
-    await deleteAllRecords(apiClient, APP_ID);
+    await deleteAllRecords(apiClient, APP_ID, true);
 
     expect(deleteAllRecordsMockFn.mock.calls[0][0]).toStrictEqual({
       app: APP_ID,
@@ -54,7 +80,21 @@ describe("deleteAllRecords", () => {
         },
       },
     ]);
+    apiClient.app.evaluateRecordsAcl = jest.fn().mockResolvedValue({
+      rights: [
+        {
+          id: 1,
+          record: {
+            viewable: true,
+            editable: true,
+            deletable: true,
+          },
+        },
+      ],
+    });
     apiClient.record.deleteAllRecords = jest.fn().mockRejectedValueOnce(error);
-    return expect(deleteAllRecords(apiClient, "1")).rejects.toThrow(error);
+    return expect(deleteAllRecords(apiClient, "1", true)).rejects.toThrow(
+      error
+    );
   });
 });

--- a/src/record/delete/usecases/delete.ts
+++ b/src/record/delete/usecases/delete.ts
@@ -1,49 +1,64 @@
 import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
-import type {
-  KintoneRecordForResponse,
-  KintoneRecordForDeleteAllParameter,
-} from "../../../kintone/types";
+import type { KintoneRecordForDeleteAllParameter } from "../../../kintone/types";
 import { logger } from "../../../utils/log";
+import { getAllRecordIds, evaluateRecords } from "../utils/record";
 import { DeleteAllRecordsError } from "./error";
 
 export const deleteAllRecords: (
   apiClient: KintoneRestAPIClient,
-  app: string
-) => Promise<void> = async (apiClient, app) => {
+  app: string,
+  isCheckPermission: boolean
+) => Promise<void> = async (apiClient, app, isCheckPermission) => {
   logger.info("Starting to delete all records...");
-  const records = await getRecordsForDeleteAll(apiClient, app);
-  if (records.length === 0) {
+  const recordIds = await getAllRecordIds(apiClient, app);
+  if (recordIds.length === 0) {
     logger.warn("The specified app does not have any records.");
     return;
   }
 
-  try {
-    const params = { app, records };
-    await apiClient.record.deleteAllRecords(params);
-    logger.info(`${records.length} records are deleted successfully`);
-  } catch (e) {
-    throw new DeleteAllRecordsError(e, records);
-  }
-};
-
-const getRecordsForDeleteAll: (
-  apiClient: KintoneRestAPIClient,
-  app: string
-) => Promise<KintoneRecordForDeleteAllParameter[]> = async (apiClient, app) => {
-  const params = { app, fields: ["$id"] };
-  const kintoneRecords = await apiClient.record.getAllRecordsWithId(params);
-  if (!kintoneRecords || kintoneRecords.length === 0) {
-    return [];
+  let privilegedRecordIds: number[] = recordIds;
+  let unprivilegedRecordIds: number[] = [];
+  if (isCheckPermission) {
+    const result = await evaluateRecords(apiClient, app, recordIds);
+    privilegedRecordIds = result.privilegedRecordIds;
+    unprivilegedRecordIds = result.unprivilegedRecordIds;
   }
 
-  const records: KintoneRecordForDeleteAllParameter[] = kintoneRecords.map(
-    (record: KintoneRecordForResponse): KintoneRecordForDeleteAllParameter => {
-      const idValue = record.$id.value as string;
+  // TODO: Refactor this logic when kintone provide the API which returns the result of the evaluation about App permission.
+  if (privilegedRecordIds.length === 0) {
+    let errorMessage = "Failed to delete all records.\n";
+    errorMessage += "No records are deleted.\n";
+    errorMessage += "An error occurred while processing records.\n";
+    errorMessage += "No privilege to proceed.";
+    throw new Error(errorMessage);
+  }
+
+  const records: KintoneRecordForDeleteAllParameter[] = privilegedRecordIds.map(
+    (recordId): KintoneRecordForDeleteAllParameter => {
       return {
-        id: parseInt(idValue, 10),
+        id: recordId,
       };
     }
   );
 
-  return records;
+  try {
+    const params = { app, records };
+    await apiClient.record.deleteAllRecords(params);
+
+    if (unprivilegedRecordIds.length === 0) {
+      logger.info(`${recordIds.length} records are deleted successfully`);
+      return;
+    }
+
+    logger.info(
+      `${privilegedRecordIds.length}/${recordIds.length} records are deleted successfully`
+    );
+    logger.info(
+      `Some records are not deleted because you do not have delete permission (ID: ${unprivilegedRecordIds.join(
+        ", "
+      )})`
+    );
+  } catch (e) {
+    throw new DeleteAllRecordsError(e, records);
+  }
 };

--- a/src/record/delete/utils/__tests__/record.test.ts
+++ b/src/record/delete/utils/__tests__/record.test.ts
@@ -1,0 +1,51 @@
+import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import { evaluateRecords } from "../record";
+
+describe("evaluateRecords", () => {
+  let apiClient: KintoneRestAPIClient;
+  beforeEach(() => {
+    apiClient = new KintoneRestAPIClient({
+      baseUrl: "https://localhost/",
+      auth: { apiToken: "dummy" },
+    });
+  });
+
+  it("should return correct value", async () => {
+    const recordIds = [1, 2, 3];
+    const privilegedRecordIds = [1, 3];
+    const unprivilegedRecordIds = [2];
+    apiClient.app.evaluateRecordsAcl = jest.fn().mockResolvedValue({
+      rights: [
+        {
+          id: 1,
+          record: {
+            viewable: true,
+            editable: true,
+            deletable: true,
+          },
+        },
+        {
+          id: 2,
+          record: {
+            viewable: true,
+            editable: true,
+            deletable: false,
+          },
+        },
+        {
+          id: 3,
+          record: {
+            viewable: true,
+            editable: true,
+            deletable: true,
+          },
+        },
+      ],
+    });
+    const actual = await evaluateRecords(apiClient, "1", recordIds);
+    return expect(actual).toEqual({
+      privilegedRecordIds,
+      unprivilegedRecordIds,
+    });
+  });
+});

--- a/src/record/delete/utils/record.ts
+++ b/src/record/delete/utils/record.ts
@@ -1,0 +1,70 @@
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { KintoneRecordForResponse } from "../../../kintone/types";
+
+const CHUNK_SIZE = 100;
+
+export const getAllRecordIds: (
+  apiClient: KintoneRestAPIClient,
+  app: string
+) => Promise<number[]> = async (apiClient, app) => {
+  const params = { app, fields: ["$id"] };
+  const kintoneRecords = await apiClient.record.getAllRecordsWithId(params);
+  if (!kintoneRecords || kintoneRecords.length === 0) {
+    return [];
+  }
+
+  return kintoneRecords.map((record: KintoneRecordForResponse): number => {
+    const idValue = record.$id.value as string;
+    return parseInt(idValue, 10);
+  });
+};
+
+export const evaluateRecords: (
+  apiClient: KintoneRestAPIClient,
+  app: string,
+  recordIds: number[]
+) => Promise<{
+  privilegedRecordIds: number[];
+  unprivilegedRecordIds: number[];
+}> = async (apiClient, app, recordIds) => {
+  let numOfEvaluatedRecords = 0;
+  let evaluationRecordIds = [];
+  const unprivilegedRecordIds: number[] = [];
+  const privilegedRecordIds: number[] = [];
+
+  if(recordIds.length === 0){
+    return {
+      privilegedRecordIds,
+      unprivilegedRecordIds
+    }
+  }
+
+  do {
+    evaluationRecordIds = recordIds.slice(
+      numOfEvaluatedRecords,
+      numOfEvaluatedRecords + CHUNK_SIZE
+    );
+    const response = await apiClient.app.evaluateRecordsAcl({
+      app,
+      ids: evaluationRecordIds,
+    });
+    const rights = response.rights;
+    for (let index = 0; index < rights.length; index++) {
+      const right = rights[index];
+      if (right.record.deletable) {
+        privilegedRecordIds.push(Number(right.id));
+      } else {
+        unprivilegedRecordIds.push(Number(right.id));
+      }
+    }
+    numOfEvaluatedRecords += CHUNK_SIZE;
+  } while (
+    evaluationRecordIds.length === CHUNK_SIZE &&
+    numOfEvaluatedRecords < recordIds.length
+  );
+
+  return {
+    privilegedRecordIds,
+    unprivilegedRecordIds,
+  };
+};

--- a/src/record/delete/utils/record.ts
+++ b/src/record/delete/utils/record.ts
@@ -49,8 +49,7 @@ export const evaluateRecords: (
       ids: evaluationRecordIds,
     });
     const rights = response.rights;
-    for (let index = 0; index < rights.length; index++) {
-      const right = rights[index];
+    for (const right of rights) {
       if (right.record.deletable) {
         privilegedRecordIds.push(Number(right.id));
       } else {

--- a/src/record/delete/utils/record.ts
+++ b/src/record/delete/utils/record.ts
@@ -32,11 +32,11 @@ export const evaluateRecords: (
   const unprivilegedRecordIds: number[] = [];
   const privilegedRecordIds: number[] = [];
 
-  if(recordIds.length === 0){
+  if (recordIds.length === 0) {
     return {
       privilegedRecordIds,
-      unprivilegedRecordIds
-    }
+      unprivilegedRecordIds,
+    };
   }
 
   do {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

The delete all records command is blocked if there is a record that does not have delete permission.

## What

- [x] Do not delete the unprivileged records.
- [x] The info of unprivileged records should be logged.

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
