### PR TITLE
test: add new test cases for CliKintoneTest-139-143, 171

### DIFF
--- a/features/delete.feature
+++ b/features/delete.feature
@@ -37,3 +37,103 @@ Feature: cli-kintone delete command
     When I run the command with args "record delete --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --yes"
     Then I should get the exit code is zero
     And The app "app_in_space" should have no records
+
+  Scenario: CliKintoneTest-139 Should delete the records of the app in which the Record_number field code has been changed.
+    Given The app "app_has_changed_record_number" has no records
+    And The app "app_has_changed_record_number" has some records as below:
+      | Text   | Number |
+      | Alice  | 10     |
+      | Lisa   | 20     |
+      | Jenny  | 30     |
+      | Rose   | 40     |
+    And Load the record numbers with field code "Cybozu_record_number" of the app "app_has_changed_record_number" as variable: "RECORD_NUMBERS"
+    And The CSV file "CliKintoneTest-139.csv" with content as below:
+      | Cybozu_record_number |
+      | $RECORD_NUMBERS[0]   |
+      | $RECORD_NUMBERS[1]   |
+    And Load app ID of the app "app_has_changed_record_number" as env var: "APP_ID"
+    And Load app token of the app "app_has_changed_record_number" with exact permissions "view,delete" as env var: "API_TOKEN"
+    When I run the command with args "record delete --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --yes --file-path CliKintoneTest-139.csv"
+    Then I should get the exit code is zero
+    And The app "app_has_changed_record_number" with the record number field code "Cybozu_record_number" should have 2 records
+    And The app "app_has_changed_record_number" should have records as below:
+      | Cybozu_record_number | Text  | Number |
+      | $RECORD_NUMBERS[2]   | Jenny | 30     |
+      | $RECORD_NUMBERS[3]   | Rose  | 40     |
+
+  Scenario: CliKintoneTest-140 Should return the error message when deleting records with non-existent record number.
+    Given The app "app_for_delete" has no records
+    And The CSV file "CliKintoneTest-140.csv" with content as below:
+      | Record_number |
+      | 0             |
+    And Load app ID of the app "app_for_delete" as env var: "APP_ID"
+    And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
+    When I run the command with args "record delete --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --yes --file-path CliKintoneTest-140.csv"
+    Then I should get the exit code is non-zero
+    And The output error message should match with the pattern: "Not exists record number. ID: 0"
+
+  Scenario: CliKintoneTest-141 Should delete the records of the app that have set the App Code, and the Record_number contains the App Code.
+    Given The app "app_has_set_app_code" has no records
+    And The app "app_has_set_app_code" has some records as below:
+      | Text  | Number |
+      | Alice | 10     |
+      | Lisa  | 20     |
+      | Jenny | 30     |
+      | Rose  | 40     |
+    And Load the record numbers of the app "app_has_set_app_code" as variable: "RECORD_NUMBERS"
+    And The CSV file "CliKintoneTest-141.csv" with content as below:
+      | Record_number            |
+      | MyApp-$RECORD_NUMBERS[0] |
+      | MyApp-$RECORD_NUMBERS[1] |
+    And Load app ID of the app "app_has_set_app_code" as env var: "APP_ID"
+    And Load app token of the app "app_has_set_app_code" with exact permissions "view,delete" as env var: "API_TOKEN"
+    When I run the command with args "record delete --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --yes --file-path CliKintoneTest-141.csv"
+    Then I should get the exit code is zero
+    And The app "app_has_set_app_code" should have 2 records
+    And The app "app_has_set_app_code" should have records as below:
+      | Record_number            | Text  | Number |
+      | MyApp-$RECORD_NUMBERS[2] | Jenny | 30     |
+      | MyApp-$RECORD_NUMBERS[3] | Rose  | 40     |
+
+  Scenario: CliKintoneTest-142 Should delete the records of the app that have set the App Code, and the Record_number does not contain the App Code.
+    Given The app "app_has_set_app_code" has no records
+    And The app "app_has_set_app_code" has some records as below:
+      | Text  | Number |
+      | Alice | 10     |
+      | Lisa  | 20     |
+      | Jenny | 30     |
+      | Rose  | 40     |
+    And Load the record numbers of the app "app_has_set_app_code" as variable: "RECORD_NUMBERS"
+    And The CSV file "CliKintoneTest-142.csv" with content as below:
+      | Record_number            |
+      | $RECORD_NUMBERS[0] |
+      | $RECORD_NUMBERS[1] |
+    And Load app ID of the app "app_has_set_app_code" as env var: "APP_ID"
+    And Load app token of the app "app_has_set_app_code" with exact permissions "view,delete" as env var: "API_TOKEN"
+    When I run the command with args "record delete --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --yes --file-path CliKintoneTest-142.csv"
+    Then I should get the exit code is zero
+    And The app "app_has_set_app_code" should have 2 records
+    And The app "app_has_set_app_code" should have records as below:
+      | Record_number            | Text  | Number |
+      | MyApp-$RECORD_NUMBERS[2] | Jenny | 30     |
+      | MyApp-$RECORD_NUMBERS[3] | Rose  | 40     |
+
+  Scenario: CliKintoneTest-143 Should return the error message when deleting records with incorrect App Code.
+    Given The CSV file "CliKintoneTest-143.csv" with content as below:
+      | Record_number        |
+      | NonExistentAppCode-1 |
+    And Load app ID of the app "app_has_set_app_code" as env var: "APP_ID"
+    And Load app token of the app "app_has_set_app_code" with exact permissions "view,delete" as env var: "API_TOKEN"
+    When I run the command with args "record delete --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --yes --file-path CliKintoneTest-143.csv"
+    Then I should get the exit code is non-zero
+    And The output error message should match with the pattern: "Invalid record number. ID: NonExistentAppCode-1"
+
+  Scenario: CliKintoneTest-171 Should return the error message when the record number field code does not exist in the CSV file.
+    Given The CSV file "CliKintoneTest-171.csv" with content as below:
+      | Text  | Number |
+      | Alice | 10     |
+    And Load app ID of the app "app_for_delete" as env var: "APP_ID"
+    And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
+    When I run the command with args "record delete --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --api-token $API_TOKEN --yes --file-path CliKintoneTest-171.csv"
+    Then I should get the exit code is non-zero
+    And The output error message should match with the pattern: "ERROR: The record number field code \(Record_number\) is not found."

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -46,6 +46,14 @@ Given(
 );
 
 Given(
+  "Load the record numbers with field code {string} of the app {string} as variable: {string}",
+  function (fieldCode: string, appKey: string, destVar: string) {
+    const recordNumbers = this.getRecordNumbersByAppKey(appKey, fieldCode);
+    this.replacements = { [destVar]: recordNumbers, ...this.replacements };
+  },
+);
+
+Given(
   "Load app token of the app {string} with exact permissions {string} as env var: {string}",
   function (appKey: string, permission: string, destEnvVar: string) {
     const permissions = permission

--- a/features/step_definitions/delete.ts
+++ b/features/step_definitions/delete.ts
@@ -5,3 +5,11 @@ Then("The app {string} should have no records", function (appKey) {
   const recordNumbers = this.getRecordNumbersByAppKey(appKey);
   assert.equal(recordNumbers.length, 0, "The app is not empty");
 });
+
+Then(
+  "The app {string} with the record number field code {string} should have {int} records",
+  function (appKey: string, fieldCode: string, numberOfRecords: number) {
+    const recordNumbers = this.getRecordNumbersByAppKey(appKey, fieldCode);
+    assert.equal(recordNumbers.length, numberOfRecords);
+  },
+);

--- a/features/utils/helper.ts
+++ b/features/utils/helper.ts
@@ -137,14 +137,24 @@ const _writeFile = async (
   return fs.writeFile(filePath, content);
 };
 
-export const getRecordNumbers = (appId: string, apiToken: string): string[] => {
-  const command = `record export --app ${appId} --base-url $$TEST_KINTONE_BASE_URL --api-token ${apiToken} --fields Record_number`;
+export const getRecordNumbers = (
+  appId: string,
+  apiToken: string,
+  options: { fieldCode?: string } = {},
+): string[] => {
+  const recordNumberFieldCode = options.fieldCode ?? "Record_number";
+  const command = `record export --app ${appId} --base-url $$TEST_KINTONE_BASE_URL --api-token ${apiToken} --fields ${recordNumberFieldCode}`;
+
   const response = execCliKintoneSync(command);
   if (response.status !== 0) {
     throw new Error(`Getting records failed. Error: \n${response.stderr}`);
   }
 
-  const recordNumbers = response.stdout.replace(/"/g, "").split("\n");
+  const regex = /([a-zA-Z]+\d*)-(\d+)/g;
+  const recordNumbers = response.stdout
+    .replace(regex, (match, appCode, number) => number)
+    .replace(/"/g, "")
+    .split("\n");
   recordNumbers.shift();
 
   return recordNumbers.filter((recordNumber) => recordNumber.length > 0);

--- a/features/utils/world.ts
+++ b/features/utils/world.ts
@@ -163,10 +163,15 @@ export class OurWorld extends World {
     return userCredential;
   }
 
-  public getRecordNumbersByAppKey(appKey: string): string[] {
+  public getRecordNumbersByAppKey(
+    appKey: string,
+    fieldCode?: string,
+  ): string[] {
     const credential = this.getAppCredentialByAppKey(appKey);
     const apiToken = this.getAPITokenByAppAndPermissions(appKey, ["view"]);
-    return getRecordNumbers(credential.appId, apiToken);
+    return getRecordNumbers(credential.appId, apiToken, {
+      fieldCode,
+    });
   }
 
   public replacePlaceholdersInRawDataTables(table: string[][]): string[][] {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Adding delete e2e test cases.

## What

- adding test cases to verify `--file-path` option
  - field code of Record Number (user choice)
  - specified in the CSV, but there is no such record
  - App with user set App Code & Record Number with App Code
  - App with user set App Code & Record Number without App Code
  - App has App Code but different App Code specified in the CSV
  - Record number field code does not exist in the CSV file

## How to test

```
pnpm build
pnpm test:e2e
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
