### PR TITLE
docs: replacing devnet URL from old version link to new version link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,4 +47,4 @@ This tool has the following big updates from https://github.com/kintone-labs/cli
 - Support a Record number as "Key to Bulk Update" instead of Record ID (`$id`).
 - Support client certificate authentication
 
-See https://developer.cybozu.io/hc/ja/articles/10663181361689 for more details.
+See https://cybozu.dev/ja/kintone/sdk/backup/cli-kintone for more details.


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

The new devnet will be released on February, and devnet url will be changed.
So, now we need to change to the new one.

| old | new |
| ---| --- |
| https://developer.cybozu.io/ | https://cybozu.dev/ |

## What

- [x] replacing devnet URL from old version link to new version link

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
