### PR TITLE
feat: show error when use username or password

### DIFF
--- a/src/cli/record/delete.ts
+++ b/src/cli/record/delete.ts
@@ -164,13 +164,7 @@ const hasApiToken = (apiTokenArg?: string | string[]): boolean => {
     return !!apiTokenArg;
   }
 
-  if (apiTokenArg.length === 0) {
-    return false;
-  }
-
-  const apiToken = apiTokenArg.filter(Boolean);
-
-  return apiToken && apiToken.length > 0;
+  return apiTokenArg.filter(Boolean).length > 0;
 };
 
 export const deleteCommand: CommandModule<{}, Args> = {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

When the user specifies `username` or `password`, an error message is thrown, but It's hard to understand that the delete command only supports API token authentication.

## What

<!-- What is a solution you want to add? -->

- [x] If specifies `username` or `password`, the error message "The delete command only supports API token authentication." will be shown

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
