### PR TITLE
ci: use licensed v4 on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: jonabc/setup-licensed@d6b3a6f7058c2b40c06d205e13e15c2418977566 # renovate: tag=v1.1.4
         with:
-          version: '3.x'
+          version: '4.x'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
     needs: release
     if: ${{ needs.release.outputs.release_created }}
     steps:
+      # setup ruby environment before running jonabc/setup-licensed
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+
       - uses: jonabc/setup-licensed@d6b3a6f7058c2b40c06d205e13e15c2418977566 # renovate: tag=v1.1.4
         with:
           version: '4.x'


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

The release workflow failed while generating a NOTICE file with a licensed.

https://github.com/kintone/cli-kintone/actions/runs/5596167103/jobs/10232877326#step:7:340

I found that this error happen with licensed v3 and not with licensed v4

https://github.com/kintone/cli-kintone/pull/403

## What

<!-- What is a solution you want to add? -->

- [x] use licensed v4 on release workflow

## How to test

<!-- How can we test this pull request? -->

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
