### PR TITLE
ci: do not run e2e and generate report on renovate pr

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   generate-report:
     runs-on: ubuntu-latest
+    if: ${{ ! startsWith(github.ref, 'refs/heads/renovate/') && !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))  }}
     steps:
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
   get-running-os-for-test-e2e:
     name: Get running OS for e2e test
     runs-on: ubuntu-latest
-    if: ${{ ! startsWith(github.ref, 'refs/heads/renovate/') }}
+    if: ${{ ! startsWith(github.ref, 'refs/heads/renovate/') && !(github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/'))  }}
     outputs:
       os: ${{ steps.get-os.outputs.os }}
     steps:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
- Most jobs will be canceled if multiple workflows are run simultaneously, especially Renovate PRs. We need to reduce the number of jobs run in branches.
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- Do not run e2e-test and generate-report job on Renovate PR (pushing and the created PR). 

## How to test
- demo:
https://github.com/kintone/cli-kintone/actions/runs/8919330902/job/24495345772 
<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
