### PR TITLE
ci: using ubuntu-latest runner for license workflow

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -10,7 +10,7 @@ jobs:
   license-finder:
     name: License Finder
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up License Finder


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

The runner of the license workflow is using the specific version (ubuntu-20.04), not the latest version.

There is no issue with the latest version.

## What

- Use ubuntu-latest runner for license workflow

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
