### PR TITLE
feat: Support log config levels

### DIFF
--- a/src/utils/__tests__/log.test.ts
+++ b/src/utils/__tests__/log.test.ts
@@ -5,23 +5,61 @@ describe("logger", () => {
   const mockDate = new Date(0);
   const spy = jest.spyOn(global, "Date").mockImplementation(() => mockDate);
 
-  it('should display correct log when calling logger with "debug" level', () => {
+  it('should display correct log message when calling logger with "debug" level', () => {
     const message = "This is example message";
-    const message1 = `This is first line message\n This is second line message\n`;
+
     const options: { logConfigLevel: LogConfigLevel; printer: Printer } = {
       logConfigLevel: "debug",
       printer: jest.fn(),
     };
     const standardLogger = new StandardLogger(options);
-    standardLogger.debug(message1);
+    standardLogger.debug(message);
 
     const expectedMessage = new RegExp(
-      `\\[${mockDate.toISOString()}] (.*)DEBUG(.*): ${message1}`,
+      `\\[${mockDate.toISOString()}] (.*)DEBUG(.*): ${message}`,
     );
 
     expect(options.printer).toHaveBeenCalledWith(
       expect.stringMatching(expectedMessage),
     );
+  });
+
+  it("should display correct log message with multiple line message", () => {
+    const firstLineMessage = `This is first line message`;
+    const secondLineMessage = `This is second line message`;
+
+    const options: { logConfigLevel: LogConfigLevel; printer: Printer } = {
+      logConfigLevel: "info",
+      printer: jest.fn(),
+    };
+    const standardLogger = new StandardLogger(options);
+    standardLogger.info(`${firstLineMessage}\n${secondLineMessage}`);
+
+    const expectedMessage = new RegExp(
+      `\\[${mockDate.toISOString()}] (.*)INFO(.*): ${firstLineMessage}\n\\[${mockDate.toISOString()}] (.*)INFO(.*): ${secondLineMessage}`,
+    );
+
+    expect(options.printer).toHaveBeenCalledWith(
+      expect.stringMatching(expectedMessage),
+    );
+  });
+
+  it("should display correct log message corresponding log config level", () => {
+    const message = "This is example message";
+    const options: { logConfigLevel: LogConfigLevel; printer: Printer } = {
+      logConfigLevel: "info",
+      printer: jest.fn((text: string) => {
+        return true;
+      }),
+    };
+
+    const standardLogger = new StandardLogger(options);
+    standardLogger.setLogConfigLevel("warn");
+    standardLogger.debug(message);
+    standardLogger.info(message);
+    standardLogger.warn(message);
+    standardLogger.error(message);
+    standardLogger.fatal(message);
   });
 
   afterAll(() => {

--- a/src/utils/__tests__/log.test.ts
+++ b/src/utils/__tests__/log.test.ts
@@ -1,38 +1,28 @@
-import type { Logger } from "../log";
-import { logger } from "../log";
+import type { LogConfigLevel, Logger, Printer } from "../log";
+import { logger, StandardLogger } from "../log";
 
 describe("logger", () => {
   const mockDate = new Date(0);
   const spy = jest.spyOn(global, "Date").mockImplementation(() => mockDate);
 
-  const patternTest = [
-    ["DEBUG", "debug"],
-    ["INFO", "info"],
-    ["WARN", "warn"],
-    ["ERROR", "error"],
-    ["FATAL", "fatal"],
-  ];
-  it.each(patternTest)(
-    `should show the %s log when calling logger with %s level`,
-    (logDisplay, logLevel) => {
-      const consoleMock = jest
-        .spyOn(console, "error")
-        .mockImplementation(() => {
-          return true;
-        });
+  it('should display correct log when calling logger with "debug" level', () => {
+    const message = "This is example message";
+    const message1 = `This is first line message\n This is second line message\n`;
+    const options: { logConfigLevel: LogConfigLevel; printer: Printer } = {
+      logConfigLevel: "debug",
+      printer: jest.fn(),
+    };
+    const standardLogger = new StandardLogger(options);
+    standardLogger.debug(message1);
 
-      logger[logLevel as keyof Logger]("This is an example message.");
+    const expectedMessage = new RegExp(
+      `\\[${mockDate.toISOString()}] (.*)DEBUG(.*): ${message1}`,
+    );
 
-      expect(consoleMock).toHaveBeenCalledTimes(1);
-      expect(consoleMock).toHaveBeenCalledWith(
-        expect.stringMatching(
-          new RegExp(
-            `\\[1970-01-01T00:00:00.000Z] (.*)${logDisplay}(.*): This is an example message.`,
-          ),
-        ),
-      );
-    },
-  );
+    expect(options.printer).toHaveBeenCalledWith(
+      expect.stringMatching(expectedMessage),
+    );
+  });
 
   afterAll(() => {
     spy.mockReset();

--- a/src/utils/__tests__/log.test.ts
+++ b/src/utils/__tests__/log.test.ts
@@ -1,30 +1,53 @@
-import type { LogConfigLevel, Logger, Printer } from "../log";
-import { logger, StandardLogger } from "../log";
+import type { LogConfigLevel, LogEventLevel, Printer } from "../log";
+import { StandardLogger } from "../log";
 
-describe("logger", () => {
+describe("StandardLogger", () => {
   const mockDate = new Date(0);
   const spy = jest.spyOn(global, "Date").mockImplementation(() => mockDate);
+  const patternTest = [
+    ["DEBUG", "debug"],
+    ["INFO", "info"],
+    ["WARN", "warn"],
+    ["ERROR", "error"],
+    ["FATAL", "fatal"],
+  ];
 
-  it('should display correct log message when calling logger with "debug" level', () => {
+  it.each(patternTest)(
+    'should display %s message when calling logger with "%s" level',
+    (logDisplay, logLevel) => {
+      const message = "This is example message";
+
+      const options: { logConfigLevel: LogConfigLevel; printer: Printer } = {
+        logConfigLevel: logLevel as LogConfigLevel,
+        printer: jest.fn(),
+      };
+      const standardLogger = new StandardLogger(options);
+      standardLogger[logLevel as LogEventLevel](message);
+
+      const expectedMessage = new RegExp(
+        `\\[${mockDate.toISOString()}] (.*)${logDisplay}(.*): ${message}`,
+      );
+
+      expect(options.printer).toHaveBeenCalledWith(
+        expect.stringMatching(expectedMessage),
+      );
+    },
+  );
+
+  it("should not display any message when calling logger with 'none' level", () => {
     const message = "This is example message";
 
     const options: { logConfigLevel: LogConfigLevel; printer: Printer } = {
-      logConfigLevel: "debug",
+      logConfigLevel: "none",
       printer: jest.fn(),
     };
     const standardLogger = new StandardLogger(options);
-    standardLogger.debug(message);
+    standardLogger.info(message);
 
-    const expectedMessage = new RegExp(
-      `\\[${mockDate.toISOString()}] (.*)DEBUG(.*): ${message}`,
-    );
-
-    expect(options.printer).toHaveBeenCalledWith(
-      expect.stringMatching(expectedMessage),
-    );
+    expect(options.printer).not.toHaveBeenCalled();
   });
 
-  it("should display correct log message with multiple line message", () => {
+  it("should display the correct log message with multiple lines message", () => {
     const firstLineMessage = `This is first line message`;
     const secondLineMessage = `This is second line message`;
 
@@ -44,22 +67,24 @@ describe("logger", () => {
     );
   });
 
-  it("should display correct log message corresponding log config level", () => {
+  it("should display the correct log message corresponding to the log config level", () => {
     const message = "This is example message";
-    const options: { logConfigLevel: LogConfigLevel; printer: Printer } = {
-      logConfigLevel: "info",
-      printer: jest.fn((text: string) => {
-        return true;
-      }),
+    const options: { logConfigLevel?: LogConfigLevel; printer: Printer } = {
+      printer: jest.fn(),
     };
-
     const standardLogger = new StandardLogger(options);
+    const formatSpy = jest.spyOn(standardLogger as any, "format");
     standardLogger.setLogConfigLevel("warn");
     standardLogger.debug(message);
     standardLogger.info(message);
     standardLogger.warn(message);
     standardLogger.error(message);
     standardLogger.fatal(message);
+
+    expect(formatSpy).toHaveBeenCalledTimes(3);
+    expect(formatSpy.mock.calls[0][0]).toEqual({ level: "warn", message });
+    expect(formatSpy.mock.calls[1][0]).toEqual({ level: "error", message });
+    expect(formatSpy.mock.calls[2][0]).toEqual({ level: "fatal", message });
   });
 
   afterAll(() => {

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -54,7 +54,7 @@ class StandardLogger implements Logger {
   };
 
   private log = (event: LogEvent): void => {
-    if(!this.isPrintable(event)) {
+    if (!this.isPrintable(event)) {
       return;
     }
 
@@ -63,11 +63,13 @@ class StandardLogger implements Logger {
   };
 
   private isPrintable = (event: LogEvent): boolean => {
-    const logConfigLevelMatrix: { [configLevel in LogConfigLevel]: LogEventLevel[] } = {
+    const logConfigLevelMatrix: {
+      [configLevel in LogConfigLevel]: LogEventLevel[];
+    } = {
       debug: ["debug", "info", "warn", "error", "fatal"],
-      info: [ "info", "warn", "error", "fatal"],
+      info: ["info", "warn", "error", "fatal"],
       warn: ["warn", "error", "fatal"],
-      error: [ "error", "fatal"],
+      error: ["error", "fatal"],
       fatal: ["fatal"],
       none: [],
     };
@@ -77,7 +79,7 @@ class StandardLogger implements Logger {
 
   private format = (event: LogEvent): string => {
     const timestamp = new Date().toISOString();
-    const eventLevelLabels: {[level in LogEventLevel]: string} = {
+    const eventLevelLabels: { [level in LogEventLevel]: string } = {
       debug: chalkStderr.green("DEBUG"),
       info: chalkStderr.blue("INFO"),
       warn: chalkStderr.yellow("WARN"),
@@ -94,13 +96,12 @@ class StandardLogger implements Logger {
       .join("\n");
   };
 
-  private print = (text: string): void => {
-    this.printer(text);
+  private print = (message: string): void => {
+    this.printer(message);
   };
 }
 
 export const logger = new StandardLogger();
-
 
 const stringifyMessage = (message: unknown): string => {
   if (message instanceof Error) {

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,43 +1,79 @@
 import { stderr as chalkStderr } from "chalk";
 import { CliKintoneError } from "./error";
 
-const currentISOString = () => new Date().toISOString();
-
-export type Logger = {
+export interface Logger {
   debug: (message: any) => void;
   info: (message: any) => void;
   warn: (message: any) => void;
   error: (message: any) => void;
   fatal: (message: any) => void;
+}
+
+type LogEventLevel = "debug" | "info" | "warn" | "error" | "fatal";
+
+type LogEvent = {
+  level: LogEventLevel;
+  message: any;
 };
 
-export const logger: Logger = {
-  debug: (message: any) => {
-    const prefix = `[${currentISOString()}] ${chalkStderr.green("DEBUG")}:`;
-    console.error(addPrefixEachLine(message, prefix));
-  },
+type LogConfigLevel = "debug" | "info" | "warn" | "error" | "fatal" | "none";
 
-  info: (message: any) => {
-    const prefix = `[${currentISOString()}] ${chalkStderr.blue("INFO")}:`;
-    console.error(addPrefixEachLine(message, prefix));
-  },
+type Printer = (data: any) => void;
 
-  warn: (message: any) => {
-    const prefix = `[${currentISOString()}] ${chalkStderr.yellow("WARN")}:`;
-    console.error(addPrefixEachLine(message, prefix));
-  },
+class StandardLogger implements Logger {
+  private readonly printer: Printer = console.error;
 
-  error: (message: any) => {
-    const parsedMessage = parseErrorMessage(message);
-    const prefix = `[${currentISOString()}] ${chalkStderr.red("ERROR")}:`;
-    console.error(addPrefixEachLine(parsedMessage, prefix));
-  },
+  private logConfigLevel: LogConfigLevel = "info";
 
-  fatal: (message: any) => {
-    const prefix = `[${currentISOString()}] ${chalkStderr.bgRed("FATAL")}:`;
-    console.error(addPrefixEachLine(message, prefix));
-  },
-};
+  constructor(options?: {
+    logConfigLevel?: LogConfigLevel;
+    printer?: Printer;
+  }) {
+    if (options?.printer) {
+      this.printer = options.printer;
+    }
+    if (options?.logConfigLevel) {
+      this.logConfigLevel = options.logConfigLevel;
+    }
+  }
+
+  public debug = (message: any): void => {
+    this.log({ level: "debug", message });
+  };
+  public info = (message: any): void => {
+    this.log({ level: "info", message });
+  };
+  public warn = (message: any): void => {
+    this.log({ level: "warn", message });
+  };
+  public error = (message: any): void => {
+    this.log({ level: "error", message });
+  };
+  public fatal = (message: any): void => {
+    this.log({ level: "fatal", message });
+  };
+
+  private log = (event: LogEvent): void => {
+    const filteredEvent = this.filter(event);
+    if (!filteredEvent) {
+      return;
+    }
+    const text = this.format(filteredEvent);
+    this.print(text);
+  };
+
+  private filter = (event: LogEvent): LogEvent | undefined => {};
+
+  private format = (event: LogEvent): string => {};
+
+  private print = (text: string): void => {
+    this.printer(text);
+  };
+}
+
+export const logger = new StandardLogger();
+
+const currentISOString = () => new Date().toISOString();
 
 const addPrefixEachLine = (message: any, prefix: string): string =>
   ("" + message)
@@ -55,3 +91,32 @@ const parseErrorMessage = (error: unknown): string => {
   }
   return "" + error;
 };
+
+//
+// export const logger: Logger = {
+//   debug: (message: any) => {
+//     const prefix = `[${currentISOString()}] ${chalkStderr.green("DEBUG")}:`;
+//     console.error(addPrefixEachLine(message, prefix));
+//   },
+//
+//   info: (message: any) => {
+//     const prefix = `[${currentISOString()}] ${chalkStderr.blue("INFO")}:`;
+//     console.error(addPrefixEachLine(message, prefix));
+//   },
+//
+//   warn: (message: any) => {
+//     const prefix = `[${currentISOString()}] ${chalkStderr.yellow("WARN")}:`;
+//     console.error(addPrefixEachLine(message, prefix));
+//   },
+//
+//   error: (message: any) => {
+//     const parsedMessage = parseErrorMessage(message);
+//     const prefix = `[${currentISOString()}] ${chalkStderr.red("ERROR")}:`;
+//     console.error(addPrefixEachLine(parsedMessage, prefix));
+//   },
+//
+//   fatal: (message: any) => {
+//     const prefix = `[${currentISOString()}] ${chalkStderr.bgRed("FATAL")}:`;
+//     console.error(addPrefixEachLine(message, prefix));
+//   },
+// };

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -9,18 +9,24 @@ export interface Logger {
   fatal: (message: any) => void;
 }
 
-type LogEventLevel = "debug" | "info" | "warn" | "error" | "fatal";
+export type LogEventLevel = "debug" | "info" | "warn" | "error" | "fatal";
 
-type LogEvent = {
+export type LogEvent = {
   level: LogEventLevel;
   message: any;
 };
 
-type LogConfigLevel = "debug" | "info" | "warn" | "error" | "fatal" | "none";
+export type LogConfigLevel =
+  | "debug"
+  | "info"
+  | "warn"
+  | "error"
+  | "fatal"
+  | "none";
 
-type Printer = (data: any) => void;
+export type Printer = (data: any) => void;
 
-class StandardLogger implements Logger {
+export class StandardLogger implements Logger {
   private readonly printer: Printer = console.error;
 
   private logConfigLevel: LogConfigLevel = "info";
@@ -98,6 +104,10 @@ class StandardLogger implements Logger {
 
   private print = (message: string): void => {
     this.printer(message);
+  };
+
+  public setLogConfigLevel = (logConfigLevel: LogConfigLevel): void => {
+    this.logConfigLevel = logConfigLevel;
   };
 }
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

We want to add more log messages to help users debug.
Lots of logs are noisy in normal usage, so we want to add a function to control log output.

https://github.com/kintone/cli-kintone/pull/485

## What

<!-- What is a solution you want to add? -->

- Support log config level
  - "debug" | "info" | "warn" | "error" | "fatal" | "none"
- The default config level is `info`

The relation between log event levels and log config levels is the following.

![Screen Shot 2023-09-19 16 25 45](https://github.com/kintone/cli-kintone/assets/33759872/8b2ee79b-6f5b-472f-a0e4-6f940f3e1ac8)


## How to test

<!-- How can we test this pull request? -->

```
pnpm test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
