### PR TITLE
fix: show version correctly

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,5 +1,6 @@
 import yargs from "yargs";
 import { recordCommand } from "./record";
+import packageJson from "../../package.json";
 
 // TODO: This is the Workaround of https://github.com/DefinitelyTyped/DefinitelyTyped/issues/63396
 // After the issue is fixed, we can remove this.
@@ -40,5 +41,6 @@ yargs
   .command(recordCommand)
   .demandCommand()
   .strict()
+  .version(packageJson.version)
   .help()
   .completion("completion", customCompletion as any).argv;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

From v1.3.0, the `--version` doesn't work correctly.
Since we started building with Vite, the reference to package.json has disappeared, and package.json is no longer bundled with the executable.


## What

<!-- What is a solution you want to add? -->

- show version correctly on `cli-kintone --version` command

## How to test

<!-- How can we test this pull request? -->

```shell
yarn install
yarn build

./bin/cli-kintone-macos --version
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
