### PR TITLE
README - English Edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A CLI tool to import/export records to/from [kintone](https://www.kintone.com/).
+A CLI tool to import/export records to/from [Kintone](https://www.kintone.com/).
 
 ---
 
@@ -29,7 +29,7 @@ A CLI tool to import/export records to/from [kintone](https://www.kintone.com/).
 
 ### import
 
-The `import` command allows you to import record data into a specified kintone app.
+The `import` command allows you to import record data into a specified Kintone app.
 
 ```
 $ cli-kintone record import \
@@ -86,7 +86,7 @@ If records contains Attachment field, `--attachments-dir` option is required.
 
 - the local file path in record is treated as relative path from `--attachments-dir`
   - upload the file there
-- file name on kintone is same as local
+- file name on Kintone is same as local
 
 #### Upsert records
 
@@ -107,7 +107,7 @@ The field specified as "Key to Bulk Update" should meet the following requiremen
 
 ### export
 
-The `export` command allows you to export record data from a specified kintone app.
+The `export` command allows you to export record data from a specified Kintone app.
 
 ```
 $ cli-kintone record export \
@@ -174,7 +174,7 @@ If set `--attachments-dir` option, attachment files will be downloaded to local 
 
 ### delete
 
-The `delete` command allows you to delete records of a specified kintone app.
+The `delete` command allows you to delete records of a specified Kintone app.
 
 **Notice**
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ A CLI tool to import/export records to/from [Kintone](https://www.kintone.com/).
    - Windows: `cli-kintone-win.zip`
    - Linux: `cli-kintone-linux.zip`
    - macOS: `cli-kintone-macos.zip`
-3. Extract the downloaded zip file and move the `cli-kintone` file to the `/usr/local/bin`.
-4. Run the `cli-kintone` command and confirm that the command is available.
+3. Extract the downloaded zip file
+4. Run the extracted file as follows and confirm that the command is available.
+   - Windows: `cli-kintone.exe` on command prompt
+   - Linux & macOS: `./cli-kintone` on terminal
 
-Note: If the terminal responds with an error stating that the command could not be found, the PATH environment variables may need to be edited to use cli-kintone.
+### Notes
+
+- If the terminal responds with an error stating that the command could not be found, the PATH environment variables may need to be edited to use cli-kintone.
+- For Linux and macOS users, it is recommended to move the `cli-kintone` file to the `/usr/local/bin`. Then `cli-kintone` command can be executed from anywhere.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ A CLI tool to import/export records to/from [Kintone](https://www.kintone.com/).
    - Linux & macOS: `./cli-kintone` on terminal
 
 ### Notes
-
-- If the terminal responds with an error stating that the command could not be found, the PATH environment variables may need to be edited to use cli-kintone.
-- For Linux and macOS users, it is recommended to move the `cli-kintone` file to the `/usr/local/bin`. Then `cli-kintone` command can be executed from anywhere.
+To run the `cli-kintone` command from any directory, do one of the following:
+- Run the command while specifying the absolute path
+- Set the PATH environment
+- Move the `cli-kintone` file to the `/usr/local/bin` directory (for Linux & macOS)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ A CLI tool to import/export records to/from [Kintone](https://www.kintone.com/).
    - Linux & macOS: `./cli-kintone` on terminal
 
 ### Notes
+
 To run the `cli-kintone` command from any directory, do one of the following:
+
 - Run the command while specifying the absolute path
 - Set the PATH environment
 - Move the `cli-kintone` file to the `/usr/local/bin` directory (for Linux & macOS)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ cli-kintone record import \
 
 #### Options
 
-Some options use environment variables starting `KINTONE_` as default values.
+Some options use environment variables starting with `KINTONE_` as default values.
 
 ```text
 Options:
@@ -73,7 +73,7 @@ Options:
       --guest-space-id       The ID of guest space
                                       [string] [default: KINTONE_GUEST_SPACE_ID]
       --attachments-dir      Attachment file directory                  [string]
-      --file-path            The path to source file.
+      --file-path            The path to the source file.
                              The file extension should be ".csv"
                                                              [string] [required]
       --encoding             Character encoding
@@ -81,19 +81,19 @@ Options:
       --update-key           The key to Bulk Update                     [string]
       --fields               The fields to be imported in comma-separated
                                                                         [string]
-      --pfx-file-path        The path to client certificate file        [string]
-      --pfx-file-password    The password of client certificate file    [string]
+      --pfx-file-path        The path to the client certificate file        [string]
+      --pfx-file-password    The password of the client certificate file    [string]
       --proxy                The URL of a proxy server
                                                  [string] [default: HTTPS_PROXY]
 ```
 
 ##### Notes
 
-- Field within a Table cannot be specified to the `fields` option.
+- A field within a Table cannot be specified to the `fields` option.
 
 #### Import Attachment field
 
-If records contain an Attachment field, `--attachments-dir` option is required.
+The `--attachments-dir` option is required if records contain an Attachment field.
 
 - The local file path in the record is treated as a relative path from `--attachments-dir`.
   - Upload the file there.
@@ -101,9 +101,9 @@ If records contain an Attachment field, `--attachments-dir` option is required.
 
 #### Upsert records
 
-When `--update-key` option is set, the option value is used as "Key to Bulk Update" to import (upsert) records.
+When the `--update-key` option is set, the option value is used as "Key to Bulk Update" to import (upsert) records.
 
-"Upsert" means updating and/or inserting records simultaneously. Data containing keys that match existing record values is used to update those records accordingly, and the remaining data is added to the specified app as new records.
+"Upsert" means updating and/or inserting records simultaneously. Data containing keys that match existing record values are used to update those records accordingly, and the remaining data is added to the specified app as new records.
 
 The field specified as "Key to Bulk Update" must meet one of the following requirements:
 
@@ -130,7 +130,7 @@ $ cli-kintone record export \
 
 #### Options
 
-Some options use environment variables starting `KINTONE_` as default values.
+Some options use environment variables starting with `KINTONE_` as default values.
 
 ```text
 Options:
@@ -157,15 +157,15 @@ Options:
       --order-by             The sort order as a query                  [string]
       --fields               The fields to be exported in comma-separated
                                                                         [string]
-      --pfx-file-path        The path to client certificate file        [string]
-      --pfx-file-password    The password of client certificate file    [string]
+      --pfx-file-path        The path to the client certificate file        [string]
+      --pfx-file-password    The password of the client certificate file    [string]
       --proxy                The URL of a proxy server
                                                  [string] [default: HTTPS_PROXY]
 ```
 
 ##### Notes
 
-- Field within a Table cannot be specified to the `fields` option.
+- A field within a Table cannot be specified to the `fields` option.
 
 #### `--condition` and `--order-by` options
 
@@ -204,7 +204,7 @@ You can bypass the confirmation step by using the options `--yes` or `-y`.
 
 #### Options
 
-Some options use environment variables starting `KINTONE_` as default values.
+Some options use environment variables starting with `KINTONE_` as default values.
 
 ```text
 Options:
@@ -218,14 +218,14 @@ Options:
       --basic-auth-password  Kintone Basic Auth Password
                                  [string] [default: KINTONE_BASIC_AUTH_PASSWORD]
       --app                  The ID of the app               [string] [required]
-      --file-path            The path to source file.
+      --file-path            The path to the source file.
                              The file extension should be ".csv"        [string]
       --encoding             Character encoding
                                      [choices: "utf8", "sjis"] [default: "utf8"]
       --guest-space-id       The ID of guest space
                                       [string] [default: KINTONE_GUEST_SPACE_ID]
-      --pfx-file-path        The path to client certificate file        [string]
-      --pfx-file-password    The password of client certificate file    [string]
+      --pfx-file-path        The path to the client certificate file        [string]
+      --pfx-file-password    The password of the client certificate file    [string]
       --proxy                The URL of a proxy server
                                                  [string] [default: HTTPS_PROXY]
   -y, --yes                  Force to delete records                   [boolean]
@@ -253,7 +253,7 @@ cli-kintone supports the following formats for both import & export commands.
 
 - CSV
 
-When importing, it automatically determines the format by the file extension (specified by `--file-path` option).
+When importing, it automatically determines the format by the file extension (specified by the `--file-path` option).
 
 More information regarding the formats is as follows:
 
@@ -326,7 +326,7 @@ file-9/test (1).txt"
 fileInTable-1-0/test (1).txt"
 ```
 
-When exporting, if the `--attachments-dir` option is NOT set, only the file name will be outputted.
+When exporting, only the file name will be outputted if the `--attachments-dir` option is NOT set.
 
 ```csv
 "fileFieldCode"
@@ -417,8 +417,8 @@ Steps:
 
 1. Install Linux on Windows with WSL. Ref: [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install).
 2. Open a new Linux Terminal.
-3. Download and extract executables from the [linux package](https://github.com/kintone/cli-kintone/releases).
-4. Run the same commands as [bash section](#bash).
+3. Download and extract executables from the [Linux package](https://github.com/kintone/cli-kintone/releases).
+4. Run the same commands as the [bash section](#bash).
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ If records contains Attachment field, `--attachments-dir` option is required.
 
 #### Upsert records
 
-When `--update-key` option is set, the option value is used as “Key to Bulk Update” to import (upsert) records.
+When `--update-key` option is set, the option value is used as "Key to Bulk Update" to import (upsert) records.
 
 "Upsert" means updating and/or inserting records at the same time. Data containing keys that match existing record values is used to update those records accordingly, and the remaining data is added to the specified app as new records.
 
@@ -328,7 +328,7 @@ test.txt"
 
 #### Table
 
-- The row where a record begins has a PRIMARY_MARK(`*`) on the “`*`“ field.
+- The row where a record begins has a PRIMARY_MARK(`*`) on the "`*`" field.
 - The data of fields outside the Table are specified in the row with PRIMARY_MARK(`*`)
   - The data of fields outside the Table in other rows will be ignored.
 - The data of fields inside the Table are specified with one or multiple rows

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ A CLI tool to import/export records to/from [Kintone](https://www.kintone.com/).
     - [Options](#options)
   - [export](#export)
     - [Options](#options-1)
+  - [delete](#delete)
+    - [Options](#options-2)
 - [Supported file formats](#supported-file-formats)
   - [CSV format](#csv-format)
+- [Command completion](#command-completion)
 - [LICENSE](#license)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ A CLI tool to import/export records to/from [Kintone](https://www.kintone.com/).
    - Windows: `cli-kintone-win.zip`
    - Linux: `cli-kintone-linux.zip`
    - macOS: `cli-kintone-macos.zip`
-3. Extract executables from the ZIP file and run it.
+3. Extract the downloaded zip file and move the `cli-kintone` files to the `/usr/local/bin`.
+4. Run `cli-kintone` command and confirm that the command is available.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ If the `--attachments-dir` option is set, attachment files will be downloaded to
 
 - The file path is `<attachmentsDir>/<fieldCode>-<recordId>/<filename>`.
   - For attachment fields in a Table, the file path is `<attachmentsDir>/<fieldCode>-<recordId>-<tableRowIndex>/<filename>`.
-- Files with the same name in the same Attachment field, the files would be renamed to `<filename> (<index>).<ext>`.
+- For files with the same name in the same Attachment field, the files will be renamed to `<filename> (<index>).<ext>`.
 
 ### delete
 
@@ -318,7 +318,7 @@ file-9/test (1).txt"
 fileInTable-1-0/test (1).txt"
 ```
 
-When exporting, if NOT set the `--attachments-dir` option, only the file name will be outputted.
+When exporting, if the `--attachments-dir` option is NOT set, only the file name will be outputted.
 
 ```csv
 "fileFieldCode"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A CLI tool to import/export records to/from [Kintone](https://www.kintone.com/).
    - Windows: `cli-kintone-win.zip`
    - Linux: `cli-kintone-linux.zip`
    - macOS: `cli-kintone-macos.zip`
-3. Extract the downloaded zip file and move the `cli-kintone` files to the `/usr/local/bin`.
+3. Extract the downloaded zip file and move the `cli-kintone` file to the `/usr/local/bin`.
 4. Run the `cli-kintone` command and confirm that the command is available.
 
 Note: If the terminal responds with an error stating that the command could not be found, the PATH environment variables may need to be edited to use cli-kintone.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A CLI tool to import/export records to/from [Kintone](https://www.kintone.com/).
 
 The `import` command allows you to import record data into a specified Kintone app.
 
-```
+```shell
 $ cli-kintone record import \
 --base-url https://${yourDomain} \
 --api-token ${apiToken} \
@@ -43,7 +43,7 @@ $ cli-kintone record import \
 
 Some options use environment variables starting `KINTONE_` as default values.
 
-```
+```text
 Options:
       --version              Show version number                       [boolean]
       --help                 Show help                                 [boolean]
@@ -109,7 +109,7 @@ The field specified as "Key to Bulk Update" should meet the following requiremen
 
 The `export` command allows you to export record data from a specified Kintone app.
 
-```
+```shell
 $ cli-kintone record export \
 --base-url https://${yourDomain} \
 --api-token ${apiToken} \
@@ -121,7 +121,7 @@ $ cli-kintone record export \
 
 Some options use environment variables starting `KINTONE_` as default values.
 
-```
+```text
 Options:
       --version              Show version number                       [boolean]
       --help                 Show help                                 [boolean]
@@ -181,7 +181,7 @@ The `delete` command allows you to delete records of a specified Kintone app.
 - This command only supports API token authentication
 - This action cannot be rollback.
 
-```
+```shell
 $ cli-kintone record delete \
 --base-url https://${yourDomain} \
 --api-token ${apiToken} \
@@ -195,7 +195,7 @@ You can use the option `--yes` or `-y` to bypass the confirmation step.
 
 Some options use environment variables starting `KINTONE_` as default values.
 
-```
+```text
 Options:
       --version              Show version number                       [boolean]
       --help                 Show help                                 [boolean]

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ A CLI tool to import/export records to/from [Kintone](https://www.kintone.com/).
    - Linux: `cli-kintone-linux.zip`
    - macOS: `cli-kintone-macos.zip`
 3. Extract the downloaded zip file and move the `cli-kintone` files to the `/usr/local/bin`.
-4. Run `cli-kintone` command and confirm that the command is available.
+4. Run the `cli-kintone` command and confirm that the command is available.
 
-Note: If the terminal responds stating that the command could not be found, the PATH environment variables may need to be edited to use cli-kintone.
+Note: If the terminal responds with an error stating that the command could not be found, the PATH environment variables may need to be edited to use cli-kintone.
 
 ## Usage
 
@@ -81,32 +81,32 @@ Options:
 
 ##### Notes
 
-- The field in a Table cannot be specified to the `fields` option.
+- Field within a Table cannot be specified to the `fields` option.
 
 #### Import Attachment field
 
-If records contains Attachment field, `--attachments-dir` option is required.
+If records contain an Attachment field, `--attachments-dir` option is required.
 
-- the local file path in record is treated as relative path from `--attachments-dir`
-  - upload the file there
-- file name on Kintone is same as local
+- The local file path in the record is treated as a relative path from `--attachments-dir`.
+  - Upload the file there.
+- The file names on Kintone will be the same as the local.
 
 #### Upsert records
 
 When `--update-key` option is set, the option value is used as "Key to Bulk Update" to import (upsert) records.
 
-"Upsert" means updating and/or inserting records at the same time. Data containing keys that match existing record values is used to update those records accordingly, and the remaining data is added to the specified app as new records.
+"Upsert" means updating and/or inserting records simultaneously. Data containing keys that match existing record values is used to update those records accordingly, and the remaining data is added to the specified app as new records.
 
-The field specified as "Key to Bulk Update" should meet the following requirements:
+The field specified as "Key to Bulk Update" must meet one of the following requirements:
 
-- be Record Number field
-- be one of the following field types with "Prohibit duplicate values" enabled
+- Be the Record Number field.
+- Be one of the following field types with the "Prohibit duplicate values" option enabled:
   - Text
   - Number
 
 ##### Notes
 
-- When the field specified as "Key to Bulk Update" is Record Number, the value of the field may have app code of the target app.
+- When the Record Number field is specified as the "Key to Bulk Update", the field's value may have the target app's code.
 
 ### export
 
@@ -157,7 +157,7 @@ Options:
 
 ##### Notes
 
-- The field in a Table cannot be specified to the `fields` option.
+- A field in a Table cannot be specified with the `fields` option.
 
 #### `--condition` and `--order-by` options
 
@@ -169,11 +169,11 @@ Refer to the [`getAllRecords()`](https://github.com/kintone/js-sdk/blob/master/p
 
 #### Download attachment files
 
-If set `--attachments-dir` option, attachment files will be downloaded to local directory.
+If the `--attachments-dir` option is set, attachment files will be downloaded to the local directory.
 
-- the file path is `<attachmentsDir>/<fieldCode>-<recordId>/<filename>`
-  - as for attachments in Table, the file path is `<attachmentsDir>/<fieldCode>-<recordId>-<tableRowIndex>/<filename>`
-- if same name files exist in same Attachment field, renamed to `<filename> (<index>).<ext>`
+- The file path is `<attachmentsDir>/<fieldCode>-<recordId>/<filename>`.
+  - For attachment fields in a Table, the file path is `<attachmentsDir>/<fieldCode>-<recordId>-<tableRowIndex>/<filename>`.
+- Files with the same name in the same Attachment field, the files would be renamed to `<filename> (<index>).<ext>`.
 
 ### delete
 
@@ -181,7 +181,7 @@ The `delete` command allows you to delete records of a specified Kintone app.
 
 **Notice**
 
-- This command only supports API token authentication
+- This command only supports API token authentication.
 - This action cannot be rollback.
 
 ```shell
@@ -192,7 +192,7 @@ $ cli-kintone record delete \
 --file-path ${filepath}
 ```
 
-You can use the option `--yes` or `-y` to bypass the confirmation step.
+You can bypass the confirmation step by using the options `--yes` or `-y`.
 
 #### Options
 
@@ -229,25 +229,25 @@ All records of the target app will be deleted if the option `--file-path` is not
 
 #### Delete specific records
 
-The specific records can be deleted by specifying the option `--file-path`.
+Specific records can be deleted by specifying the option `--file-path`.
 
 The value of the `--file-path` must be the path to the CSV file and should meet the following requirements:
 
-- The file extension should be ".csv"
+- The file extension should be ".csv".
 - The header row of the record number column must be the record number field code which is defined in the target app.
-- If using the app code in the record number,
-  - Every row should contain the same app code (not mix)
+- If using the app code in the record number:
+  - Every row should contain the same app code (not mixed).
   - The app code is equal to the target app's one.
 
 ## Supported file formats
 
-cli-kintone supports following formats for both import/export commands.
+cli-kintone supports the following formats for both import & export commands.
 
 - CSV
 
-When importing, it determines the format automatically by the extension of the file (specified by `--file-path` option).
+When importing, it automatically determines the format by the file extension (specified by `--file-path` option).
 
-The detailed formats are as follows:
+More information regarding the formats is as follows:
 
 ### CSV format
 
@@ -264,7 +264,7 @@ Here are considerations for some field types:
 
 #### Text area
 
-If the value contains line break, enclose the value in double quotes.
+If the value contains a line break, enclose the value in double quotes.
 
 ```csv
 "TextAreaField"
@@ -275,7 +275,7 @@ text"
 
 #### Check box, Multi-choice
 
-Specify multiple values divided by line break (\n).
+Specify multiple values by separating them with line breaks (\n).
 
 ```csv
 "CheckboxField"
@@ -285,7 +285,7 @@ value2"
 
 #### User Selection, Department Selection, Group Selection
 
-If multiple value is selected, separated with line break (\n). (equivalent to `value.code` in REST API).
+If multiple values are selected, they will be separated with a line break (\n) (equivalent to `value.code` in REST API).
 
 ```csv
 "userSelectionField","departmentSelectionField","groupSelectionField"
@@ -304,7 +304,7 @@ Specify the user's login name (equivalent to `value.code` in REST API).
 
 #### Attachment
 
-Files in same Attachment field (in same Table row) are separated with line break (\n).
+Files in the same Attachment field (in the same Table row) are separated with line breaks (\n).
 
 ```csv
 "file"
@@ -318,7 +318,7 @@ file-9/test (1).txt"
 fileInTable-1-0/test (1).txt"
 ```
 
-When export, if NOT set `--attachments-dir` option, only the file name will be output.
+When exporting, if NOT set the `--attachments-dir` option, only the file name will be outputted.
 
 ```csv
 "fileFieldCode"
@@ -329,10 +329,10 @@ test.txt"
 #### Table
 
 - The row where a record begins has a PRIMARY_MARK(`*`) on the "`*`" field.
-- The data of fields outside the Table are specified in the row with PRIMARY_MARK(`*`)
+- The data of fields outside the Table are specified in the row with PRIMARY_MARK(`*`).
   - The data of fields outside the Table in other rows will be ignored.
-- The data of fields inside the Table are specified with one or multiple rows
-  - If there is no data about the Table in the row, the row is ignored
+- The data of fields inside the Table are specified with one or more rows.
+  - If there is no data about the Table in the row, the row is ignored.
 
 ```csv
 "*","Text","Table","TextInTable"
@@ -352,13 +352,13 @@ with multiple Table fields
 
 ## Command completion
 
-cli-kintone provides a command-completion feature that enables you to use the **Tab** key to complete a partially entered command.
+cli-kintone provides a command-completion feature that lets you use the **Tab** key to complete a partially entered command.
 
-cli-kintone command completion is now supported only for `bash` and `zsh` shell.
+cli-kintone command completion is now supported for `bash` and `zsh` shells.
 
 ### zsh
 
-To enable it in `zsh`, `cd` to the directory that contains the cli-kintone executable file, then run the below commands:
+To enable it in `zsh`, `cd` to the directory that contains the cli-kintone executable file, then run the following commands:
 
 ```shell
 # 1. Set PATH environment variables
@@ -381,7 +381,7 @@ source ~/.zshrc
 
 ### bash
 
-To enable it in `bash`, `cd` to the directory that contains the cli-kintone executable file, then run the below commands:
+To enable it in `bash`, `cd` to the directory that contains the cli-kintone executable file, then run the following commands:
 
 ```shell
 # 1. Create command completion script
@@ -407,10 +407,10 @@ For Windows OS, you can use cli-kintone command completion via `bash` on [WSL2](
 
 Steps:
 
-1. Install Linux on Windows with WSL. Ref: [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install)
-2. Open a new Linux Terminal
+1. Install Linux on Windows with WSL. Ref: [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install).
+2. Open a new Linux Terminal.
 3. Download and extract executables from the [linux package](https://github.com/kintone/cli-kintone/releases).
-4. Run the same commands as [bash section](#bash)
+4. Run the same commands as [bash section](#bash).
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Options:
 
 ##### Notes
 
-- A field in a Table cannot be specified with the `fields` option.
+- Field within a Table cannot be specified to the `fields` option.
 
 #### `--condition` and `--order-by` options
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A CLI tool to import/export records to/from [Kintone](https://www.kintone.com/).
 3. Extract the downloaded zip file and move the `cli-kintone` files to the `/usr/local/bin`.
 4. Run `cli-kintone` command and confirm that the command is available.
 
+Note: If the terminal responds stating that the command could not be found, the PATH environment variables may need to be edited to use cli-kintone.
+
 ## Usage
 
 ### import


### PR DESCRIPTION
## Why

* Improve the README file's English
* Clarify the installation process

## What

Changes made to README:
* Capitalize Kintone's K
* Add shell or text to unspecified code blocks
* Installation Section > Add move to `/usr/local/bin` step
* Installation > Append a PATH environment variables note
* Replace curly brackets
* English review
* Table Table of Contents {New}
* Updated Installation's Step 3, 4, & Notes {New}

## How to test

* Confirm the changes on the README file locally

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.

### Warning from Linters
The following got flagged by the linter but were not the result of this PR:

[lint:eslint] ✖ 5 problems (0 errors, 5 warnings)

`warning ../../package.json: No license field`

`cli-kintone/src/__tests__/api.test.ts`
* 226:19  warning  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
* 251:19  warning  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap

`cli-kintone/src/kintone/client.ts`
* 65:10  warning  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap

`cli-kintone/src/record/export/usecases/__tests__/get/index.test.ts`
* 92:28  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

`cli-kintone/src/record/import/usecases/add/record.ts`
* 84:13  warning  Blocks are nested too deeply (5). Maximum allowed is 4  max-depth