### PR TITLE
feat: support trace log level

### DIFF
--- a/src/record/import/usecases/__tests__/add/progress.test.ts
+++ b/src/record/import/usecases/__tests__/add/progress.test.ts
@@ -7,6 +7,7 @@ const mockLogger: Logger = {
   warn: jest.fn(),
   error: jest.fn(),
   debug: jest.fn(),
+  trace: jest.fn(),
   fatal: jest.fn(),
 };
 

--- a/src/utils/__tests__/log.test.ts
+++ b/src/utils/__tests__/log.test.ts
@@ -5,6 +5,7 @@ describe("StandardLogger", () => {
   const mockDate = new Date(0);
   const spy = jest.spyOn(global, "Date").mockImplementation(() => mockDate);
   const patternTest = [
+    ["TRACE", "trace"],
     ["DEBUG", "debug"],
     ["INFO", "info"],
     ["WARN", "warn"],
@@ -75,6 +76,7 @@ describe("StandardLogger", () => {
     const standardLogger = new StandardLogger(options);
     const formatSpy = jest.spyOn(standardLogger as any, "format");
     standardLogger.setLogConfigLevel("warn");
+    standardLogger.trace(message);
     standardLogger.debug(message);
     standardLogger.info(message);
     standardLogger.warn(message);

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -2,6 +2,7 @@ import { stderr as chalkStderr } from "chalk";
 import { CliKintoneError } from "./error";
 
 export interface Logger {
+  trace: (message: any) => void;
   debug: (message: any) => void;
   info: (message: any) => void;
   warn: (message: any) => void;
@@ -10,6 +11,7 @@ export interface Logger {
 }
 
 export const LOG_CONFIG_LEVELS = <const>[
+  "trace",
   "debug",
   "info",
   "warn",
@@ -20,7 +22,13 @@ export const LOG_CONFIG_LEVELS = <const>[
 
 export type LogConfigLevel = (typeof LOG_CONFIG_LEVELS)[number];
 
-export type LogEventLevel = "debug" | "info" | "warn" | "error" | "fatal";
+export type LogEventLevel =
+  | "trace"
+  | "debug"
+  | "info"
+  | "warn"
+  | "error"
+  | "fatal";
 
 export type LogEvent = {
   level: LogEventLevel;
@@ -44,6 +52,10 @@ export class StandardLogger implements Logger {
     if (options?.logConfigLevel) {
       this.logConfigLevel = options.logConfigLevel;
     }
+  }
+
+  trace(message: any): void {
+    this.log({ level: "trace", message });
   }
 
   debug(message: any): void {
@@ -79,6 +91,7 @@ export class StandardLogger implements Logger {
     const logConfigLevelMatrix: {
       [configLevel in LogConfigLevel]: LogEventLevel[];
     } = {
+      trace: ["trace", "debug", "info", "warn", "error", "fatal"],
       debug: ["debug", "info", "warn", "error", "fatal"],
       info: ["info", "warn", "error", "fatal"],
       warn: ["warn", "error", "fatal"],
@@ -93,6 +106,7 @@ export class StandardLogger implements Logger {
   private format(event: LogEvent): string {
     const timestamp = new Date().toISOString();
     const eventLevelLabels: { [level in LogEventLevel]: string } = {
+      trace: chalkStderr.bgGreen("TRACE"),
       debug: chalkStderr.green("DEBUG"),
       info: chalkStderr.blue("INFO"),
       warn: chalkStderr.yellow("WARN"),


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

Currently, there is no way to print internal process statuses.

## What

- Support trace log level

## How to test

Run command with `--log-level trace`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
