### PR TITLE
feat: support proxy authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,14 @@ The value of the `--file-path` must be the path to the CSV file and should meet 
   - Every row should contain the same app code (not mixed).
   - The app code is equal to the target app's one.
 
+## Proxy Authentication
+
+cli-kintone supports proxy authentication via proxy url by the following format:
+
+```
+http://user:pass@domain:port
+```
+
 ## Supported file formats
 
 cli-kintone supports the following formats for both import & export commands.

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ The value of the `--file-path` must be the path to the CSV file and should meet 
 cli-kintone supports proxy authentication via proxy url by the following format:
 
 ```
-http://user:pass@domain:port
+http://username:password@domain:port
 ```
 
 ## Supported file formats

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -3,7 +3,7 @@ import { buildRestAPIClient } from "../kintone/client";
 import { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import * as https from "https";
 import fs from "fs";
-import HttpsProxyAgent from "https-proxy-agent";
+import httpsProxyAgent from "https-proxy-agent";
 const packageJson = require("../../package.json");
 const expectedUa = `${packageJson.name}@${packageJson.version}`;
 
@@ -35,42 +35,49 @@ jest.mock("https", () => {
 });
 
 jest.mock("https-proxy-agent", () => {
-  return jest
-    .fn()
-    .mockImplementation(
-      (opts: {
+  return jest.fn().mockImplementation(
+    (opts: {
+      protocol?: string;
+      host?: string;
+      port?: string;
+      pfx?: Buffer | string;
+      passphrase?: string;
+      headers?: {
+        "Proxy-Authorization"?: string;
+      };
+    }) => {
+      const agentInstance: {
         protocol?: string;
         host?: string;
         port?: string;
         pfx?: Buffer | string;
         passphrase?: string;
-      }) => {
-        const agentInstance: {
-          protocol?: string;
-          host?: string;
-          port?: string;
-          pfx?: Buffer | string;
-          passphrase?: string;
-        } = {};
+        headers?: {
+          "Proxy-Authorization"?: string;
+        };
+      } = {};
 
-        if (opts.protocol) {
-          agentInstance.protocol = opts.protocol;
-        }
-        if (opts.host) {
-          agentInstance.host = opts.host;
-        }
-        if (opts.port) {
-          agentInstance.port = opts.port;
-        }
-        if (opts.pfx) {
-          agentInstance.pfx = opts.pfx;
-        }
-        if (opts.passphrase) {
-          agentInstance.passphrase = opts.passphrase;
-        }
-        return agentInstance;
+      if (opts.protocol) {
+        agentInstance.protocol = opts.protocol;
       }
-    );
+      if (opts.host) {
+        agentInstance.host = opts.host;
+      }
+      if (opts.port) {
+        agentInstance.port = opts.port;
+      }
+      if (opts.pfx) {
+        agentInstance.pfx = opts.pfx;
+      }
+      if (opts.passphrase) {
+        agentInstance.passphrase = opts.passphrase;
+      }
+      if (opts.headers) {
+        agentInstance.headers = opts.headers;
+      }
+      return agentInstance;
+    }
+  );
 });
 
 describe("api", () => {
@@ -81,6 +88,10 @@ describe("api", () => {
   const PFX_FILE_PATH = "./dummy.pfx";
   const PFX_FILE_PASSWORD = "pfx_password";
   const HTTPS_PROXY = "http://proxy.example.com:3128";
+
+  const PROXY_USERNAME = "proxyUser";
+  const PROXY_PASSWORD = "proxyPass";
+  const AUTHN_HTTPS_PROXY = `http://${PROXY_USERNAME}:${PROXY_PASSWORD}@proxy.example.com:3128`;
 
   it("should pass username and password to the apiClient correctly", () => {
     const apiClient = buildRestAPIClient({
@@ -223,7 +234,7 @@ describe("api", () => {
         password: PASSWORD,
       },
       userAgent: expectedUa,
-      httpsAgent: HttpsProxyAgent({
+      httpsAgent: httpsProxyAgent({
         protocol: "http:",
         host: "proxy.example.com",
         port: "3128",
@@ -248,12 +259,42 @@ describe("api", () => {
         password: PASSWORD,
       },
       userAgent: expectedUa,
-      httpsAgent: HttpsProxyAgent({
+      httpsAgent: httpsProxyAgent({
         protocol: "http:",
         host: "proxy.example.com",
         port: "3128",
         pfx: "dummy",
         passphrase: PFX_FILE_PASSWORD,
+      }),
+      proxy: false,
+    });
+  });
+
+  it("should pass information of proxy authentication to the apiClient correctly", () => {
+    const apiClient = buildRestAPIClient({
+      baseUrl: BASE_URL,
+      username: USERNAME,
+      password: PASSWORD,
+      httpsProxy: AUTHN_HTTPS_PROXY,
+    });
+    const proxyAuthorizationStr =
+      "Basic " +
+      Buffer.from(`${PROXY_USERNAME}:${PROXY_PASSWORD}`).toString("base64");
+    expect(apiClient).toBeInstanceOf(KintoneRestAPIClient);
+    expect(KintoneRestAPIClient).toHaveBeenCalledWith({
+      baseUrl: BASE_URL,
+      auth: {
+        username: USERNAME,
+        password: PASSWORD,
+      },
+      userAgent: expectedUa,
+      httpsAgent: httpsProxyAgent({
+        protocol: "http:",
+        host: "proxy.example.com",
+        port: "3128",
+        headers: {
+          "Proxy-Authorization": proxyAuthorizationStr,
+        },
       }),
       proxy: false,
     });

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -35,27 +35,10 @@ jest.mock("https", () => {
 });
 
 jest.mock("https-proxy-agent", () => {
-  return jest.fn().mockImplementation(
-    (opts: {
-      protocol?: string;
-      host?: string;
-      port?: string;
-      pfx?: Buffer | string;
-      passphrase?: string;
-      headers?: {
-        "Proxy-Authorization"?: string;
-      };
-    }) => {
-      const agentInstance: {
-        protocol?: string;
-        host?: string;
-        port?: string;
-        pfx?: Buffer | string;
-        passphrase?: string;
-        headers?: {
-          "Proxy-Authorization"?: string;
-        };
-      } = {};
+  return jest
+    .fn()
+    .mockImplementation((opts: httpsProxyAgent.HttpsProxyAgentOptions) => {
+      const agentInstance: httpsProxyAgent.HttpsProxyAgentOptions = {};
 
       if (opts.protocol) {
         agentInstance.protocol = opts.protocol;
@@ -76,8 +59,7 @@ jest.mock("https-proxy-agent", () => {
         agentInstance.headers = opts.headers;
       }
       return agentInstance;
-    }
-  );
+    });
 });
 
 describe("api", () => {
@@ -91,7 +73,7 @@ describe("api", () => {
 
   const PROXY_USERNAME = "proxyUser";
   const PROXY_PASSWORD = "proxyPass";
-  const AUTHN_HTTPS_PROXY = `http://${PROXY_USERNAME}:${PROXY_PASSWORD}@proxy.example.com:3128`;
+  const HTTPS_PROXY_WITH_AUTHN = `http://${PROXY_USERNAME}:${PROXY_PASSWORD}@proxy.example.com:3128`;
 
   it("should pass username and password to the apiClient correctly", () => {
     const apiClient = buildRestAPIClient({
@@ -275,9 +257,9 @@ describe("api", () => {
       baseUrl: BASE_URL,
       username: USERNAME,
       password: PASSWORD,
-      httpsProxy: AUTHN_HTTPS_PROXY,
+      httpsProxy: HTTPS_PROXY_WITH_AUTHN,
     });
-    const proxyAuthorizationStr =
+    const proxyAuthorizationHeaderValue =
       "Basic " +
       Buffer.from(`${PROXY_USERNAME}:${PROXY_PASSWORD}`).toString("base64");
     expect(apiClient).toBeInstanceOf(KintoneRestAPIClient);
@@ -293,7 +275,7 @@ describe("api", () => {
         host: "proxy.example.com",
         port: "3128",
         headers: {
-          "Proxy-Authorization": proxyAuthorizationStr,
+          "Proxy-Authorization": proxyAuthorizationHeaderValue,
         },
       }),
       proxy: false,

--- a/src/kintone/client.ts
+++ b/src/kintone/client.ts
@@ -73,14 +73,17 @@ const buildHttpsAgent = (options: {
 
   if (username.length > 0 && password.length > 0) {
     proxyOptions.headers = {
-      "Proxy-Authorization": generateProxyAuthorizationStr(username, password),
+      "Proxy-Authorization": generateProxyAuthorizationHeaderValue(
+        username,
+        password
+      ),
     };
   }
 
   return httpsProxyAgent(proxyOptions);
 };
 
-const generateProxyAuthorizationStr = (
+const generateProxyAuthorizationHeaderValue = (
   username: string,
   password: string
 ): string => {

--- a/src/kintone/client.ts
+++ b/src/kintone/client.ts
@@ -1,6 +1,6 @@
 import { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import * as packageJson from "../../package.json";
-import HttpsProxyAgent from "https-proxy-agent";
+import httpsProxyAgent from "https-proxy-agent";
 import * as https from "https";
 import fs from "fs";
 
@@ -61,13 +61,30 @@ const buildHttpsAgent = (options: {
     return new https.Agent({ ...clientAuth });
   }
 
-  const { protocol, hostname, port } = new URL(options.proxy);
-  return HttpsProxyAgent({
+  const { protocol, hostname, port, username, password } = new URL(
+    options.proxy
+  );
+  const proxyOptions: httpsProxyAgent.HttpsProxyAgentOptions = {
     protocol: protocol,
     host: hostname,
     port: port,
     ...clientAuth,
-  });
+  };
+
+  if (username.length > 0 && password.length > 0) {
+    proxyOptions.headers = {
+      "Proxy-Authorization": generateProxyAuthorizationStr(username, password),
+    };
+  }
+
+  return httpsProxyAgent(proxyOptions);
+};
+
+const generateProxyAuthorizationStr = (
+  username: string,
+  password: string
+): string => {
+  return "Basic " + Buffer.from(`${username}:${password}`).toString("base64");
 };
 
 export const buildRestAPIClient = (options: RestAPIClientOptions) => {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Currently, cli-kintone v1 does not support proxy authentication as cli-kintone v0 yet.

## What

- [x] Support proxy authentication via `--proxy` option and ENV Vars: HTTPS_PROXY and https_proxy

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
