### PR TITLE
ci: pin version of third party actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     name: Node.js ubuntu-latest 16.x
     runs-on: ubuntu-latest
     steps:
-      - uses: jonabc/setup-licensed@1174d936f99ee3ae0077011a357f43b9b6f152b5
+      - uses: jonabc/setup-licensed@d6b3a6f7058c2b40c06d205e13e15c2418977566 # renovate: tag=v1.1.4
         with:
           version: '3.x'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Setup Licensed
-        uses: jonabc/setup-licensed@1174d936f99ee3ae0077011a357f43b9b6f152b5
+      - uses: jonabc/setup-licensed@d6b3a6f7058c2b40c06d205e13e15c2418977566 # renovate: tag=v1.1.4
         with:
           version: '3.x'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     needs: release
     if: ${{ needs.release.outputs.release_created }}
     steps:
-      - uses: jonabc/setup-licensed@1174d936f99ee3ae0077011a357f43b9b6f152b5
+      - uses: jonabc/setup-licensed@d6b3a6f7058c2b40c06d205e13e15c2418977566 # renovate: tag=v1.1.4
         with:
           version: '3.x'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,12 +1,22 @@
 {
-  extends: ["github>cybozu/renovate-config", ":prConcurrentLimitNone"],
+  extends: [
+    "github>cybozu/renovate-config",
+    ":prConcurrentLimitNone",
+    "helpers:pinGitHubActionDigests"
+  ],
   npm: {
     packageRules: [
       {
         // automerge minor updates of devDependencies
-        matchPackagePatterns: ["*"],
-        matchDepTypes: ["devDependencies"],
-        matchUpdateTypes: ["minor"],
+        matchPackagePatterns: [
+          "*"
+        ],
+        matchDepTypes: [
+          "devDependencies"
+        ],
+        matchUpdateTypes: [
+          "minor"
+        ],
         automerge: true,
       },
     ],


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

To use digest pinning but want to follow the action version tag on updating third party actions

## What

<!-- What is a solution you want to add? -->

- Specify version to third party actions

https://docs.renovatebot.com/modules/manager/github-actions/#additional-information
https://zenn.dev/roottool/scraps/5a73b98e88d4d1

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
