### PR TITLE
test: add new test cases for testing the interaction mode of the delete command

### DIFF
--- a/features/delete.feature
+++ b/features/delete.feature
@@ -273,6 +273,73 @@ Feature: cli-kintone delete command
     Then I should get the exit code is zero
     And The output error message should match with the pattern: "WARN: The specified app does not have any records."
 
+  Scenario: CliKintoneTest-167 Should not delete the records when specifying "N" in the confirmation prompt.
+    Given Load app ID of the app "app_for_delete" as env var: "APP_ID"
+    And The app "app_for_delete" has no records
+    And The app "app_for_delete" has some records as below:
+      | Text  | Number |
+      | Alice | 10     |
+      | Bob   | 20     |
+      | Jenny | 30     |
+    And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
+    When I run the command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN" then I type "N" and press Enter
+    Then I should get the exit code is zero
+    And The app "app_for_delete" should have 3 records
+    And The app "app_for_delete" should have records as below:
+      | Text  | Number |
+      | Alice | 10     |
+      | Bob   | 20     |
+      | Jenny | 30     |
+
+  Scenario: CliKintoneTest-168 Should delete the records when specifying "Y" in the confirmation prompt.
+    Given Load app ID of the app "app_for_delete" as env var: "APP_ID"
+    And The app "app_for_delete" has no records
+    And The app "app_for_delete" has some records as below:
+      | Text  | Number |
+      | Alice | 10     |
+      | Bob   | 20     |
+      | Jenny | 30     |
+    And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
+    When I run the command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN" then I type "Y" and press Enter
+    Then I should get the exit code is zero
+    And The app "app_for_delete" should have no records
+
+  Scenario: CliKintoneTest-169 Should not delete the records when specifying other than Y, n in the confirmation prompt.
+    Given Load app ID of the app "app_for_delete" as env var: "APP_ID"
+    And The app "app_for_delete" has no records
+    And The app "app_for_delete" has some records as below:
+      | Text  | Number |
+      | Alice | 10     |
+      | Bob   | 20     |
+      | Jenny | 30     |
+    And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
+    When I run the command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN" then I type "abc" and press Enter
+    Then I should get the exit code is zero
+    And The app "app_for_delete" should have 3 records
+    And The app "app_for_delete" should have records as below:
+      | Text  | Number |
+      | Alice | 10     |
+      | Bob   | 20     |
+      | Jenny | 30     |
+
+  Scenario: CliKintoneTest-170 Should not delete the records when pressing Enter (without a specific answer) in the confirmation prompt.
+    Given Load app ID of the app "app_for_delete" as env var: "APP_ID"
+    And The app "app_for_delete" has no records
+    And The app "app_for_delete" has some records as below:
+      | Text  | Number |
+      | Alice | 10     |
+      | Bob   | 20     |
+      | Jenny | 30     |
+    And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
+    When I run the command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN" then press Enter
+    Then I should get the exit code is zero
+    And The app "app_for_delete" should have 3 records
+    And The app "app_for_delete" should have records as below:
+      | Text  | Number |
+      | Alice | 10     |
+      | Bob   | 20     |
+      | Jenny | 30     |
+
   Scenario: CliKintoneTest-171 Should return the error message when the record number field code does not exist in the CSV file.
     Given The CSV file "CliKintoneTest-171.csv" with content as below:
       | Text  | Number |

--- a/features/delete.feature
+++ b/features/delete.feature
@@ -358,7 +358,9 @@ Feature: cli-kintone delete command
       | Bob   | 20     |
       | Jenny | 30     |
     And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
-    When I run the command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN" then I type "N" and press Enter
+    When I run the delete command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
+    And I type "N"
+    And I press Enter
     Then I should get the exit code is zero
     And The app "app_for_delete" should have 3 records
     And The app "app_for_delete" should have records as below:
@@ -376,7 +378,9 @@ Feature: cli-kintone delete command
       | Bob   | 20     |
       | Jenny | 30     |
     And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
-    When I run the command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN" then I type "Y" and press Enter
+    When I run the delete command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
+    And I type "Y"
+    And I press Enter
     Then I should get the exit code is zero
     And The app "app_for_delete" should have no records
 
@@ -389,7 +393,9 @@ Feature: cli-kintone delete command
       | Bob   | 20     |
       | Jenny | 30     |
     And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
-    When I run the command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN" then I type "abc" and press Enter
+    When I run the delete command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
+    And I type "abc"
+    And I press Enter
     Then I should get the exit code is zero
     And The app "app_for_delete" should have 3 records
     And The app "app_for_delete" should have records as below:
@@ -407,7 +413,8 @@ Feature: cli-kintone delete command
       | Bob   | 20     |
       | Jenny | 30     |
     And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
-    When I run the command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN" then press Enter
+    When I run the delete command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
+    And I press Enter
     Then I should get the exit code is zero
     And The app "app_for_delete" should have 3 records
     And The app "app_for_delete" should have records as below:

--- a/features/delete.feature
+++ b/features/delete.feature
@@ -358,7 +358,7 @@ Feature: cli-kintone delete command
       | Bob   | 20     |
       | Jenny | 30     |
     And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
-    When I run the delete command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
+    When I run the command with a prompt with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
     And I type "N"
     And I press Enter
     Then I should get the exit code is zero
@@ -378,7 +378,7 @@ Feature: cli-kintone delete command
       | Bob   | 20     |
       | Jenny | 30     |
     And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
-    When I run the delete command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
+    When I run the command with a prompt with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
     And I type "Y"
     And I press Enter
     Then I should get the exit code is zero
@@ -393,7 +393,7 @@ Feature: cli-kintone delete command
       | Bob   | 20     |
       | Jenny | 30     |
     And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
-    When I run the delete command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
+    When I run the command with a prompt with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
     And I type "abc"
     And I press Enter
     Then I should get the exit code is zero
@@ -413,7 +413,7 @@ Feature: cli-kintone delete command
       | Bob   | 20     |
       | Jenny | 30     |
     And Load app token of the app "app_for_delete" with exact permissions "view,delete" as env var: "API_TOKEN"
-    When I run the delete command with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
+    When I run the command with a prompt with args "record delete --app $APP_ID --base-url $$TEST_KINTONE_BASE_URL --api-token $API_TOKEN"
     And I press Enter
     Then I should get the exit code is zero
     And The app "app_for_delete" should have 3 records

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -173,6 +173,26 @@ When("I run the command with args {string}", function (args: string) {
   this.execCliKintoneSync(args);
 });
 
+When(
+  "I run the command with args {string} then I type {string} and press Enter",
+  function (args: string, input: string) {
+    const interactiveCommand = `echo "${input}"`;
+    this.execCliKintoneWithInteractiveCommand(args, {
+      interactiveCommand: interactiveCommand,
+    });
+  },
+);
+
+When(
+  "I run the command with args {string} then press Enter",
+  function (args: string) {
+    const interactiveCommand: string = `echo ""`;
+    this.execCliKintoneWithInteractiveCommand(args, {
+      interactiveCommand: interactiveCommand,
+    });
+  },
+);
+
 Then("I should get the exit code is non-zero", function () {
   assert.notEqual(this.response.status, 0, this.response.stderr.toString());
 });

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -173,6 +173,20 @@ When("I run the command with args {string}", function (args: string) {
   this.execCliKintoneSync(args);
 });
 
+When("I type {string}", function (userInput) {
+  this.childProcess.stdin.write(userInput);
+});
+
+When("I press Enter", function () {
+  return new Promise<void>((resolve) => {
+    this.childProcess.stdin.write("\n");
+    this.childProcess.stdin.end();
+    this.childProcess.on("close", () => {
+      resolve();
+    });
+  });
+});
+
 Then("I should get the exit code is non-zero", function () {
   assert.notEqual(this.response.status, 0, this.response.stderr.toString());
 });

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -173,26 +173,6 @@ When("I run the command with args {string}", function (args: string) {
   this.execCliKintoneSync(args);
 });
 
-When(
-  "I run the command with args {string} then I type {string} and press Enter",
-  function (args: string, input: string) {
-    const interactiveCommand = `echo ${input}`;
-    this.execCliKintoneWithInteractiveCommand(args, {
-      interactiveCommand: interactiveCommand,
-    });
-  },
-);
-
-When(
-  "I run the command with args {string} then press Enter",
-  function (args: string) {
-    const interactiveCommand: string = `echo ""`;
-    this.execCliKintoneWithInteractiveCommand(args, {
-      interactiveCommand: interactiveCommand,
-    });
-  },
-);
-
 Then("I should get the exit code is non-zero", function () {
   assert.notEqual(this.response.status, 0, this.response.stderr.toString());
 });

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -176,7 +176,7 @@ When("I run the command with args {string}", function (args: string) {
 When(
   "I run the command with args {string} then I type {string} and press Enter",
   function (args: string, input: string) {
-    const interactiveCommand = `echo "${input}"`;
+    const interactiveCommand = `echo ${input}`;
     this.execCliKintoneWithInteractiveCommand(args, {
       interactiveCommand: interactiveCommand,
     });

--- a/features/step_definitions/common.ts
+++ b/features/step_definitions/common.ts
@@ -173,6 +173,13 @@ When("I run the command with args {string}", function (args: string) {
   this.execCliKintoneSync(args);
 });
 
+When(
+  "I run the command with a prompt with args {string}",
+  function (args: string) {
+    this.execCliKintone(args);
+  },
+);
+
 When("I type {string}", function (userInput) {
   this.childProcess.stdin.write(userInput);
 });

--- a/features/step_definitions/delete.ts
+++ b/features/step_definitions/delete.ts
@@ -1,6 +1,5 @@
 import * as assert from "assert";
 import { Then, When } from "../utils/world";
-import { waitUntil } from "../utils/helper";
 
 Then("The app {string} should have no records", function (appKey) {
   const recordNumbers = this.getRecordNumbersByAppKey(appKey);
@@ -23,8 +22,12 @@ When("I type {string}", function (userInput) {
   this.childProcess.stdin.write(userInput);
 });
 
-When("I press Enter", async function () {
-  this.childProcess.stdin.write("\n");
-  this.childProcess.stdin.end();
-  await waitUntil(() => this.childProcess.exitCode !== null);
+When("I press Enter", function () {
+  return new Promise<void>((resolve) => {
+    this.childProcess.stdin.write("\n");
+    this.childProcess.stdin.end();
+    this.childProcess.on("close", () => {
+      resolve();
+    });
+  });
 });

--- a/features/step_definitions/delete.ts
+++ b/features/step_definitions/delete.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { Then, When } from "../utils/world";
+import { Then } from "../utils/world";
 
 Then("The app {string} should have no records", function (appKey) {
   const recordNumbers = this.getRecordNumbersByAppKey(appKey);
@@ -13,7 +13,3 @@ Then(
     assert.equal(recordNumbers.length, numberOfRecords);
   },
 );
-
-When("I run the delete command with args {string}", function (args: string) {
-  this.execCliKintone(args);
-});

--- a/features/step_definitions/delete.ts
+++ b/features/step_definitions/delete.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
-import { Then } from "../utils/world";
+import { Then, When } from "../utils/world";
+import { waitUntil } from "../utils/helper";
 
 Then("The app {string} should have no records", function (appKey) {
   const recordNumbers = this.getRecordNumbersByAppKey(appKey);
@@ -13,3 +14,17 @@ Then(
     assert.equal(recordNumbers.length, numberOfRecords);
   },
 );
+
+When("I run the delete command with args {string}", function (args: string) {
+  this.execCliKintone(args);
+});
+
+When("I type {string}", function (userInput) {
+  this.childProcess.stdin.write(userInput);
+});
+
+When("I press Enter", async function () {
+  this.childProcess.stdin.write("\n");
+  this.childProcess.stdin.end();
+  await waitUntil(() => this.childProcess.exitCode !== null);
+});

--- a/features/step_definitions/delete.ts
+++ b/features/step_definitions/delete.ts
@@ -17,17 +17,3 @@ Then(
 When("I run the delete command with args {string}", function (args: string) {
   this.execCliKintone(args);
 });
-
-When("I type {string}", function (userInput) {
-  this.childProcess.stdin.write(userInput);
-});
-
-When("I press Enter", function () {
-  return new Promise<void>((resolve) => {
-    this.childProcess.stdin.write("\n");
-    this.childProcess.stdin.end();
-    this.childProcess.on("close", () => {
-      resolve();
-    });
-  });
-});

--- a/features/utils/helper.ts
+++ b/features/utils/helper.ts
@@ -212,25 +212,3 @@ export const replacePlaceholders = (
     },
   );
 };
-
-export const waitUntil = (
-  condition: () => any,
-  interval = 1000,
-  timeout = 30000,
-) => {
-  const startTime = Date.now();
-
-  return new Promise<void>((resolve, reject) => {
-    const checkCondition = () => {
-      if (condition()) {
-        resolve();
-      } else if (Date.now() - startTime > timeout) {
-        reject(new Error("Timeout waiting for condition to be met"));
-      } else {
-        setTimeout(checkCondition, interval);
-      }
-    };
-
-    checkCondition();
-  });
-};

--- a/features/utils/world.ts
+++ b/features/utils/world.ts
@@ -1,11 +1,12 @@
-import type { SpawnSyncReturns } from "child_process";
+import type { SpawnSyncReturns, ChildProcessByStdio } from "child_process";
 import type { Credentials, AppCredential, Permission } from "./credentials";
 import * as cucumber from "@cucumber/cucumber";
 import { World } from "@cucumber/cucumber";
-import type { SupportedEncoding, Replacements, ExecOptions } from "./helper";
+import type { SupportedEncoding, Replacements } from "./helper";
 import {
   generateCsvFile,
   execCliKintoneSync,
+  execCliKintone,
   generateFile,
   getRecordNumbers,
   replacePlaceholders,
@@ -16,13 +17,32 @@ import {
   getUserCredentialByUserKey,
   getUserCredentialByAppAndUserPermissions,
 } from "./credentials";
+import type { Writable, Readable } from "node:stream";
+
+type Response = {
+  stdout: Buffer;
+  stderr: Buffer;
+  status: number | null;
+};
 
 export class OurWorld extends World {
   public env: { [key: string]: string } = {};
   public replacements: Replacements = {};
+  private _childProcess?: ChildProcessByStdio<Writable, Readable, Readable>;
   private _workingDir?: string;
   private _credentials?: Credentials;
-  private _response?: SpawnSyncReturns<Buffer>;
+  private _response?: SpawnSyncReturns<Buffer> | Response;
+
+  public get childProcess() {
+    if (this._childProcess === undefined) {
+      throw new Error("No child process found. Please run the command first.");
+    }
+    return this._childProcess;
+  }
+
+  public set childProcess(value) {
+    this._childProcess = value;
+  }
 
   public get response() {
     if (this._response === undefined) {
@@ -73,21 +93,42 @@ export class OurWorld extends World {
     );
   }
 
-  public execCliKintoneWithInteractiveCommand(
-    args: string,
-    options: { interactiveCommand: string },
-  ) {
-    const execOptions: ExecOptions = {
-      env: this.env,
-      cwd: this.workingDir,
-      interactiveCommand: options.interactiveCommand,
-      shell: true,
-    };
+  private resetResponse() {
+    this._response = undefined;
+  }
 
-    this.response = execCliKintoneSync(
+  public execCliKintone(args: string) {
+    this.resetResponse();
+    this.childProcess = execCliKintone(
       replacePlaceholders(args, this.replacements),
-      execOptions,
+      {
+        env: this.env,
+        cwd: this.workingDir,
+      },
     );
+
+    let stdout: Buffer;
+    let stderr: Buffer;
+
+    this.childProcess.stdout.on("data", (data: Buffer) => {
+      stdout = data;
+    });
+
+    this.childProcess.stderr.on("data", (data: Buffer) => {
+      stderr = data;
+    });
+
+    this.childProcess.on("close", (code: number) => {
+      this.response = {
+        stdout: stdout ?? Buffer.from(""),
+        stderr: stderr ?? Buffer.from(""),
+        status: code,
+      };
+    });
+
+    this.childProcess.on("error", (err) => {
+      throw new Error(`Error: ${err.message}`);
+    });
   }
 
   public async generateCsvFile(

--- a/features/utils/world.ts
+++ b/features/utils/world.ts
@@ -93,12 +93,7 @@ export class OurWorld extends World {
     );
   }
 
-  private resetResponse() {
-    this._response = undefined;
-  }
-
   public execCliKintone(args: string) {
-    this.resetResponse();
     this.childProcess = execCliKintone(
       replacePlaceholders(args, this.replacements),
       {

--- a/features/utils/world.ts
+++ b/features/utils/world.ts
@@ -2,7 +2,7 @@ import type { SpawnSyncReturns } from "child_process";
 import type { Credentials, AppCredential, Permission } from "./credentials";
 import * as cucumber from "@cucumber/cucumber";
 import { World } from "@cucumber/cucumber";
-import type { SupportedEncoding, Replacements } from "./helper";
+import type { SupportedEncoding, Replacements, ExecOptions } from "./helper";
 import {
   generateCsvFile,
   execCliKintoneSync,
@@ -70,6 +70,23 @@ export class OurWorld extends World {
         env: this.env,
         cwd: this.workingDir,
       },
+    );
+  }
+
+  public execCliKintoneWithInteractiveCommand(
+    args: string,
+    options: { interactiveCommand: string },
+  ) {
+    const execOptions: ExecOptions = {
+      env: this.env,
+      cwd: this.workingDir,
+      interactiveCommand: options.interactiveCommand,
+      shell: true,
+    };
+
+    this.response = execCliKintoneSync(
+      replacePlaceholders(args, this.replacements),
+      execOptions,
     );
   }
 

--- a/features/utils/world.ts
+++ b/features/utils/world.ts
@@ -31,7 +31,7 @@ export class OurWorld extends World {
   private _childProcess?: ChildProcessByStdio<Writable, Readable, Readable>;
   private _workingDir?: string;
   private _credentials?: Credentials;
-  private _response?: SpawnSyncReturns<Buffer> | Response;
+  private _response?: Response;
 
   public get childProcess() {
     if (this._childProcess === undefined) {
@@ -84,13 +84,19 @@ export class OurWorld extends World {
   }
 
   public execCliKintoneSync(args: string) {
-    this.response = execCliKintoneSync(
+    const res: SpawnSyncReturns<Buffer> = execCliKintoneSync(
       replacePlaceholders(args, this.replacements),
       {
         env: this.env,
         cwd: this.workingDir,
       },
     );
+
+    this.response = {
+      stdout: res.stdout ?? Buffer.from(""),
+      stderr: res.stderr ?? Buffer.from(""),
+      status: res.status,
+    };
   }
 
   public execCliKintone(args: string) {

--- a/features/utils/world.ts
+++ b/features/utils/world.ts
@@ -113,7 +113,7 @@ export class OurWorld extends World {
       stderr = data;
     });
 
-    this.childProcess.on("close", (code: number) => {
+    this.childProcess.on("exit", (code: number) => {
       this.response = {
         stdout: stdout ?? Buffer.from(""),
         stderr: stderr ?? Buffer.from(""),


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Adding delete e2e test cases.

## What

- adding test cases to verify the interactive mode of the delete command
  - specify n, then Enter
  - specify Y, then Enter
  - specify other Y/n, then Enter
  - Enter (without specific answer)

## How to test

```
pnpm build
pnpm test:e2e
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
