### PR TITLE
ci: do not run e2e test for renovate PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
   get-running-os-for-test-e2e:
     name: Get running OS for e2e test
     runs-on: ubuntu-latest
+    if: ${{ ! startsWith(github.ref, 'refs/heads/renovate/') }}
     outputs:
       os: ${{ steps.get-os.outputs.os }}
     steps:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Do not run e2e test for Renovate PR. 
Because most of jobs will be canceled if we have multiple workflows run simultaneously, especially Renovate PRs.
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Check branch name `renovate/**` before running `get-running-os-for-test-e2e` (prerequisite job of e2e test job)
<!-- What is a solution you want to add? -->

## How to test
- demo:
https://github.com/kintone/cli-kintone/actions/runs/8919330902/job/24495345772 
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
