### PR TITLE
ci: resolve release-please-action warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
         id: release
         with:
           token: ${{ steps.create-iat.outputs.token }}
-          command: manifest
 
   rename:
     name: Rename release title

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "bootstrap-sha": "6cd3804556cc650b8c6d4a209ddb90555ebde6dc",
   "packages": {
     ".": {
+      "release-type": "node",
       "draft": true,
       "prerelease": false,
       "bump-minor-pre-major": true,

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,6 @@
   "bootstrap-sha": "6cd3804556cc650b8c6d4a209ddb90555ebde6dc",
   "packages": {
     ".": {
-      "release-type": "node",
       "draft": true,
       "prerelease": false,
       "bump-minor-pre-major": true,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

release-please use a manifest config file by default. Therefore, we do not need to specify the `command` option.

## What

- Remove the `command` option.

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
