### PR TITLE
test: automate setup and tear down for record export

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -1,7 +1,8 @@
 Feature: cli-kintone export command
 
   Scenario: CliKintoneTest-81 Should return the record contents in CSV format
-    Given The app "$$TEST_KINTONE_APP_ID_FOR_EXPORT" has some records as below:
+    Given The app "$$TEST_KINTONE_APP_ID_FOR_EXPORT" with "$$TEST_KINTONE_API_TOKEN_FOR_DELETE" has no records
+    And The app "$$TEST_KINTONE_APP_ID_FOR_EXPORT" has some records as below:
       | Text   | Number |
       | Alice  | 10     |
       | Bob    | 20     |

--- a/features/export.feature
+++ b/features/export.feature
@@ -1,9 +1,14 @@
 Feature: cli-kintone export command
 
   Scenario: CliKintoneTest-81 Should return the record contents in CSV format
+    Given The app "$$TEST_KINTONE_APP_ID_FOR_EXPORT" has some records as below:
+      | Text   | Number |
+      | Alice  | 10     |
+      | Bob    | 20     |
+      | Jenny  | 30     |
     When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $$TEST_KINTONE_APP_ID_FOR_EXPORT --api-token $$TEST_KINTONE_API_TOKEN_FOR_EXPORT"
     Then I should get the exit code is zero
     And The header row of the output message should match with the pattern: "\"Record_number\",\"Text\",\"Number\""
-    And The output message should match with the pattern: "\"1\",\"Alice\",\"10\""
-    And The output message should match with the pattern: "\"2\",\"Bob\",\"20\""
-    And The output message should match with the pattern: "\"3\",\"Jenny\",\"30\""
+    And The output message should match with the pattern: "\"\d+\",\"Alice\",\"10\""
+    And The output message should match with the pattern: "\"\d+\",\"Bob\",\"20\""
+    And The output message should match with the pattern: "\"\d+\",\"Jenny\",\"30\""

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -1,5 +1,9 @@
 import * as assert from "assert";
-import { execCliKintoneSync, replaceTokenWithEnvVars } from "../ultils/helper";
+import {
+  createCsvFile,
+  execCliKintoneSync,
+  replaceTokenWithEnvVars,
+} from "../ultils/helper";
 import { Given, When, Then } from "../ultils/world";
 
 Given(
@@ -10,6 +14,30 @@ Given(
       throw new Error(`The env variable is missing: ${srcKey}`);
     }
     this.env = { [destKey]: value, ...this.env };
+  },
+);
+
+Given(
+  "The app {string} with {string} has no records",
+  function (appId: string, apiToken: string) {
+    const command = `record delete --app ${appId} --base-url $$TEST_KINTONE_BASE_URL --api-token ${apiToken} --yes`;
+    const response = execCliKintoneSync(replaceTokenWithEnvVars(command));
+    if (response.status !== 0) {
+      throw new Error(`Resetting app failed. Error: \n${response.stderr}`);
+    }
+  },
+);
+
+Given(
+  "The app {string} has some records as below:",
+  async function (appId, table) {
+    const tempFilePath = await createCsvFile(table.raw());
+    const command = `record import --file-path ${tempFilePath} --app ${appId} --base-url $$TEST_KINTONE_BASE_URL --username $$TEST_KINTONE_USERNAME --password $$TEST_KINTONE_PASSWORD`;
+
+    const response = execCliKintoneSync(replaceTokenWithEnvVars(command));
+    if (response.status !== 0) {
+      throw new Error(`Importing CSV failed. Error: \n${response.stderr}`);
+    }
   },
 );
 

--- a/features/step_definitions/setup.ts
+++ b/features/step_definitions/setup.ts
@@ -1,22 +1,4 @@
 import { setWorldConstructor } from "@cucumber/cucumber";
-import { Given, OurWorld } from "../ultils/world";
-import {
-  execCliKintoneSync,
-  replaceTokenWithEnvVars,
-  createCsvFile,
-} from "../ultils/helper";
+import { OurWorld } from "../ultils/world";
 
 setWorldConstructor(OurWorld);
-
-Given(
-  "The app {string} has some records as below:",
-  async function (appId, table) {
-    const tempFilePath = await createCsvFile(table.raw());
-    const command = `record import --file-path ${tempFilePath} --app ${appId} --base-url $$TEST_KINTONE_BASE_URL --username $$TEST_KINTONE_USERNAME --password $$TEST_KINTONE_PASSWORD`;
-
-    const response = execCliKintoneSync(replaceTokenWithEnvVars(command));
-    if (response.status !== 0) {
-      throw new Error(`Importing CSV failed. Error: \n${response.stderr}`);
-    }
-  },
-);

--- a/features/step_definitions/setup.ts
+++ b/features/step_definitions/setup.ts
@@ -1,4 +1,22 @@
 import { setWorldConstructor } from "@cucumber/cucumber";
-import { OurWorld } from "../ultils/world";
+import { Given, OurWorld } from "../ultils/world";
+import {
+  execCliKintoneSync,
+  replaceTokenWithEnvVars,
+  createCsvFile,
+} from "../ultils/helper";
 
 setWorldConstructor(OurWorld);
+
+Given(
+  "The app {string} has some records as below:",
+  async function (appId, table) {
+    const tempFilePath = await createCsvFile(table.raw());
+    const command = `record import --file-path ${tempFilePath} --app ${appId} --base-url $$TEST_KINTONE_BASE_URL --username $$TEST_KINTONE_USERNAME --password $$TEST_KINTONE_PASSWORD`;
+
+    const response = execCliKintoneSync(replaceTokenWithEnvVars(command));
+    if (response.status !== 0) {
+      throw new Error(`Importing CSV failed. Error: \n${response.stderr}`);
+    }
+  },
+);

--- a/features/ultils/helper.ts
+++ b/features/ultils/helper.ts
@@ -47,7 +47,7 @@ export const createCsvFile = async (
   inputCsvObject: string[][],
 ): Promise<string> => {
   const csvContent = inputCsvObject
-    .map((row: any) => row.map((field: any) => `"${field}"`).join(","))
+    .map((row) => row.map((field) => `"${field}"`).join(","))
     .join("\n");
 
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "cli-kintone-"));

--- a/features/ultils/helper.ts
+++ b/features/ultils/helper.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from "child_process";
 import path from "path";
+import fs from "fs/promises";
+import os from "os";
 
 export const execCliKintoneSync = (
   args: string,
@@ -39,4 +41,18 @@ const replacer = (substring: string) => {
     throw new Error(`The env variable is missing: ${key}`);
   }
   return value;
+};
+
+export const createCsvFile = async (
+  inputCsvObject: string[][],
+): Promise<string> => {
+  const csvContent = inputCsvObject
+    .map((row: any) => row.map((field: any) => `"${field}"`).join(","))
+    .join("\n");
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "cli-kintone-"));
+  const tempFilePath = path.join(tempDir, "records.csv");
+  await fs.writeFile(tempFilePath, csvContent);
+
+  return tempFilePath;
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- automate setup and tear-down for export command test cases.
<!-- What is a solution you want to add? -->

## How to test
`pnpm test:e2e`
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
