### PR TITLE
fix: catch the stream error

### DIFF
--- a/src/record/import/utils/file.ts
+++ b/src/record/import/utils/file.ts
@@ -15,11 +15,17 @@ export const readFile: (
   if (format === "json" && encoding !== "utf8") {
     throw new Error("source file is JSON and JSON MUST be encoded with UTF-8");
   }
-  const stream = fs
-    .createReadStream(filePath)
-    .pipe(iconv.decodeStream(encoding));
-  const content = await readStream(stream);
-  return { content, format };
+
+  return new Promise((resolve, reject) => {
+    (async () => {
+      const stream = fs.createReadStream(filePath);
+      stream.on("error", reject);
+
+      const readWriteStream = stream.pipe(iconv.decodeStream(encoding));
+      const content = await readStream(readWriteStream);
+      resolve({ content, format });
+    })();
+  });
 };
 
 const readStream: (stream: NodeJS.ReadWriteStream) => Promise<string> = async (


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Currently, we don't catch the stream error, so when the stream throws an error, It's not easy to read
```
$ ./cli.js record import --app 1 --file-path not_eixst.csv
node:events:505
      throw er; // Unhandled 'error' event
      ^

Error: ENOENT: no such file or directory, open 'not_eixst.csv'
Emitted 'error' event on ReadStream instance at:
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'not_eixst.csv'
}
```

## What

- [x] catch the stream error and throw a readable error message, e.g.
```
Error: ENOENT: no such file or directory, open 'not_eixst.csv'
```

## How to test

```
yarn build & yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
