### PR TITLE
ci: trigger CI checks for release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,20 @@ on:
 jobs:
   release:
     name: Create draft release
-    permissions:
-      contents: write
-      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     steps:
+      - uses: cybozu/octoken-action@v1
+        id: create-iat
+        with:
+          github_app_id: ${{ secrets.RELEASE_GITHUB_APP_ID}}
+          github_app_private_key: ${{ secrets.RELEASE_GITHUB_APP_KEY }}
       - uses: google-github-actions/release-please-action@ca6063f4ed81b55db15b8c42d1b6f7925866342d # v3
         id: release
         with:
+          token: ${{ steps.create-iat.outputs.token }}
           command: manifest
 
   rename:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

CI Checks do not run when the release pull request is created/updated.

## What

- [x] After the release pull request is created/updated, the CI Check should be run

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
