### PR TITLE
fix: increase the socket timeout value

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -61,7 +61,7 @@ describe("api", () => {
   const PFX_FILE_PATH = "./dummy.pfx";
   const PFX_FILE_PASSWORD = "pfx_password";
   const HTTPS_PROXY = "http://proxy.example.com:3128";
-  const DEFAULT_SOCKET_TIMEOUT = 60000;
+  const DEFAULT_SOCKET_TIMEOUT = 600000;
 
   it("should pass username and password to the apiClient correctly", () => {
     const apiClient = buildRestAPIClient({

--- a/src/kintone/client.ts
+++ b/src/kintone/client.ts
@@ -19,7 +19,7 @@ export type RestAPIClientOptions = {
   httpsProxy?: string;
 };
 
-const DEFAULT_SOCKET_TIMEOUT = 60000;
+const DEFAULT_SOCKET_TIMEOUT = 600000;
 
 const buildAuthParam = (options: RestAPIClientOptions) => {
   const passwordAuthParam = {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Workaround for https://github.com/kintone/cli-kintone/issues/525

## What

- Increase the socket timeout value to 10 minutes (temporary solution).

## How to test

```
$ cat records.csv
"Attachment"
"Attachment-1/1gb"

$ ls -l attachments/Attachment-1/1gb
-rw-r--r-- 1 shinya-u shinya-u 1073741824 Sep 14 05:09 attachments/Attachment-1/1gb

$ cli-kintone record import --base-url https://****kintone.com --app 9 --attachments-dir attachments --file-path records.csv
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
