### PR TITLE
ci: Replace `octoken-action` by `create-github-app-token`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: cybozu/octoken-action@v1
+      - uses: actions/create-github-app-token@v1
         id: create-iat
         with:
           github_app_id: ${{ secrets.RELEASE_GITHUB_APP_ID}}


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Replace deprecated octoken-action with built-in github action (create-github-app-token) to make our tool well maintainance.
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Replace deprecated octoken-action with built-in create-github-app-token in release.yml
<!-- What is a solution you want to add? -->

## How to test
- Demo repo:
https://github.com/tuanpham-playground/js-sdk-create-github-app-token/actions/runs/6571307859/job/17850207216
<!-- How can we test this pull request? -->
    ( check with peter-evans/create-or-update-comment@v3 )
## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
