### PR TITLE
fix: allow Date field format is yyyy/mm/dd

### DIFF
--- a/src/record/import/repositories/parsers/parseCsv/__tests__/fieldValue.test.ts
+++ b/src/record/import/repositories/parsers/parseCsv/__tests__/fieldValue.test.ts
@@ -86,6 +86,10 @@ const patterns: Array<{
     input: { type: "DATE", value: "2012-01-11" },
     expected: { value: "2012-01-11" },
   },
+  {
+    input: { type: "DATE", value: "2012/01/11" },
+    expected: { value: "2012-01-11" },
+  },
   { input: { type: "DATE", value: "" }, expected: { value: "" } },
   { input: { type: "TIME", value: "11:30" }, expected: { value: "11:30" } },
   { input: { type: "TIME", value: "" }, expected: { value: "" } },

--- a/src/record/import/repositories/parsers/parseCsv/fieldValue.ts
+++ b/src/record/import/repositories/parsers/parseCsv/fieldValue.ts
@@ -18,12 +18,13 @@ export const convertFieldValue = ({
     case "RICH_TEXT":
     case "LINK":
     case "DROP_DOWN":
-    case "DATE":
     case "DATETIME":
     case "TIME":
     case "UPDATED_TIME":
     case "CREATED_TIME":
       return { value };
+    case "DATE":
+      return { value: value.replace(/\//g, "-") };
     case "CREATOR":
     case "MODIFIER":
       return {


### PR DESCRIPTION
## Why
User can import data into Date field even if the data format is "yyyy/mm/dd".

## What
Convert yyyy/mm/dd format into yyyy-mm-dd before importing.

## How to test
`yarn build && yarn test`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `yarn lint` and `yarn test` on the root directory.
