### PR TITLE
chore: improve error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Options:
                                                  [string] [default: HTTPS_PROXY]
 ```
 
-Notes: The field in a Table cannot be specified to the `fields` option
+##### Notes
+
+- The field in a Table cannot be specified to the `fields` option.
 
 #### Import Attachment field
 
@@ -99,7 +101,9 @@ The field specified as "Key to Bulk Update" should meet the following requiremen
   - Text
   - Number
 
-NOTE: When the field specified as "Key to Bulk Update" is Record Number, the value of the field may have app code of the target app.
+##### Notes
+
+- When the field specified as "Key to Bulk Update" is Record Number, the value of the field may have app code of the target app.
 
 ### export
 
@@ -148,7 +152,9 @@ Options:
                                                  [string] [default: HTTPS_PROXY]
 ```
 
-Notes: The field in a Table cannot be specified to the `fields` option
+##### Notes
+
+- The field in a Table cannot be specified to the `fields` option.
 
 #### `--condition` and `--order-by` options
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Options:
                                                  [string] [default: HTTPS_PROXY]
 ```
 
+Notes: The field in a Table cannot be specified to the `fields` option
+
 #### Import Attachment field
 
 If records contains Attachment field, `--attachments-dir` option is required.
@@ -145,6 +147,8 @@ Options:
       --proxy                The URL of a proxy server
                                                  [string] [default: HTTPS_PROXY]
 ```
+
+Notes: The field in a Table cannot be specified to the `fields` option
 
 #### `--condition` and `--order-by` options
 

--- a/src/record/export/schema/__tests__/userSelected.test.ts
+++ b/src/record/export/schema/__tests__/userSelected.test.ts
@@ -66,7 +66,7 @@ describe("userSelected", () => {
     expect(() =>
       userSelected(["recordNumber", "subTableText"], fieldsJson, layoutJson)
     ).toThrow(
-      'The specified field "subTableText" in a table cannot be specified to fields option'
+      'The field in a Table cannot be specified to the fields option ("subTableText")\nPlease specify the Table field instead'
     );
   });
   it("should throw an Error if specified field does not exist", () => {

--- a/src/record/export/schema/transformers/userSelected.ts
+++ b/src/record/export/schema/transformers/userSelected.ts
@@ -40,7 +40,7 @@ const validateFields = (fields: string[], fieldsJson: FieldsJson) => {
     for (const property of Object.values(fieldsJson.properties)) {
       if (property.type === "SUBTABLE" && field in property.fields) {
         throw new Error(
-          `The specified field "${field}" in a table cannot be specified to fields option`
+          `The field in a Table cannot be specified to the fields option ("${field}")\nPlease specify the Table field instead`
         );
       }
     }

--- a/src/record/import/schema/__tests__/userSelected.test.ts
+++ b/src/record/import/schema/__tests__/userSelected.test.ts
@@ -61,7 +61,7 @@ describe("userSelected", () => {
     expect(() =>
       userSelected(["richText", "subTableText"], fieldsJson)
     ).toThrow(
-      'The specified field "subTableText" in a table cannot be specified to fields option'
+      'The field in a Table cannot be specified to the fields option ("subTableText")\nPlease specify the Table field instead'
     );
   });
   it("should throw an Error if specified field does not exist", () => {

--- a/src/record/import/schema/transformers/userSelected.ts
+++ b/src/record/import/schema/transformers/userSelected.ts
@@ -40,7 +40,7 @@ const validateFields = (fields: string[], fieldsJson: FieldsJson) => {
     for (const property of Object.values(fieldsJson.properties)) {
       if (property.type === "SUBTABLE" && field in property.fields) {
         throw new Error(
-          `The specified field "${field}" in a table cannot be specified to fields option`
+          `The field in a Table cannot be specified to the fields option ("${field}")\nPlease specify the Table field instead`
         );
       }
     }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Current Error Message
The specified field "フィールドコード" in a table cannot be specified in the fields option

In the case of the current error message, the user cannot know the reason why I cannot export the field in the subtable is:
cli-kintone cannot export the fields in the subtable ( because of cli-kintone spec )
or
the fields in the subtable have a problem ( because of the user kintone app's field )
That's why we want to improve the error message so that users can understand the reason.

## What

- [x] Update the error message

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
