### PR TITLE
feat: specifying socket timeout

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -74,6 +74,7 @@ describe("api", () => {
   const PROXY_USERNAME = "proxyUser";
   const PROXY_PASSWORD = "proxyPass";
   const HTTPS_PROXY_WITH_AUTHN = `http://${PROXY_USERNAME}:${PROXY_PASSWORD}@proxy.example.com:3128`;
+  const DEFAULT_SOCKET_TIMEOUT = 60000;
 
   it("should pass username and password to the apiClient correctly", () => {
     const apiClient = buildRestAPIClient({
@@ -91,6 +92,7 @@ describe("api", () => {
       userAgent: expectedUa,
       httpsAgent: new https.Agent(),
       proxy: false,
+      socketTimeout: DEFAULT_SOCKET_TIMEOUT,
     });
   });
 
@@ -114,6 +116,7 @@ describe("api", () => {
       userAgent: expectedUa,
       httpsAgent: new https.Agent(),
       proxy: false,
+      socketTimeout: DEFAULT_SOCKET_TIMEOUT,
     });
   });
 
@@ -129,6 +132,7 @@ describe("api", () => {
       userAgent: expectedUa,
       httpsAgent: new https.Agent(),
       proxy: false,
+      socketTimeout: DEFAULT_SOCKET_TIMEOUT,
     });
   });
 
@@ -149,6 +153,7 @@ describe("api", () => {
       userAgent: expectedUa,
       httpsAgent: new https.Agent(),
       proxy: false,
+      socketTimeout: DEFAULT_SOCKET_TIMEOUT,
     });
   });
 
@@ -176,6 +181,7 @@ describe("api", () => {
       userAgent: expectedUa,
       httpsAgent: new https.Agent(),
       proxy: false,
+      socketTimeout: DEFAULT_SOCKET_TIMEOUT,
     });
   });
   it("should pass information of client certificate to the apiClient correctly", () => {
@@ -199,6 +205,7 @@ describe("api", () => {
         passphrase: PFX_FILE_PASSWORD,
       }),
       proxy: false,
+      socketTimeout: DEFAULT_SOCKET_TIMEOUT,
     });
   });
   it("should pass information of proxy server to the apiClient correctly", () => {
@@ -222,6 +229,7 @@ describe("api", () => {
         port: "3128",
       }),
       proxy: false,
+      socketTimeout: DEFAULT_SOCKET_TIMEOUT,
     });
   });
   it("should pass information of client certificate and proxy server to the apiClient correctly", () => {
@@ -249,6 +257,7 @@ describe("api", () => {
         passphrase: PFX_FILE_PASSWORD,
       }),
       proxy: false,
+      socketTimeout: DEFAULT_SOCKET_TIMEOUT,
     });
   });
 
@@ -279,6 +288,7 @@ describe("api", () => {
         },
       }),
       proxy: false,
+      socketTimeout: DEFAULT_SOCKET_TIMEOUT,
     });
   });
 });

--- a/src/kintone/client.ts
+++ b/src/kintone/client.ts
@@ -18,6 +18,8 @@ export type RestAPIClientOptions = {
   httpsProxy?: string;
 };
 
+const DEFAULT_SOCKET_TIMEOUT = 60000;
+
 const buildAuthParam = (options: RestAPIClientOptions) => {
   const passwordAuthParam = {
     username: options.username,
@@ -103,5 +105,6 @@ export const buildRestAPIClient = (options: RestAPIClientOptions) => {
       pfxFilePath: options.pfxFilePath,
       pfxFilePassword: options.pfxFilePassword,
     }),
+    socketTimeout: DEFAULT_SOCKET_TIMEOUT,
   });
 };

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -55,6 +55,7 @@ export abstract class CliKintoneError extends Error {
   }
 
   private _isNetworkError(error: unknown): error is NetworkError {
+    // TODO: once @kintone/rest-api-client officially exports the socket timeout error, we can use it instead.
     return (
       typeof error === "object" &&
       error !== null &&

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -26,7 +26,10 @@ export abstract class CliKintoneError extends Error {
       return this._toStringKintoneAllRecordsError(this.cause);
     } else if (this.cause instanceof KintoneRestAPIError) {
       return this._toStringKintoneRestAPIError(this.cause);
+    } else if (this._networkError(this.cause)) {
+      return this._toStringNetworkError(this.cause);
     }
+
     return this.cause + "\n";
   }
 
@@ -47,6 +50,17 @@ export abstract class CliKintoneError extends Error {
       default:
         return `${error.message}\n`;
     }
+  }
+
+  private _networkError(error: any): boolean {
+    return error && error.code === "ECONNABORTED";
+  }
+
+  private _toStringNetworkError(error: any): string {
+    let errorMessage = `[${error.code}] ${error.message}\n`;
+    errorMessage += "The cli-kintone aborted due to a network error.\n";
+    errorMessage += "Please check your network connection.\n";
+    return errorMessage;
   }
 
   toString(): string {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -3,6 +3,8 @@ import {
   KintoneRestAPIError,
 } from "@kintone/rest-api-client";
 
+type NetworkError = { code?: string; message?: string };
+
 export abstract class CliKintoneError extends Error {
   readonly message: string;
   readonly detail: string = "";
@@ -52,11 +54,16 @@ export abstract class CliKintoneError extends Error {
     }
   }
 
-  private _networkError(error: any): boolean {
-    return error && error.code === "ECONNABORTED";
+  private _networkError(error: unknown): error is NetworkError {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ECONNABORTED"
+    );
   }
 
-  private _toStringNetworkError(error: any): string {
+  private _toStringNetworkError(error: NetworkError): string {
     let errorMessage = `[${error.code}] ${error.message}\n`;
     errorMessage += "The cli-kintone aborted due to a network error.\n";
     errorMessage += "Please check your network connection.\n";

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -28,7 +28,7 @@ export abstract class CliKintoneError extends Error {
       return this._toStringKintoneAllRecordsError(this.cause);
     } else if (this.cause instanceof KintoneRestAPIError) {
       return this._toStringKintoneRestAPIError(this.cause);
-    } else if (this._networkError(this.cause)) {
+    } else if (this._isNetworkError(this.cause)) {
       return this._toStringNetworkError(this.cause);
     }
 
@@ -54,7 +54,7 @@ export abstract class CliKintoneError extends Error {
     }
   }
 
-  private _networkError(error: unknown): error is NetworkError {
+  private _isNetworkError(error: unknown): error is NetworkError {
     return (
       typeof error === "object" &&
       error !== null &&


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

When the user cannot execute cli-kintone caused of the user's network error, cli-kintone should finish the process and show the error without waiting time.

## What

- [x] Specifying socket timeout. The default value is 60 seconds

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
