### PR TITLE
fix: Fixed so that empty strings are not quoted.

### DIFF
--- a/src/record/export/repositories/stringifiers/csvStringifier/index.ts
+++ b/src/record/export/repositories/stringifiers/csvStringifier/index.ts
@@ -25,7 +25,7 @@ export class CsvStringifier implements Stringifier {
       header: true,
       delimiter: SEPARATOR,
       record_delimiter: LINE_BREAK,
-      quoted_match: /^(?!\*$).*$/,
+      quoted_match: /^(?!\*$).+$/,
       quoted_empty: false,
     });
 


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

The behavior of empty cells has changed due to an update to csv-stringify.
Double quotes are now given to empty cells.
https://github.com/kintone/cli-kintone/actions/runs/12022648673/job/33517941330

Pull Request for the cause
https://github.com/adaltas/node-csv/issues/344

## What

<!-- What is a solution you want to add? -->

Change the quoted_match option so that it does not match an empty string.

## How to test

<!-- How can we test this pull request? -->

Confirmed that the E2E test passes.
https://github.com/kintone/cli-kintone/actions/runs/12173755388/job/33954636716

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
