### PR TITLE
feat: user cannot execute delete all records command with User Authn

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The `delete` command allows you to delete records of a specified kintone app.
 
 **Notice**
 
+- This command only supports API Token
 - This action cannot be rollback.
 
 ```
@@ -189,10 +190,6 @@ Options:
       --help                 Show help                                 [boolean]
       --base-url             Kintone Base Url
                                  [string] [required] [default: KINTONE_BASE_URL]
-  -u, --username             Kintone Username
-                                            [string] [default: KINTONE_USERNAME]
-  -p, --password             Kintone Password
-                                            [string] [default: KINTONE_PASSWORD]
       --api-token            App's API token[array] [default: KINTONE_API_TOKEN]
       --basic-auth-username  Kintone Basic Auth Username
                                  [string] [default: KINTONE_BASIC_AUTH_USERNAME]

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The `delete` command allows you to delete records of a specified kintone app.
 
 **Notice**
 
-- This command only supports API Token
+- This command only supports API token authentication
 - This action cannot be rollback.
 
 ```

--- a/src/cli/record/delete.ts
+++ b/src/cli/record/delete.ts
@@ -16,22 +16,6 @@ const builder = (args: yargs.Argv) =>
       demandOption: true,
       requiresArg: true,
     })
-    .option("username", {
-      alias: "u",
-      describe: "Kintone Username",
-      default: process.env.KINTONE_USERNAME,
-      defaultDescription: "KINTONE_USERNAME",
-      type: "string",
-      requiresArg: true,
-    })
-    .option("password", {
-      alias: "p",
-      describe: "Kintone Password",
-      default: process.env.KINTONE_PASSWORD,
-      defaultDescription: "KINTONE_PASSWORD",
-      type: "string",
-      requiresArg: true,
-    })
     .option("api-token", {
       describe: "App's API token",
       default: process.env.KINTONE_API_TOKEN,
@@ -90,8 +74,6 @@ type Args = yargs.Arguments<
 const handler = (args: Args) => {
   return run({
     baseUrl: args["base-url"],
-    username: args.username,
-    password: args.password,
     apiToken: args["api-token"],
     basicAuthUsername: args["basic-auth-username"],
     basicAuthPassword: args["basic-auth-password"],


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
There are some issues with performance and the number of API requests.
So, now the delete all records command only supports the API Token.

## What

- [x] Do not support User Authn for delete all records command

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
