### PR TITLE
test: add new test cases for --encoding option of the export command

### DIFF
--- a/features/export.feature
+++ b/features/export.feature
@@ -412,3 +412,36 @@ Feature: cli-kintone export command
     When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --guest-space-id 9999999999999999999"
     Then I should get the exit code is non-zero
     And The output error message should match with the pattern: "\[403] \[CB_NO02] No privilege to proceed"
+
+  Scenario: CliKintoneTest-111 Should return the record contents when exporting the record with --encoding option is utf8.
+    Given The app "app_for_export" has no records
+    And The app "app_for_export" has some records as below:
+      | Text       | Number |
+      | レコード番号 | 10     |
+    And Load app ID of the app "app_for_export" as env var: "APP_ID"
+    And Load app token of the app "app_for_export" with exact permissions "view" as env var: "API_TOKEN"
+    When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --encoding utf8"
+    Then I should get the exit code is zero
+    And The output message with "utf8" encoded should match with the data below:
+      | Record_number | Text       | Number |
+      | \d+           | レコード番号 | 10     |
+
+  Scenario: CliKintoneTest-112 Should return the record contents when exporting the record with --encoding option is sjis.
+    Given The app "app_for_export" has no records
+    And The app "app_for_export" has some records as below:
+      | Text    | Number |
+      | 作成日時 | 10     |
+    And Load app ID of the app "app_for_export" as env var: "APP_ID"
+    And Load app token of the app "app_for_export" with exact permissions "view" as env var: "API_TOKEN"
+    When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --encoding sjis"
+    Then I should get the exit code is zero
+    And The output message with "sjis" encoded should match with the data below:
+      | Record_number | Text        | Number |
+      | \d+           | 作成日時     | 10     |
+
+  Scenario: CliKintoneTest-113 Should return the error message when exporting the record with an unsupported character encoding.
+    Given Load app ID of the app "app_for_export" as env var: "APP_ID"
+    And Load app token of the app "app_for_export" with exact permissions "view" as env var: "API_TOKEN"
+    When I run the command with args "record export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --encoding unsupported_encoding"
+    Then I should get the exit code is non-zero
+    And The output error message should match with the pattern: "Argument: encoding, Given: \"unsupported_encoding\", Choices: \"utf8\", \"sjis\""

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -2,6 +2,8 @@ import * as assert from "assert";
 import { Given, When, Then } from "../utils/world";
 import type { Permission } from "../utils/credentials";
 import { TOKEN_PERMISSIONS } from "../utils/credentials";
+import type { SupportedEncoding } from "../utils/helper";
+import { SUPPORTED_ENCODING } from "../utils/helper";
 
 Given(
   "Load environment variable {string} as {string}",
@@ -166,18 +168,18 @@ When("I run the command with args {string}", function (args: string) {
 });
 
 Then("I should get the exit code is non-zero", function () {
-  assert.notEqual(this.response.status, 0, this.response.stderr);
+  assert.notEqual(this.response.status, 0, this.response.stderr.toString());
 });
 
 Then("I should get the exit code is zero", function () {
-  assert.equal(this.response.status, 0, this.response.stderr);
+  assert.equal(this.response.status, 0, this.response.stderr.toString());
 });
 
 Then(
   "The output error message should match with the pattern: {string}",
   function (errorMessage: string) {
     const reg = new RegExp(errorMessage);
-    assert.match(this.response.stderr, reg);
+    assert.match(this.response.stderr.toString(), reg);
   },
 );
 
@@ -185,7 +187,7 @@ Then(
   "The output message should match with the pattern: {string}",
   function (message: string) {
     const reg = new RegExp(message);
-    assert.match(this.response.stdout, reg);
+    assert.match(this.response.stdout.toString(), reg);
   },
 );
 
@@ -197,7 +199,7 @@ Then(
       const values = record
         .map((field: string) => (field ? `"${field}"` : ""))
         .join(",");
-      assert.match(this.response.stdout, new RegExp(`${values}`));
+      assert.match(this.response.stdout.toString(), new RegExp(`${values}`));
     });
   },
 );
@@ -206,7 +208,7 @@ Then(
   "The header row of the output message should match with the pattern: {string}",
   function (headerRow: string) {
     const reg = new RegExp(`^${headerRow}`);
-    assert.match(this.response.stdout, reg);
+    assert.match(this.response.stdout.toString(), reg);
   },
 );
 

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -2,8 +2,6 @@ import * as assert from "assert";
 import { Given, When, Then } from "../utils/world";
 import type { Permission } from "../utils/credentials";
 import { TOKEN_PERMISSIONS } from "../utils/credentials";
-import type { SupportedEncoding } from "../utils/helper";
-import { SUPPORTED_ENCODING } from "../utils/helper";
 
 Given(
   "Load environment variable {string} as {string}",

--- a/features/step_definitions/delete.ts
+++ b/features/step_definitions/delete.ts
@@ -13,10 +13,10 @@ Then("The app {string} should have no records", function (appKey) {
     throw new Error(`Getting records failed. Error: \n${this.response.stderr}`);
   }
 
-  const actualData = this.response.stdout.slice(
-    this.response.stdout.indexOf("\n") + 1,
-  );
+  const actualData = this.response.stdout
+    .toString()
+    .slice(this.response.stdout.toString().indexOf("\n") + 1);
 
   assert.equal(actualData, "");
-  assert.match(this.response.stderr, new RegExp(NO_RECORDS_WARNING));
+  assert.match(this.response.stderr.toString(), new RegExp(NO_RECORDS_WARNING));
 });

--- a/features/step_definitions/import.ts
+++ b/features/step_definitions/import.ts
@@ -54,7 +54,7 @@ Then(
       const values = record
         .map((field: string) => (field ? `"${field}"` : ""))
         .join(",");
-      assert.match(this.response.stdout, new RegExp(`${values}`));
+      assert.match(this.response.stdout.toString(), new RegExp(`${values}`));
     });
   },
 );
@@ -93,7 +93,7 @@ Then(
           return `"${field}"`;
         })
         .join(",");
-      assert.match(this.response.stdout, new RegExp(`${values}`));
+      assert.match(this.response.stdout.toString(), new RegExp(`${values}`));
     });
   },
 );

--- a/features/step_definitions/version.ts
+++ b/features/step_definitions/version.ts
@@ -5,6 +5,6 @@ Then(
   "I should get the version formatted in {string}",
   function (versionFormat: string) {
     const reg = new RegExp(versionFormat);
-    assert.match(this.response.stdout, reg);
+    assert.match(this.response.stdout.toString(), reg);
   },
 );

--- a/features/utils/helper.ts
+++ b/features/utils/helper.ts
@@ -28,7 +28,6 @@ export const execCliKintoneSync = (
   );
 
   const response = spawnSync(getCliKintoneBinary(), cleanedArgs, {
-    encoding: "utf-8",
     env: options?.env ?? {},
     cwd: options?.cwd ?? process.cwd(),
   });
@@ -144,7 +143,10 @@ export const getRecordNumbers = (appId: string, apiToken: string): string[] => {
     throw new Error(`Getting records failed. Error: \n${response.stderr}`);
   }
 
-  const recordNumbers = response.stdout.replace(/"/g, "").split("\n");
+  const recordNumbers = response.stdout
+    .toString()
+    .replace(/"/g, "")
+    .split("\n");
   recordNumbers.shift();
 
   return recordNumbers.filter((recordNumber) => recordNumber.length > 0);

--- a/features/utils/world.ts
+++ b/features/utils/world.ts
@@ -22,7 +22,7 @@ export class OurWorld extends World {
   public replacements: Replacements = {};
   private _workingDir?: string;
   private _credentials?: Credentials;
-  private _response?: SpawnSyncReturns<string>;
+  private _response?: SpawnSyncReturns<Buffer>;
 
   public get response() {
     if (this._response === undefined) {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Adding export e2e test cases.

## What

- adding test cases to verify `--encoding` option
  - `--encoding` utf8
  - `--encoding` sjis
  - unsupported character code

## How to test

```
pnpm build
pnpm test:e2e
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
