### PR TITLE
fix: detection of color support

### DIFF
--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -5,7 +5,7 @@ import { RepositoryError } from "../record/import/repositories/error";
 import { DeleteAllRecordsError } from "../record/delete/usecases/deleteAll/error";
 import { DeleteSpecifiedRecordsError } from "../record/delete/usecases/deleteByRecordNumber/error";
 
-import chalk from "chalk";
+import { stderr as chalkStderr } from "chalk";
 
 const currentISOString = () => new Date().toISOString();
 
@@ -18,24 +18,24 @@ export type Logger = {
 
 export const logger: Logger = {
   info: (message: any) => {
-    const prefix = `[${currentISOString()}] ${chalk.blue("INFO")}:`;
+    const prefix = `[${currentISOString()}] ${chalkStderr.blue("INFO")}:`;
     console.error(addPrefixEachLine(message, prefix));
   },
 
   warn: (message: any) => {
-    const prefix = `[${currentISOString()}] ${chalk.yellow("WARN")}:`;
+    const prefix = `[${currentISOString()}] ${chalkStderr.yellow("WARN")}:`;
     console.error(addPrefixEachLine(message, prefix));
   },
 
   error: (message: any) => {
     const parsedMessage = parseErrorMessage(message);
-    const prefix = `[${currentISOString()}] ${chalk.red("ERROR")}:`;
+    const prefix = `[${currentISOString()}] ${chalkStderr.red("ERROR")}:`;
     console.error(addPrefixEachLine(parsedMessage, prefix));
   },
 
   debug: (message: any) => {
     return; // TODO: Decide how enable debug log
-    const prefix = `[${currentISOString()}] ${chalk.yellow("DEBUG")}:`;
+    const prefix = `[${currentISOString()}] ${chalkStderr.yellow("DEBUG")}:`;
     console.error(addPrefixEachLine(message, prefix));
   },
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

https://github.com/kintone/cli-kintone/issues/258

## What

<!-- What is a solution you want to add? -->

cli-kintone uses `console.error` (stderr) for log output.

According to the documentation of chalk, we have to use `chalkStderr` for stderr.

https://github.com/chalk/chalk#chalkstderr-and-supportscolorstderr

## How to test

<!-- How can we test this pull request? -->

```
yarn install
yarn build

./bin/cli-kintone-macos record delete --app 123 > log.txt
# Check log.txt doesn't include color codes
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
