### PR TITLE
refactor: remove `as any` type assertion

### DIFF
--- a/src/kintone/client.ts
+++ b/src/kintone/client.ts
@@ -97,9 +97,7 @@ export const buildRestAPIClient = (options: RestAPIClientOptions) => {
     ...buildBasicAuthParam(options),
     ...(options.guestSpaceId ? { guestSpaceId: options.guestSpaceId } : {}),
     userAgent: `${packageJson.name}@${packageJson.version}`,
-    // TODO: fix type definition of @kintone/rest-api-client
-    // Currently, the proxy property doesn't accept false
-    proxy: false as any,
+    proxy: false,
     httpsAgent: buildHttpsAgent({
       proxy: options.httpsProxy,
       pfxFilePath: options.pfxFilePath,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
From [@kintone/rest-api-client@3.3.14](https://github.com/kintone/js-sdk/releases/tag/%40kintone%2Frest-api-client%403.3.14), the `proxy` option of KintoneRestAPIClient has started accepting `false` value.
PR: https://github.com/kintone/js-sdk/pull/2102 .
Before that, we had passed `false` to KintoneRestAPIClient using an `as any` assertion.

## What

<!-- What is a solution you want to add? -->
- Removed hacky code.

## How to test

<!-- How can we test this pull request? -->
N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
