### PR TITLE
fix: making false the default value of the delete command prompt

### DIFF
--- a/src/cli/record/delete.ts
+++ b/src/cli/record/delete.ts
@@ -144,7 +144,7 @@ const handler = async (args: Args) => {
       name: FORCE_DELETE_KEY,
       type: "confirm",
       message: "Are you sure want to delete records?",
-      default: true,
+      default: false,
     },
   ];
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Making false the default value of the delete command prompt
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Change default value from `true` to `false`
<!-- What is a solution you want to add? -->

## How to test
- Run `delete` command and check the default answer
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
