### PR TITLE
ci: add `permissions` to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   release:
     name: Create draft release
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -19,6 +22,8 @@ jobs:
 
   rename:
     name: Rename release title
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: release
     if: ${{ needs.release.outputs.release_created }}
@@ -32,6 +37,8 @@ jobs:
 
   upload:
     name: Upload executables
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: release
     if: ${{ needs.release.outputs.release_created }}
@@ -60,6 +67,8 @@ jobs:
 
   publish:
     name: Publish release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: [release, rename, upload]
     env:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

For security improvement, we will make the default workflow permission `read-only`.
In this PR, we update the `release` workflow because it requires additional permission.

## What

<!-- What is a solution you want to add? -->

- update release.yml
  - release job: `content: write` and `pull-requests: write`
  - rename: `content: write`
  - upload: `content: write`
  - publish: `content: write`

## How to test

<!-- How can we test this pull request? -->

N/A

I tested the permission on my reproduction repo
https://github.com/tasshi-playground/github-actions-permisison-test

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [ ] Passed `yarn lint` and `yarn test` on the root directory.
