### PR TITLE
feat: publish cli-kintone to npm registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - run: pnpm build:artifacts
+      - run: pnpm build:all
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,5 +25,4 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - run: pnpm build
       - run: pnpm lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,5 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - run: pnpm lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,14 +46,11 @@ jobs:
     if: ${{ needs.release.outputs.release_created }}
     steps:
       - uses: actions/checkout@v4
-
       - uses: pnpm/action-setup@v3
-
       - uses: actions/setup-node@v4
         with:
           node-version: "18"
           cache: "pnpm"
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - run: pnpm build:artifacts
@@ -67,7 +64,7 @@ jobs:
             ${GITHUB_WORKSPACE}/artifacts/cli-kintone_v${VERSION}_macos.zip \
             ${GITHUB_WORKSPACE}/artifacts/cli-kintone_v${VERSION}_win.zip
 
-  publish:
+  publish-release:
     name: Publish release
     permissions:
       contents: write
@@ -79,8 +76,27 @@ jobs:
     steps:
       - run: gh release edit ${{ needs.release.outputs.tag_name }} --draft=false
 
+  publish-npm:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: [publish-release]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Configure npm user
+        run: npm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: pnpm build:ts
+      - run: pnpm publish
+
   actions-timeline:
-    needs: [publish]
+    needs: [publish-npm]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,9 @@ jobs:
 
   publish-npm:
     name: Publish to npm
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     needs: [publish-release]
     steps:
@@ -93,7 +96,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: pnpm build:ts
-      - run: pnpm publish
+      - run: pnpm publish --access public
+        env:
+          # https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools
+          NPM_CONFIG_PROVENANCE: true
 
   actions-timeline:
     needs: [publish-npm]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
         run: npm config set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - run: pnpm build:ts
+      - run: pnpm build
       - run: pnpm publish --access public
         env:
           # https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - run: pnpm build:all
+      - run: pnpm build
       - run: pnpm test:ci
       - name: Extract platform
         if: ${{ !cancelled() }}
@@ -83,7 +83,7 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - run: pnpm build:all
+      - run: pnpm build:executables
       - name: Run e2e tests
         env:
           TEST_KINTONE_BASE_URL: ${{ secrets.TEST_KINTONE_BASE_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - run: pnpm build
+      - run: pnpm build:all
       - run: pnpm test:ci
       - name: Extract platform
         if: ${{ !cancelled() }}
@@ -83,7 +83,7 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - run: pnpm build
+      - run: pnpm build:all
       - name: Run e2e tests
         env:
           TEST_KINTONE_BASE_URL: ${{ secrets.TEST_KINTONE_BASE_URL }}

--- a/cli.js
+++ b/cli.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require("./dist/index.js");
+require("./lib/src/cli/main");

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "bin": {
     "cli-kintone": "cli.js"
   },
-  "types": "lib/index.d.ts",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "start": "run-s clean 'build:ts --watch'",
@@ -23,7 +22,7 @@
     "license:analyze": "license-manager analyze -c license-manager.config.js",
     "license:extract": "license-manager extract -c license-manager.config.js -w .",
     "compress": "zx ./scripts/compress-to-zip-file.mjs",
-    "typecheck": "tsc --pretty --noEmit",
+    "typecheck": "tsc --project tsconfig.typecheck.json --pretty --noEmit",
     "test": "jest",
     "test:ci": "pnpm clean:test && jest --runInBand -c jest.config.ci.js",
     "test:e2e": "cucumber-js",
@@ -48,9 +47,9 @@
     "url": "git+https://github.com/kintone/cli-kintone.git"
   },
   "files": [
-    "lib",
-    "dist",
-    "cli.js"
+    "CHANGELOG.md",
+    "cli.js",
+    "dist"
   ],
   "keywords": [
     "kintone"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "start": "run-s clean 'build:ts --watch'",
-    "build": "run-s clean build:ts package",
-    "build:ts": "ncc build ./src/cli/main.ts -m",
-    "build:artifacts": "run-s build license:analyze license:extract compress",
+    "start": "run-s clean:lib 'build:tsc --watch'",
+    "build": "run-s clean:lib build:tsc",
+    "build:all": "run-s build build:artifacts",
+    "build:artifacts": "run-s clean:artifacts build:executables license:analyze license:extract compress",
+    "build:executables": "run-s build:ncc package",
+    "build:tsc": "tsc --build ./tsconfig.build.json",
+    "build:ncc": "ncc build ./src/cli/main.ts -m",
     "package": "pkg ./dist/index.js --compress Brotli -o bin/cli-kintone -t linux,macos,win",
     "license:analyze": "license-manager analyze -c license-manager.config.js",
     "license:extract": "license-manager extract -c license-manager.config.js -w .",
@@ -34,7 +37,9 @@
     "fix": "run-p fix:*",
     "fix:lint": "run-s 'lint:eslint --fix'",
     "fix:prettier": "run-s 'lint:prettier --write'",
-    "clean": "rimraf lib bin artifacts dist",
+    "clean": "run-s clean:lib clean:artifacts clean:test",
+    "clean:lib": "rimraf lib",
+    "clean:artifacts": "rimraf bin artifacts dist",
     "clean:test": "rimraf allure-results allure-report",
     "doc:start": "pnpm --filter ./website start",
     "doc:build": "pnpm --filter ./website build",
@@ -49,7 +54,8 @@
   "files": [
     "CHANGELOG.md",
     "cli.js",
-    "dist"
+    "lib",
+    "!**/*.tsbuildinfo"
   ],
   "keywords": [
     "kintone"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kintone/cli-kintone",
+  "name": "@kintone/cli",
   "version": "1.11.1",
   "publishConfig": {
     "access": "public"
@@ -8,7 +8,7 @@
     "name": "Cybozu, Inc.",
     "url": "https://cybozu.co.jp"
   },
-  "description": "A cli-kintone",
+  "description": "cli-kintone; The CLI tool for importing and exporting Kintone records.",
   "bin": {
     "cli-kintone": "cli.js"
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
+  // tsconfig for compilation
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*", "package.json"],
+  "exclude": ["src/**/__tests__/*", "src/**/*.test.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,10 +16,10 @@
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
      "outDir": "./lib",                        /* Redirect output structure to the directory. */
      "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    "composite": true,                        /* Enable project compilation */
+    // "composite": true,                        /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
+     "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
      "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
@@ -68,8 +68,13 @@
     "forceConsistentCasingInFileNames": true,  /* Disallow inconsistently-cased references to the same file. */
     "resolveJsonModule": true
   },
-  "include": ["src/**/*", "features/**/*", "package.json",
-    "e2e-credentials-schema.json"
-  ],
-  "exclude": ["node_modules"]
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.build.json"
+    },
+    {
+    "path": "./tsconfig.typecheck.json"
+    }
+  ]
 }

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,4 +1,5 @@
 {
+  // tsconfig for type checking and syntax highlight
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "composite": true

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "include": [
+    "src/**/*",
+    "features/**/*",
+    "package.json",
+    "e2e-credentials-schema.json"
+  ]
+}

--- a/website/docs/community/contributing.md
+++ b/website/docs/community/contributing.md
@@ -55,10 +55,40 @@ pnpm build
 
 ### Build
 
+Currently, we have different build processes for the npm package and executables.
+
+To build both of them, run `build:all` command:
+
+```shell
+pnpm build:all
+```
+
+#### Build npm package
+
 Run `build` command:
 
 ```shell
 pnpm build
+```
+
+To build in watch mode, run `start` command:
+
+```shell
+pnpm start
+```
+
+To check behavior, run the entrypoint file directly:
+
+```shell
+./cli.js
+```
+
+#### Build executables
+
+Run `build:artifacts` command:
+
+```shell
+pnpm build:artifacts
 ```
 
 Executables will be generated in `bin` directory.
@@ -68,18 +98,6 @@ bin
 ├── cli-kintone-linux
 ├── cli-kintone-macos
 └── cli-kintone-win.exe
-```
-
-To build in watch mode, run `start` command:
-
-```shell
-pnpm start
-```
-
-In watch mode, only JavaScript output in `dist` directory are updated. So run the entrypoint file directly.
-
-```shell
-node ./cli.js
 ```
 
 ### Testing

--- a/website/docs/guide/index.mdx
+++ b/website/docs/guide/index.mdx
@@ -2,6 +2,9 @@
 sidebar_position: 100
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Getting Started
 
 :::info
@@ -56,17 +59,25 @@ To run cli-kintone, a Kintone subscription with API access is required.
 
 ### Installing
 
-1. Jump to the [Releases](https://github.com/kintone/cli-kintone/releases) page.
-2. Download latest cli-kintone ZIP file and extract it.
+<Tabs>
+    <TabItem value="binary" label="Binary" default>
+        1. Jump to the [Releases](https://github.com/kintone/cli-kintone/releases) page.
+        2. Download latest cli-kintone ZIP file and extract it.
+    </TabItem>
+    <TabItem value="npm" label="npm">
+        Run `npm install` command:
+
+        ```shell
+        npm install @kintone/cli --global
+        ```
+    </TabItem>
+</Tabs>
 
 For more details, see [Installation](./installation) page.
 
 ### Operation check
 
 Run cli-kintone with `--version` option.
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 
 <Tabs>
   <TabItem value="linux-macos" label="Linux/macOS" default>

--- a/website/docs/guide/installation.md
+++ b/website/docs/guide/installation.md
@@ -6,6 +6,25 @@ sidebar_position: 200
 
 This page will help you install cli-kintone.
 
+## From npmjs.com
+
+If you have configured [Node.js](https://nodejs.org/) on your environment, you can use [npm](https://docs.npmjs.com/about-npm) to install cli-kintone.
+It is suitable for use in plugin/customization development or for CI.
+
+Run the following command:
+
+```shell
+npm install @kintone/cli --global
+```
+
+Or to install locally:
+
+```shell
+npm install @kintone/cli
+```
+
+See [@kintone/cli](https://www.npmjs.com/package/@kintone/cli) for more details about our npm package.
+
 ## From binary file
 
 1. Jump to the [Releases](https://github.com/kintone/cli-kintone/releases) page.


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

cli-kintone is mainly used on personal computers or servers by IT administrators,
but also used in plugin/customization development or on CI.

In this PR, we start publishing cli-kintone to npm registry as `@kintone/cli` to provide easier installation with Node.js.

## What

<!-- What is a solution you want to add? -->

- [x] publish cli-kintone to npm on release workflow
- [x] update document site

## How to test

<!-- How can we test this pull request? -->

### Installation test

```shell

## Generate package file
cd cli-kintone
pnpm build
pnpm pack ## kintone-cli-1.11.1.tgz is generated.

mkdir cli-kintone-test
cd cli-kintone-test
npm init

npm install -D kintone-cli-1.11.1.tgz
npx cli-kintone --version # cli-kintone's version will be printed
```

### Publication test

I tested that we can publish the npm package successfully on my playground repository.

- repository: https://github.com/tasshi-playground/demo-publish-node-cli-tool
- CI: https://github.com/tasshi-playground/demo-publish-node-cli-tool/actions/runs/11398487869/job/31715621623#step:7:28
- npm package: https://www.npmjs.com/package/@tasshi/demo-publish-node-cli-tool

![Screen Shot 2024-10-18 15 17 51](https://github.com/user-attachments/assets/59d9b013-b133-4584-aba0-171417032895)

### Checking documentation site

Run `pnpm doc:start` to preview

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
