### PR TITLE
test: refactor replacement token

### DIFF
--- a/features/ultils/helper.ts
+++ b/features/ultils/helper.ts
@@ -41,9 +41,7 @@ const replaceTokenWithEnvVars = (
 ) =>
   input
     .replace(/\$\$[a-zA-Z0-9_]+/g, processEnvReplacer)
-    .replace(/\$[a-zA-Z0-9_]+/g, (substring) =>
-      inputEnvReplacer(substring, envVars),
-    );
+    .replace(/\$[a-zA-Z0-9_]+/g, inputEnvReplacer(envVars));
 
 const processEnvReplacer = (substring: string) => {
   const key = substring.replace("$$", "");
@@ -54,20 +52,19 @@ const processEnvReplacer = (substring: string) => {
   return value;
 };
 
-const inputEnvReplacer = (
-  substring: string,
-  envVars: { [key: string]: string } | undefined,
-) => {
-  if (!envVars) {
-    return substring;
-  }
+const inputEnvReplacer = (envVars: { [key: string]: string } | undefined) => {
+  return (substring: string) => {
+    if (!envVars) {
+      return substring;
+    }
 
-  const key = substring.replace("$", "");
-  const value = envVars[key];
-  if (value === undefined) {
-    throw new Error(`The env variable in input parameter is missing: ${key}`);
-  }
-  return value;
+    const key = substring.replace("$", "");
+    const value = envVars[key];
+    if (value === undefined) {
+      throw new Error(`The env variable in input parameter is missing: ${key}`);
+    }
+    return value;
+  };
 };
 
 export const createCsvFile = async (

--- a/features/ultils/helper.ts
+++ b/features/ultils/helper.ts
@@ -42,19 +42,19 @@ const replaceTokenWithEnvVars = (
   input
     .replace(/\$\$[a-zA-Z0-9_]+/g, processEnvReplacer)
     .replace(/\$[a-zA-Z0-9_]+/g, (substring) =>
-      worldEnvReplacer(substring, envVars),
+      inputEnvReplacer(substring, envVars),
     );
 
 const processEnvReplacer = (substring: string) => {
   const key = substring.replace("$$", "");
   const value = process.env[key];
   if (value === undefined) {
-    throw new Error(`The env variable is missing: ${key}`);
+    throw new Error(`The env variable in process.env is missing: ${key}`);
   }
   return value;
 };
 
-const worldEnvReplacer = (
+const inputEnvReplacer = (
   substring: string,
   envVars: { [key: string]: string } | undefined,
 ) => {
@@ -65,7 +65,7 @@ const worldEnvReplacer = (
   const key = substring.replace("$", "");
   const value = envVars[key];
   if (value === undefined) {
-    throw new Error(`The env variable is missing: ${key}`);
+    throw new Error(`The env variable in input parameter is missing: ${key}`);
   }
   return value;
 };


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

There are different ways to specify environment variables on different platforms.

For Linux/macOS: `$VAR_NAME`

For Windows: `%VAR_NAME%`

Currently, we're using `$VAR_NAME`, and It does not work on Windows.

## What

- The token will be replaced by code, not using ENV Vars.

## How to test

```
pnpm build
pnpm test:e2e
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
