### PR TITLE
ci: pass GITHUB_TOKEN to setup-licensed to avoid rate limit

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -35,6 +35,7 @@ jobs:
         uses: jonabc/setup-licensed@24931374ba8e67b4153ccbade94deca833861ed1
         with:
           version: '3.x'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

setup-licensed failed due to the API rate limit being exceeded.

https://github.com/kintone/cli-kintone/actions/runs/3898012816/jobs/6656297952

## What

<!-- What is a solution you want to add? -->

Pass the `${{ secrets.GITHUB_TOKEN }}` to setup-licensed.

- Without authn, the requests are limited to 60 requests per hour.
- With authn with GITHUB_TOKEN, it will be 15,000 requests per hour.

https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions 

## How to test

<!-- How can we test this pull request? -->

See the test run.
https://github.com/kintone/cli-kintone/actions/runs/3899341336/jobs/6658919903

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
