### PR TITLE
chore: Update the lint command to forbid new warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:ci": "jest --runInBand",
     "test:e2e": "cucumber-js",
     "lint": "run-p -l lint:*",
-    "lint:eslint": "eslint --ext .js,.mjs,.cjs,.ts,.mts,.cts ./",
+    "lint:eslint": "eslint --ext .js,.mjs,.cjs,.ts,.mts,.cts ./ --max-warnings 0",
     "lint:prettier": "prettier --check '**/*.{json,md,yml,yaml}'",
     "fix": "run-p fix:*",
     "fix:lint": "run-s 'lint:eslint --fix'",


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- prevent new ESLint warnings/errors

<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Add --max-warnings 0 to eslint script

<!-- What is a solution you want to add? -->

## How to test
- `pnpm lint`

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
