### PR TITLE
feat: enable record import with a Record Number field

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Options:
 ##### Notes
 
 - A field within a Table cannot be specified to the `fields` option.
-- A Record Number field is ignored
 
 #### Import Attachment field
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Options:
 ##### Notes
 
 - A field within a Table cannot be specified to the `fields` option.
+- A Record Number field is ignored
 
 #### Import Attachment field
 
@@ -118,6 +119,7 @@ The field specified as "Key to Bulk Update" must meet one of the following requi
 ##### Notes
 
 - When the Record Number field is specified as the "Key to Bulk Update", the field's value may have the target app's code.
+- A Record Number field is only evaluated for records to be updated when it is specified as "Key to Bulk Update".
 - The following fields in records to be updated are ignored.
   - Created by
   - Created datetime

--- a/src/record/import/usecases/__tests__/add/index.test.ts
+++ b/src/record/import/usecases/__tests__/add/index.test.ts
@@ -78,7 +78,7 @@ describe("addRecords", () => {
     });
   });
 
-  it("should ignore a Record Number field", async () => {
+  it("should includes a Record Number field", async () => {
     const addAllRecordsMockFn = jest.fn().mockResolvedValue([{}]);
     apiClient.record.addAllRecords = addAllRecordsMockFn;
     const APP_ID = "1";
@@ -121,7 +121,7 @@ describe("addRecords", () => {
 
     expect(addAllRecordsMockFn.mock.calls[0][0]).toStrictEqual({
       app: APP_ID,
-      records: [{ number: { value: "1" } }],
+      records: [{ recordNumber: { value: "1" }, number: { value: "1" } }],
     });
   });
 

--- a/src/record/import/usecases/__tests__/add/index.test.ts
+++ b/src/record/import/usecases/__tests__/add/index.test.ts
@@ -78,6 +78,53 @@ describe("addRecords", () => {
     });
   });
 
+  it("should ignore a Record Number field", async () => {
+    const addAllRecordsMockFn = jest.fn().mockResolvedValue([{}]);
+    apiClient.record.addAllRecords = addAllRecordsMockFn;
+    const APP_ID = "1";
+    const RECORDS: LocalRecord[] = [
+      {
+        data: { recordNumber: { value: "1" }, number: { value: "1" } },
+        metadata: {
+          format: { type: "csv", firstRowIndex: 0, lastRowIndex: 0 },
+        },
+      },
+    ];
+    const SCHEMA: RecordSchema = {
+      fields: [
+        {
+          type: "RECORD_NUMBER",
+          code: "recordNumber",
+          label: "recordNumber",
+          noLabel: false,
+        },
+        {
+          type: "NUMBER",
+          code: "number",
+          label: "number",
+          noLabel: false,
+          required: true,
+          minValue: "",
+          maxValue: "",
+          digit: false,
+          unique: true,
+          defaultValue: "",
+          displayScale: "",
+          unit: "",
+          unitPosition: "BEFORE",
+        },
+      ],
+    };
+    const repository = new LocalRecordRepositoryMock(RECORDS, "csv");
+
+    await addRecords(apiClient, APP_ID, repository, SCHEMA, {});
+
+    expect(addAllRecordsMockFn.mock.calls[0][0]).toStrictEqual({
+      app: APP_ID,
+      records: [{ number: { value: "1" } }],
+    });
+  });
+
   it("should throw error when attachmentsDir is NOT given", () => {
     const APP_ID = "1";
 

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithRecordNumber/expected.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithRecordNumber/expected.ts
@@ -1,0 +1,45 @@
+import type { TestPattern } from "../../index.test";
+
+export const expected: TestPattern["expected"] = {
+  success: {
+    requests: [
+      // Records for update should not include a Record Number field
+      {
+        type: "update",
+        payload: {
+          app: "1",
+          records: [
+            {
+              updateKey: {
+                field: "singleLineText",
+                value: "value1",
+              },
+              record: {
+                number: {
+                  value: "1",
+                },
+              },
+            },
+          ],
+        },
+      },
+      // Records for add should not include a Record Number field
+      {
+        type: "add",
+        payload: {
+          app: "1",
+          records: [
+            {
+              singleLineText: {
+                value: "value3",
+              },
+              number: {
+                value: "3",
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+};

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithRecordNumber/index.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithRecordNumber/index.ts
@@ -1,0 +1,23 @@
+import type { TestPattern } from "../../index.test";
+import { records } from "./records";
+import { schema } from "./schema";
+import { expected } from "./expected";
+import { recordsOnKintone } from "./recordsOnKintone";
+import { LocalRecordRepositoryMock } from "../../../../../repositories/localRecordRepositoryMock";
+
+export const pattern: TestPattern = {
+  description:
+    "should upsert records correctly with a Record Number field even if the Record Number field isn't specified as update key",
+  input: {
+    records: records,
+    repository: new LocalRecordRepositoryMock(records, "csv"),
+    schema: schema,
+    updateKey: "singleLineText",
+    options: {
+      attachmentsDir: "",
+      skipMissingFields: true,
+    },
+  },
+  recordsOnKintone: recordsOnKintone,
+  expected: expected,
+};

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithRecordNumber/records.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithRecordNumber/records.ts
@@ -1,0 +1,36 @@
+import type { LocalRecord } from "../../../../../types/record";
+
+export const records: LocalRecord[] = [
+  {
+    data: {
+      recordNumber: {
+        value: "1",
+      },
+      singleLineText: {
+        value: "value1",
+      },
+      number: {
+        value: "1",
+      },
+    },
+    metadata: {
+      format: { type: "csv", firstRowIndex: 1, lastRowIndex: 1 },
+    },
+  },
+  {
+    data: {
+      recordNumber: {
+        value: "3",
+      },
+      singleLineText: {
+        value: "value3",
+      },
+      number: {
+        value: "3",
+      },
+    },
+    metadata: {
+      format: { type: "csv", firstRowIndex: 2, lastRowIndex: 2 },
+    },
+  },
+];

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithRecordNumber/recordsOnKintone.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithRecordNumber/recordsOnKintone.ts
@@ -1,0 +1,34 @@
+import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
+
+export const recordsOnKintone: Awaited<
+  ReturnType<KintoneRestAPIClient["record"]["getAllRecords"]>
+> = [
+  {
+    recordNumber: {
+      type: "RECORD_NUMBER",
+      value: "1",
+    },
+    singleLineText: {
+      type: "SINGLE_LINE_TEXT",
+      value: "value1",
+    },
+    number: {
+      type: "NUMBER",
+      value: "1",
+    },
+  },
+  {
+    recordNumber: {
+      type: "RECORD_NUMBER",
+      value: "2",
+    },
+    singleLineText: {
+      type: "SINGLE_LINE_TEXT",
+      value: "value2",
+    },
+    number: {
+      type: "NUMBER",
+      value: "2",
+    },
+  },
+];

--- a/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithRecordNumber/schema.ts
+++ b/src/record/import/usecases/__tests__/upsert/fixtures/upsertWithRecordNumber/schema.ts
@@ -1,0 +1,40 @@
+import type { RecordSchema } from "../../../../../types/schema";
+
+export const schema: RecordSchema = {
+  fields: [
+    {
+      type: "RECORD_NUMBER",
+      code: "recordNumber",
+      label: "recordNumber",
+      noLabel: false,
+    },
+    {
+      type: "SINGLE_LINE_TEXT",
+      code: "singleLineText",
+      label: "singleLineText",
+      noLabel: false,
+      required: false,
+      minLength: "",
+      maxLength: "",
+      expression: "",
+      hideExpression: false,
+      unique: true,
+      defaultValue: "",
+    },
+    {
+      type: "NUMBER",
+      code: "number",
+      label: "number",
+      noLabel: false,
+      required: true,
+      minValue: "",
+      maxValue: "",
+      digit: false,
+      unique: true,
+      defaultValue: "",
+      displayScale: "",
+      unit: "",
+      unitPosition: "BEFORE",
+    },
+  ],
+};

--- a/src/record/import/usecases/__tests__/upsert/index.test.ts
+++ b/src/record/import/usecases/__tests__/upsert/index.test.ts
@@ -19,6 +19,7 @@ import { pattern as upsertWithMissingFieldInTableFromRecord } from "./fixtures/u
 import { pattern as upsertByRecordNumberWithMixedRecordNumber } from "./fixtures/upsertByRecordNumberWithInvalidRecordNumber";
 import { pattern as upsertByRecordNumberWithInvalidRecordNumber } from "./fixtures/upsertByRecordNumberWithMixedRecordNumber";
 import { pattern as upsertWithNonUpdatableFields } from "./fixtures/upsertWithNonUpdatableFields";
+import { pattern as upsertWithRecordNumber } from "./fixtures/upsertWithRecordNumber";
 
 import { UpsertRecordsError } from "../../upsert/error";
 import type { LocalRecordRepository } from "../../interface";
@@ -86,6 +87,7 @@ describe("upsertRecords", () => {
     upsertByRecordNumberWithMixedRecordNumber,
     upsertByRecordNumberWithInvalidRecordNumber,
     upsertWithNonUpdatableFields,
+    upsertWithRecordNumber,
   ];
 
   it.each(patterns)(

--- a/src/record/import/usecases/add/record.ts
+++ b/src/record/import/usecases/add/record.ts
@@ -19,6 +19,10 @@ export const recordConverter: (
 ) => {
   const newRecord: KintoneRecordForParameter = {};
   for (const fieldSchema of schema.fields) {
+    // Ignore a Record Number field
+    if (fieldSchema.type === "RECORD_NUMBER") {
+      continue;
+    }
     if (!(fieldSchema.code in record.data)) {
       if (skipMissingFields) {
         continue;

--- a/src/record/import/usecases/add/record.ts
+++ b/src/record/import/usecases/add/record.ts
@@ -19,10 +19,6 @@ export const recordConverter: (
 ) => {
   const newRecord: KintoneRecordForParameter = {};
   for (const fieldSchema of schema.fields) {
-    // Ignore a Record Number field
-    if (fieldSchema.type === "RECORD_NUMBER") {
-      continue;
-    }
     if (!(fieldSchema.code in record.data)) {
       if (skipMissingFields) {
         continue;

--- a/src/record/import/usecases/upsert.ts
+++ b/src/record/import/usecases/upsert.ts
@@ -103,6 +103,8 @@ const convertToKintoneRecordForUpdate = async (
 ): Promise<KintoneRecordForUpdateParameter[]> => {
   const { attachmentsDir, skipMissingFields } = options;
 
+  const updateKeyField = updateKey.getUpdateKeyField();
+
   const kintoneRecords: KintoneRecordForUpdateParameter[] = [];
   for (const record of records) {
     const kintoneRecord = await recordConverter(
@@ -116,7 +118,6 @@ const convertToKintoneRecordForUpdate = async (
         })
     );
 
-    const updateKeyField = updateKey.getUpdateKeyField();
     const updateKeyValue = updateKey.findUpdateKeyValueFromRecord(record);
 
     // Delete update key field
@@ -160,7 +161,6 @@ const convertToKintoneRecordForAdd = async (
   }
 ): Promise<KintoneRecordForParameter[]> => {
   const { attachmentsDir, skipMissingFields } = options;
-  const updateKeyField = updateKey.getUpdateKeyField();
 
   const kintoneRecords: KintoneRecordForParameter[] = [];
   for (const record of records) {
@@ -174,10 +174,6 @@ const convertToKintoneRecordForAdd = async (
           skipMissingFields,
         })
     );
-
-    if (updateKeyField.type === "RECORD_NUMBER") {
-      delete kintoneRecord[updateKeyField.code];
-    }
 
     kintoneRecords.push(kintoneRecord);
   }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Currently, importing (add/upsert) records with a Record Number field fails.
On GUI CSV import, a Record Number field in CSV is ignored and importing is performed successfully.

## What

<!-- What is a solution you want to add? -->

1. Remove a Record Number field from records when upserting

## How to test

<!-- How can we test this pull request? -->

Using CSV that includes a Record Number field

```csv
"recordNumber",uniqueKey,"text"
"1","record1","existing data 1"
"2","record2","existing data 2"
"3","record3","new data"
```

Execute import command

```shell
## upsert: The Record number field is ignored, and importing finishes successfully
node  ./cli.js record import --app $APP_ID --file-path ./records.csv --update-key uniqueKey

## add: The Record number field is still evaluated and causes an error
node ./cli.js record import --app $APP_ID --file-path ./records.csv
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
