### PR TITLE
feat: adding option --encoding for the delete records command

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Options:
       --app                  The ID of the app               [string] [required]
       --file-path            The path to source file.
                              The file extension should be ".csv"        [string]
+      --encoding             Character encoding
+                                     [choices: "utf8", "sjis"] [default: "utf8"]
       --guest-space-id       The ID of guest space
                                       [string] [default: KINTONE_GUEST_SPACE_ID]
       --pfx-file-path        The path to client certificate file        [string]

--- a/src/cli/record/delete.ts
+++ b/src/cli/record/delete.ts
@@ -3,10 +3,13 @@ import type { CommandModule } from "yargs";
 import { run } from "../../record/delete";
 import inquirer from "inquirer";
 import type { Question } from "inquirer";
+import type { SupportedImportEncoding } from "../../utils/file";
 
 const command = "delete";
 
 const describe = "delete all records";
+
+const encoding: SupportedImportEncoding[] = ["utf8", "sjis"];
 
 const FORCE_DELETE_KEY = "yes";
 const FORCE_DELETE_ALIAS = "y";
@@ -80,6 +83,12 @@ const builder = (args: yargs.Argv) =>
       describe: "The path to the CSV file",
       type: "string",
       requiresArg: true,
+    })
+    .option("encoding", {
+      describe: "Character encoding",
+      default: "utf8" as SupportedImportEncoding,
+      choices: encoding,
+      requiresArg: true,
     });
 
 type Args = yargs.Arguments<
@@ -98,6 +107,7 @@ const execute = (args: Args) => {
     pfxFilePassword: args["pfx-file-password"],
     httpsProxy: args.proxy,
     filePath: args["file-path"],
+    encoding: args.encoding,
   });
 };
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Currently, the delete command does not support the CSV file with the `sjis` encoding.

## What

- [x] Allow the user can specify the option `--encoding` when using the delete records command.
So, they can use the CSV which has the encoding "utf8" or "sjis".

## How to test

```
yarn build & yarn test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
