### PR TITLE
chore: change deps commit type from fix to chore

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,6 +6,16 @@
   npm: {
     packageRules: [
       {
+        // set `chore` to the commit for updating deps and devDeps
+        matchPackagePatterns: [
+          "*"
+        ],
+        matchDepTypes: [
+          "devDependencies"
+        ],
+        semanticCommitType: "chore",
+      },
+      {
         // automerge minor updates of devDependencies
         matchPackagePatterns: [
           "*"

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,12 +6,9 @@
   npm: {
     packageRules: [
       {
-        // set `chore` to the commit for updating deps and devDeps
+        // set `chore` to the commit for updating packages
         matchPackagePatterns: [
           "*"
-        ],
-        matchDepTypes: [
-          "devDependencies"
         ],
         semanticCommitType: "chore",
       },


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

The commit type for updating deps is fix, but we don't want to do this because it shows up as Bug Fixes in the release notes.

## What

<!-- What is a solution you want to add? -->

Change the commit type from `fix` to `chore`.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
