### PR TITLE
build: add packageManager to package.json and remove fixed version in github action workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.6.5
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -20,8 +20,6 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.6.5
 
       - uses: actions/setup-node@v3
         with:
@@ -55,8 +53,6 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.6.5
 
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.6.5
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.6.5
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.6.5
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/yamory.yml
+++ b/.github/workflows/yamory.yml
@@ -13,8 +13,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: 8.6.5
 
       - uses: actions/setup-node@v3
         with:

--- a/package.json
+++ b/package.json
@@ -87,5 +87,6 @@
     "iconv-lite": "^0.6.3",
     "inquirer": "^8.2.5",
     "yargs": "^17.7.2"
-  }
+  },
+  "packageManager": "pnpm@8.6.10"
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Ignore warning when using other version of `pnpm`, that caused by lack of `packageManager` option in package.json
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Add `packageManager` option in  package.json
- Remove fix version of pnpm in github action workflows
<!-- What is a solution you want to add? -->

## How to test
- `pnpm install` without warning when using other pnpm version
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
