### PR TITLE
ci: upgrade pnpm/action-setup to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Load test report history
         id: allure-history
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         continue-on-error: true # in case run without branch for GitHub page source
         with:
           ref: gh-pages

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Load test report history
         id: allure-history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         continue-on-error: true # in case run without branch for GitHub page source
         with:
           ref: gh-pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - uses: actions/setup-node@v4
         with:
@@ -75,7 +75,7 @@ jobs:
         os: ${{ fromJSON(needs.get-running-os-for-test-e2e.outputs.os) }}
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/yamory.yml
+++ b/.github/workflows/yamory.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v3
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

There is a new version of pnpm/action-setup v3. This version runs on Nodejs 20.

## What

- Upgrade pnpm/action-setup to v3

## How to test

N/A

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
