### PR TITLE
test: add CliKintoneTest-78,79,80,82

### DIFF
--- a/features/common.feature
+++ b/features/common.feature
@@ -17,7 +17,7 @@ Feature: common test cases
   Scenario: CliKintoneTest-4 Should return the help description by --help
     When I run the command with args "--help"
     Then I should get the exit code is zero
-    And The output message should match with the pattern: "cli-kintone-(macos|win\.exe|linux) <command>"
+    And   The output message should match with the pattern: "cli-kintone-(macos|win\.exe|linux) <command>"
 
   Scenario: CliKintoneTest-5 Should return the error message when lacking of --base-url option
     When I run the command with args "record export --app 1"

--- a/features/common.feature
+++ b/features/common.feature
@@ -17,7 +17,7 @@ Feature: common test cases
   Scenario: CliKintoneTest-4 Should return the help description by --help
     When I run the command with args "--help"
     Then I should get the exit code is zero
-    And   The output message should match with the pattern: "cli-kintone-(macos|win\.exe|linux) <command>"
+    And The output message should match with the pattern: "cli-kintone-(macos|win\.exe|linux) <command>"
 
   Scenario: CliKintoneTest-5 Should return the error message when lacking of --base-url option
     When I run the command with args "record export --app 1"

--- a/features/export.feature
+++ b/features/export.feature
@@ -1,22 +1,6 @@
 @isolated
 Feature: cli-kintone export command
 
-  Scenario: CliKintoneTest-81 Should return the record contents in CSV format
-    Given The app "app_for_export" has no records
-    And The app "app_for_export" has some records as below:
-      | Text   | Number |
-      | Alice  | 10     |
-      | Bob    | 20     |
-      | Jenny  | 30     |
-    And Load app ID of the app "app_for_export" as env var: "APP_ID"
-    And Load app token of the app "app_for_export" with exact permissions "view" as env var: "API_TOKEN"
-    When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN"
-    Then I should get the exit code is zero
-    And The header row of the output message should match with the pattern: "\"Record_number\",\"Text\",\"Number\""
-    And The output message should match with the pattern: "\"\d+\",\"Alice\",\"10\""
-    And The output message should match with the pattern: "\"\d+\",\"Bob\",\"20\""
-    And The output message should match with the pattern: "\"\d+\",\"Jenny\",\"30\""
-
   Scenario: CliKintoneTest-78 Should return the error message when the user has no privilege to view records
     Given Load app ID of the app "app_for_export" as env var: "APP_ID"
     And Load username and password of the app "app_for_export" with exact permissions "add" as env vars: "USERNAME" and "PASSWORD"
@@ -36,10 +20,10 @@ Feature: cli-kintone export command
     When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN"
     Then I should get the exit code is zero
     And The output message should match with the data below:
-      | Text   | Number |
-      | Alice  | 10     |
-      | Bob    | 20     |
-      | Jenny  | 30     |
+      | Record_number | Text  | Number |
+      | \d+           | Alice | 10     |
+      | \d+           | Bob   | 20     |
+      | \d+           | Jenny | 30     |
 
   Scenario: CliKintoneTest-80 Should return the record contents in CSV format with an invalid --api-token and a valid --username/--password
     Given The app "app_for_export" has no records
@@ -53,11 +37,28 @@ Feature: cli-kintone export command
     When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token INVALID_TOKEN --username $USERNAME --password $PASSWORD"
     Then I should get the exit code is zero
     And The output message should match with the data below:
-      | Text  | Number |
-      | Alice | 10     |
-      | Bob   | 20     |
-      | Jenny | 30     |
+      | Record_number | Text  | Number |
+      | \d+           | Alice | 10     |
+      | \d+           | Bob   | 20     |
+      | \d+           | Jenny | 30     |
 
+  Scenario: CliKintoneTest-81 Should return the record contents in CSV format
+    Given The app "app_for_export" has no records
+    And The app "app_for_export" has some records as below:
+      | Text   | Number |
+      | Alice  | 10     |
+      | Bob    | 20     |
+      | Jenny  | 30     |
+    And Load app ID of the app "app_for_export" as env var: "APP_ID"
+    And Load app token of the app "app_for_export" with exact permissions "view" as env var: "API_TOKEN"
+    When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN"
+    Then I should get the exit code is zero
+    And The header row of the output message should match with the pattern: "\"Record_number\",\"Text\",\"Number\""
+    And The output message should match with the data below:
+      | Record_number | Text  | Number |
+      | \d+           | Alice | 10     |
+      | \d+           | Bob   | 20     |
+      | \d+           | Jenny | 30     |
   Scenario: CliKintoneTest-82 Should return the error message when exporting the record with a draft API Token.
     Given Load app ID of the app "app_for_draft_token" as env var: "APP_ID"
     And Load app token of the app "app_for_draft_token" with exact permissions "view" as env var: "DRAFT_API_TOKEN"

--- a/features/export.feature
+++ b/features/export.feature
@@ -35,7 +35,7 @@ Feature: cli-kintone export command
     And Load app token of the app "app_in_space" with exact permissions "view" as env var: "API_TOKEN"
     When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN"
     Then I should get the exit code is zero
-    And The app "app_in_space" should has records as below:
+    And The output message should match with the data below:
       | Text   | Number |
       | Alice  | 10     |
       | Bob    | 20     |
@@ -52,7 +52,7 @@ Feature: cli-kintone export command
     And Load username and password of the app "app_for_export" with exact permissions "view" as env vars: "USERNAME" and "PASSWORD"
     When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token INVALID_TOKEN --username $USERNAME --password $PASSWORD"
     Then I should get the exit code is zero
-    And The app "app_for_export" should has records as below:
+    And The output message should match with the data below:
       | Text  | Number |
       | Alice | 10     |
       | Bob   | 20     |

--- a/features/export.feature
+++ b/features/export.feature
@@ -8,7 +8,7 @@ Feature: cli-kintone export command
     Then I should get the exit code is non-zero
     And The output error message should match with the pattern: "ERROR: \[403\] \[CB_NO02\] No privilege to proceed."
 
-  Scenario: CliKintoneTest-79 Should return the record contents of the app in the space in CSV format
+  Scenario: CliKintoneTest-79 Should return the record contents in CSV format of the app in a space
     Given The app "app_in_space" has no records
     And The app "app_in_space" has some records as below:
       | Text   | Number |
@@ -59,6 +59,7 @@ Feature: cli-kintone export command
       | \d+           | Alice | 10     |
       | \d+           | Bob   | 20     |
       | \d+           | Jenny | 30     |
+
   Scenario: CliKintoneTest-82 Should return the error message when exporting the record with a draft API Token.
     Given Load app ID of the app "app_for_draft_token" as env var: "APP_ID"
     And Load app token of the app "app_for_draft_token" with exact permissions "view" as env var: "DRAFT_API_TOKEN"

--- a/features/export.feature
+++ b/features/export.feature
@@ -58,7 +58,7 @@ Feature: cli-kintone export command
       | Bob   | 20     |
       | Jenny | 30     |
 
-  Scenario: CliKintoneTest-82 Should return the error message when exporting the record contents with draft API Token
+  Scenario: CliKintoneTest-82 Should return the error message when exporting the record with a draft API Token.
     Given Load app ID of the app "app_for_draft_token" as env var: "APP_ID"
     And Load app token of the app "app_for_draft_token" with exact permissions "view" as env var: "DRAFT_API_TOKEN"
     When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $DRAFT_API_TOKEN"

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -163,6 +163,17 @@ Then(
 );
 
 Then(
+  "The output message should match with the data below:",
+  async function (table) {
+    const records = table.raw();
+    records.forEach((record: string[]) => {
+      const values = record.map((field: string) => `"${field}"`).join(",");
+      assert.match(this.response.stdout, new RegExp(`${values}`));
+    });
+  },
+);
+
+Then(
   "The header row of the output message should match with the pattern: {string}",
   function (headerRow: string) {
     const reg = new RegExp(`^${headerRow}`);

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -167,7 +167,9 @@ Then(
   async function (table) {
     const records = table.raw();
     records.forEach((record: string[]) => {
-      const values = record.map((field: string) => `"${field}"`).join(",");
+      const values = record
+        .map((field: string) => (field ? `"${field}"` : ""))
+        .join(",");
       assert.match(this.response.stdout, new RegExp(`${values}`));
     });
   },


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Adding export e2e test cases.

## What

- adding test cases to verify --api-token option in export command
  - no privilege
  - app in space
  - with username/password(verify the priority between user/pass and api_token)
  - token in draft app settings

## How to test

```
pnpm build
pnpm test:e2e
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
