### PR TITLE
feat: Support new log event levels (debug and fatal)

### DIFF
--- a/src/record/import/usecases/__tests__/add/progress.test.ts
+++ b/src/record/import/usecases/__tests__/add/progress.test.ts
@@ -7,6 +7,7 @@ const mockLogger: Logger = {
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
+  fatal: jest.fn(),
 };
 
 describe("ProgressLogger", () => {

--- a/src/utils/__tests__/log.test.ts
+++ b/src/utils/__tests__/log.test.ts
@@ -1,0 +1,29 @@
+import type { Logger } from "../log";
+import { logger } from "../log";
+
+describe("logger", () => {
+  const patternTest = [
+    ["INFO", "info"],
+    ["WARN", "warn"],
+    ["ERROR", "error"],
+    ["DEBUG", "debug"],
+    ["FATAL", "fatal"],
+  ];
+  it.each(patternTest)(
+    `should show the %s log when calling logger with %s level`,
+    (logDisplay, logLevel) => {
+      const consoleMock = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {
+          return true;
+        });
+
+      logger[logLevel as keyof Logger]("This is an example message.");
+
+      expect(consoleMock).toHaveBeenCalledTimes(1);
+      expect(consoleMock).toHaveBeenCalledWith(
+        expect.stringMatching(`${logDisplay}(.*) This is an example message.`),
+      );
+    },
+  );
+});

--- a/src/utils/__tests__/log.test.ts
+++ b/src/utils/__tests__/log.test.ts
@@ -2,11 +2,14 @@ import type { Logger } from "../log";
 import { logger } from "../log";
 
 describe("logger", () => {
+  const mockDate = new Date(0);
+  const spy = jest.spyOn(global, "Date").mockImplementation(() => mockDate);
+
   const patternTest = [
+    ["DEBUG", "debug"],
     ["INFO", "info"],
     ["WARN", "warn"],
     ["ERROR", "error"],
-    ["DEBUG", "debug"],
     ["FATAL", "fatal"],
   ];
   it.each(patternTest)(
@@ -22,8 +25,17 @@ describe("logger", () => {
 
       expect(consoleMock).toHaveBeenCalledTimes(1);
       expect(consoleMock).toHaveBeenCalledWith(
-        expect.stringMatching(`${logDisplay}(.*) This is an example message.`),
+        expect.stringMatching(
+          new RegExp(
+            `\\[1970-01-01T00:00:00.000Z] (.*)${logDisplay}(.*): This is an example message.`,
+          ),
+        ),
       );
     },
   );
+
+  afterAll(() => {
+    spy.mockReset();
+    spy.mockRestore();
+  });
 });

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -4,14 +4,19 @@ import { CliKintoneError } from "./error";
 const currentISOString = () => new Date().toISOString();
 
 export type Logger = {
+  debug: (message: any) => void;
   info: (message: any) => void;
   warn: (message: any) => void;
   error: (message: any) => void;
-  debug: (message: any) => void;
   fatal: (message: any) => void;
 };
 
 export const logger: Logger = {
+  debug: (message: any) => {
+    const prefix = `[${currentISOString()}] ${chalkStderr.green("DEBUG")}:`;
+    console.error(addPrefixEachLine(message, prefix));
+  },
+
   info: (message: any) => {
     const prefix = `[${currentISOString()}] ${chalkStderr.blue("INFO")}:`;
     console.error(addPrefixEachLine(message, prefix));
@@ -26,11 +31,6 @@ export const logger: Logger = {
     const parsedMessage = parseErrorMessage(message);
     const prefix = `[${currentISOString()}] ${chalkStderr.red("ERROR")}:`;
     console.error(addPrefixEachLine(parsedMessage, prefix));
-  },
-
-  debug: (message: any) => {
-    const prefix = `[${currentISOString()}] ${chalkStderr.green("DEBUG")}:`;
-    console.error(addPrefixEachLine(message, prefix));
   },
 
   fatal: (message: any) => {

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -8,6 +8,7 @@ export type Logger = {
   warn: (message: any) => void;
   error: (message: any) => void;
   debug: (message: any) => void;
+  fatal: (message: any) => void;
 };
 
 export const logger: Logger = {
@@ -28,8 +29,12 @@ export const logger: Logger = {
   },
 
   debug: (message: any) => {
-    return; // TODO: Decide how enable debug log
-    const prefix = `[${currentISOString()}] ${chalkStderr.yellow("DEBUG")}:`;
+    const prefix = `[${currentISOString()}] ${chalkStderr.green("DEBUG")}:`;
+    console.error(addPrefixEachLine(message, prefix));
+  },
+
+  fatal: (message: any) => {
+    const prefix = `[${currentISOString()}] ${chalkStderr.bgRed("FATAL")}:`;
     console.error(addPrefixEachLine(message, prefix));
   },
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Support new log event levels: debug and fatal
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Add more new log level to Logger and customize color follow the level
<!-- What is a solution you want to add? -->

## How to test
- Usage: `logger.debug("test message")` and `logger.fatal("test message")`
- `pnpm test`
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added tests if it is required.
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
