### PR TITLE
feat: retry API request on 5xx errors

### DIFF
--- a/src/record/export/usecases/get.ts
+++ b/src/record/export/usecases/get.ts
@@ -242,14 +242,22 @@ const downloadAndSaveFile: (
         fileKey,
       }),
     {
-      onError: (e, attemptCount, nextDelay) => {
+      onError: (e, attemptCount, toRetry, nextDelay, config) => {
         logger.warn(
           "Failed to download attachment file due to an error on kintone",
         );
         logger.warn(e);
-        logger.warn(
-          `Retrying request after ${nextDelay} milliseconds... (count: ${attemptCount})`,
-        );
+        if (toRetry) {
+          if (attemptCount === config.maxAttempt) {
+            logger.error(
+              `Retry limit reached (count: ${attemptCount}), limit: ${config.maxAttempt}`,
+            );
+          } else {
+            logger.warn(
+              `Retrying request after ${nextDelay} milliseconds... (count: ${attemptCount}, limit: ${config.maxAttempt})`,
+            );
+          }
+        }
       },
       retryCondition: (e: unknown) =>
         e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,

--- a/src/record/export/usecases/get.ts
+++ b/src/record/export/usecases/get.ts
@@ -6,6 +6,7 @@ import type {
   KintoneRecordField,
   KintoneRestAPIClient,
 } from "@kintone/rest-api-client";
+import { KintoneRestAPIError } from "@kintone/rest-api-client";
 
 import path from "path";
 
@@ -14,6 +15,7 @@ import { getAllRecords } from "./get/getAllRecords";
 import type { LocalRecordRepository } from "./interface";
 import { replaceSpecialCharacters } from "../utils/file";
 import { logger } from "../../../utils/log";
+import { retry } from "../../../utils/retry";
 
 export const NO_RECORDS_WARNING =
   "No records exist in the app or match the condition.";
@@ -234,9 +236,26 @@ const downloadAndSaveFile: (
   fileKey: string,
   localFilePath: string,
 ) => Promise<string> = async (apiClient, fileKey, localFilePath) => {
-  const file = await apiClient.file.downloadFile({
-    fileKey,
-  });
+  const file = await retry(
+    () =>
+      apiClient.file.downloadFile({
+        fileKey,
+      }),
+    {
+      onError: (e, attemptCount, nextDelay) => {
+        logger.warn(
+          "Failed to download attachment file due to an error on kintone",
+        );
+        logger.warn(e);
+        logger.warn(
+          `Retrying request after ${nextDelay} milliseconds... (count: ${attemptCount})`,
+        );
+      },
+      retryCondition: (e: unknown) =>
+        e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,
+    },
+  );
+
   return saveFileWithoutOverwrite(localFilePath, file);
 };
 

--- a/src/record/export/usecases/get.ts
+++ b/src/record/export/usecases/get.ts
@@ -246,6 +246,7 @@ const downloadAndSaveFile: (
         logger.warn(
           "Failed to download attachment file due to an error on kintone",
         );
+        logger.warn(`fileKey: ${fileKey}, path: ${localFilePath}`);
         logger.warn(e);
         if (toRetry) {
           if (attemptCount === config.maxAttempt) {

--- a/src/record/import/usecases/add/field.ts
+++ b/src/record/import/usecases/add/field.ts
@@ -65,6 +65,7 @@ const fileFieldProcessor = async (
           logger.warn(
             "Failed to upload attachment file due to an error on kintone",
           );
+          logger.warn(`path: ${fileInfo.localFilePath}`);
           logger.warn(e);
           if (toRetry) {
             if (attemptCount === config.maxAttempt) {

--- a/src/record/import/usecases/add/field.ts
+++ b/src/record/import/usecases/add/field.ts
@@ -3,6 +3,7 @@ import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
 import type * as Fields from "../../types/field";
 import type { FieldSchema } from "../../types/schema";
 import path from "path";
+import { retry } from "../../../../utils/retry";
 
 export const fieldProcessor: (
   apiClient: KintoneRestAPIClient,
@@ -50,11 +51,13 @@ const fileFieldProcessor = async (
     if (!fileInfo.localFilePath) {
       throw new Error("local file path not defined.");
     }
-    const { fileKey } = await apiClient.file.uploadFile({
-      file: {
-        path: path.join(attachmentsDir, fileInfo.localFilePath),
-      },
-    });
+    const { fileKey } = await retry(() =>
+      apiClient.file.uploadFile({
+        file: {
+          path: path.join(attachmentsDir, fileInfo.localFilePath),
+        },
+      }),
+    );
     uploadedList.push({
       fileKey,
     });

--- a/src/record/import/usecases/add/field.ts
+++ b/src/record/import/usecases/add/field.ts
@@ -1,9 +1,11 @@
 import type { KintoneRecordForParameter } from "../../../../kintone/types";
 import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import { KintoneRestAPIError } from "@kintone/rest-api-client";
 import type * as Fields from "../../types/field";
 import type { FieldSchema } from "../../types/schema";
 import path from "path";
 import { retry } from "../../../../utils/retry";
+import { logger } from "../../../../utils/log";
 
 export const fieldProcessor: (
   apiClient: KintoneRestAPIClient,
@@ -51,13 +53,28 @@ const fileFieldProcessor = async (
     if (!fileInfo.localFilePath) {
       throw new Error("local file path not defined.");
     }
-    const { fileKey } = await retry(() =>
-      apiClient.file.uploadFile({
-        file: {
-          path: path.join(attachmentsDir, fileInfo.localFilePath),
+    const { fileKey } = await retry(
+      () =>
+        apiClient.file.uploadFile({
+          file: {
+            path: path.join(attachmentsDir, fileInfo.localFilePath),
+          },
+        }),
+      {
+        onError: (e, attemptCount, nextDelay) => {
+          logger.warn(
+            "Failed to upload attachment file due to an error on kintone",
+          );
+          logger.warn(e);
+          logger.warn(
+            `Retrying request after ${nextDelay} milliseconds... (count: ${attemptCount})`,
+          );
         },
-      }),
+        retryCondition: (e: unknown) =>
+          e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,
+      },
     );
+
     uploadedList.push({
       fileKey,
     });

--- a/src/record/import/usecases/add/field.ts
+++ b/src/record/import/usecases/add/field.ts
@@ -61,14 +61,21 @@ const fileFieldProcessor = async (
           },
         }),
       {
-        onError: (e, attemptCount, nextDelay) => {
+        onError: (e, attemptCount, toRetry, nextDelay, config) => {
           logger.warn(
             "Failed to upload attachment file due to an error on kintone",
           );
           logger.warn(e);
-          logger.warn(
-            `Retrying request after ${nextDelay} milliseconds... (count: ${attemptCount})`,
-          );
+          if (toRetry) {
+            if (attemptCount === config.maxAttempt) {
+              logger.error(
+                `Retry limit reached (count: ${attemptCount}), limit: ${config.maxAttempt}`,
+              );
+            }
+            logger.warn(
+              `Retrying request after ${nextDelay} milliseconds... (count: ${attemptCount}, limit: ${config.maxAttempt})`,
+            );
+          }
         },
         retryCondition: (e: unknown) =>
           e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,

--- a/src/utils/__tests__/retry.test.ts
+++ b/src/utils/__tests__/retry.test.ts
@@ -1,0 +1,85 @@
+import { retry } from "../retry";
+
+describe("retry", () => {
+  it("should return result when given function is resolved", async () => {
+    const maxAttempt = 5;
+    const initialDelay = 100;
+    const maxDelay = 500;
+    const maxJitter = 10;
+
+    const promise = retry(
+      () => {
+        return true;
+      },
+      () => {
+        /* noop */
+      },
+      maxAttempt,
+      initialDelay,
+      maxDelay,
+      maxJitter,
+    );
+    await expect(promise).resolves.toBe(true);
+  });
+
+  it("should throw an error when all retries are failed", async () => {
+    const maxAttempt = 5;
+    const initialDelay = 100;
+    const maxDelay = 500;
+    const maxJitter = 10;
+
+    const promise = retry(
+      () => {
+        throw new Error(`Error`);
+      },
+      () => {
+        /* noop */
+      },
+      maxAttempt,
+      initialDelay,
+      maxDelay,
+      maxJitter,
+    );
+    await expect(promise).rejects.toThrow(new Error(`Error`));
+  });
+
+  it(
+    "should repeat given function after delay on error and return result on resolve",
+    async () => {
+      const maxAttempt = 10;
+      const initialDelay = 100;
+      const maxDelay = 500;
+      const maxJitter = 10;
+
+      const expectedNextDelays = [
+        { min: 100, max: 110 },
+        { min: 200, max: 210 },
+        { min: 400, max: 410 },
+        { min: 500, max: 510 },
+        { min: 500, max: 510 },
+      ];
+      let count = 1;
+      const result = await retry(
+        () => {
+          if (count === 6) {
+            return true;
+          }
+          throw new Error(`Error: ${count}`);
+        },
+        (_, __, nextDelay) => {
+          expect(nextDelay).toBeGreaterThanOrEqual(
+            expectedNextDelays[count - 1].min,
+          );
+          expect(nextDelay).toBeLessThan(expectedNextDelays[count - 1].max);
+          count++;
+        },
+        maxAttempt,
+        initialDelay,
+        maxDelay,
+        maxJitter,
+      );
+      expect(result).toBe(true);
+    },
+    5 * 1000,
+  );
+});

--- a/src/utils/__tests__/retry.test.ts
+++ b/src/utils/__tests__/retry.test.ts
@@ -8,75 +8,151 @@ jest.mock("timers/promises", () => ({
 }));
 
 describe("retry", () => {
-  it("should return result when given function is resolved", async () => {
-    const promise = retry(() => {
-      return true;
+  describe("input sync function", () => {
+    it("should return result when given function is resolved", async () => {
+      const promise = retry(() => {
+        return true;
+      });
+      await expect(promise).resolves.toBe(true);
     });
-    await expect(promise).resolves.toBe(true);
-  });
 
-  it("should throw an error when all retries are failed", async () => {
-    const promise = retry(() => {
-      throw new Error(`Error`);
+    it("should throw an error when all retries are failed", async () => {
+      const promise = retry(() => {
+        throw new Error(`Error`);
+      });
+      await expect(promise).rejects.toThrow(new Error(`Error`));
     });
-    await expect(promise).rejects.toThrow(new Error(`Error`));
-  });
 
-  it("should throw an error when retry conditions are not match", async () => {
-    let count = 0;
-    const promise = retry(
-      () => {
-        throw new Error(`Error: ${count}`);
-      },
-      {
-        onError: () => {
-          count++;
-        },
-        retryCondition: (e) => e instanceof Error && e.message !== "Error: 3",
-      },
-    );
-    await expect(promise).rejects.toThrow(new Error(`Error: 3`));
-  });
-
-  it(
-    "should repeat given function after delay on error and return result on resolve",
-    async () => {
-      const maxAttempt = 10;
-      const initialDelay = 100;
-      const maxDelay = 500;
-      const maxJitter = 10;
-
-      const expectedNextDelays = [
-        { min: 100, max: 110 },
-        { min: 200, max: 210 },
-        { min: 400, max: 410 },
-        { min: 500, max: 510 },
-        { min: 500, max: 510 },
-      ];
-      let count = 1;
-      const result = await retry(
+    it("should throw an error when retry conditions are not match", async () => {
+      let count = 0;
+      const promise = retry(
         () => {
-          if (count === 6) {
-            return true;
-          }
           throw new Error(`Error: ${count}`);
         },
         {
-          onError: (_, __, ___, nextDelay) => {
-            expect(nextDelay).toBeGreaterThanOrEqual(
-              expectedNextDelays[count - 1].min,
-            );
-            expect(nextDelay).toBeLessThan(expectedNextDelays[count - 1].max);
+          onError: () => {
             count++;
           },
-          maxAttempt,
-          initialDelay,
-          maxDelay,
-          maxJitter,
+          retryCondition: (e) => e instanceof Error && e.message !== "Error: 3",
         },
       );
-      expect(result).toBe(true);
-    },
-    5 * 1000,
-  );
+      await expect(promise).rejects.toThrow(new Error(`Error: 3`));
+    });
+
+    it(
+      "should repeat given function after delay on error and return result on resolve",
+      async () => {
+        const maxAttempt = 10;
+        const initialDelay = 100;
+        const maxDelay = 500;
+        const maxJitter = 10;
+
+        const expectedNextDelays = [
+          { min: 100, max: 110 },
+          { min: 200, max: 210 },
+          { min: 400, max: 410 },
+          { min: 500, max: 510 },
+          { min: 500, max: 510 },
+        ];
+        let count = 1;
+        const result = await retry(
+          () => {
+            if (count === 6) {
+              return true;
+            }
+            throw new Error(`Error: ${count}`);
+          },
+          {
+            onError: (_, __, ___, nextDelay) => {
+              expect(nextDelay).toBeGreaterThanOrEqual(
+                expectedNextDelays[count - 1].min,
+              );
+              expect(nextDelay).toBeLessThan(expectedNextDelays[count - 1].max);
+              count++;
+            },
+            maxAttempt,
+            initialDelay,
+            maxDelay,
+            maxJitter,
+          },
+        );
+        expect(result).toBe(true);
+      },
+      5 * 1000,
+    );
+  });
+
+  describe("input async function", () => {
+    it("should return result when given function is resolved", async () => {
+      const promise = retry(async () => {
+        return true;
+      });
+      await expect(promise).resolves.toBe(true);
+    });
+
+    it("should throw an error when all retries are failed", async () => {
+      const promise = retry(async () => {
+        throw new Error(`Error`);
+      });
+      await expect(promise).rejects.toThrow(new Error(`Error`));
+    });
+
+    it("should throw an error when retry conditions are not match", async () => {
+      let count = 0;
+      const promise = retry(
+        async () => {
+          throw new Error(`Error: ${count}`);
+        },
+        {
+          onError: () => {
+            count++;
+          },
+          retryCondition: (e) => e instanceof Error && e.message !== "Error: 3",
+        },
+      );
+      await expect(promise).rejects.toThrow(new Error(`Error: 3`));
+    });
+
+    it(
+      "should repeat given function after delay on error and return result on resolve",
+      async () => {
+        const maxAttempt = 10;
+        const initialDelay = 100;
+        const maxDelay = 500;
+        const maxJitter = 10;
+
+        const expectedNextDelays = [
+          { min: 100, max: 110 },
+          { min: 200, max: 210 },
+          { min: 400, max: 410 },
+          { min: 500, max: 510 },
+          { min: 500, max: 510 },
+        ];
+        let count = 1;
+        const result = await retry(
+          async () => {
+            if (count === 6) {
+              return true;
+            }
+            throw new Error(`Error: ${count}`);
+          },
+          {
+            onError: (_, __, ___, nextDelay) => {
+              expect(nextDelay).toBeGreaterThanOrEqual(
+                expectedNextDelays[count - 1].min,
+              );
+              expect(nextDelay).toBeLessThan(expectedNextDelays[count - 1].max);
+              count++;
+            },
+            maxAttempt,
+            initialDelay,
+            maxDelay,
+            maxJitter,
+          },
+        );
+        expect(result).toBe(true);
+      },
+      5 * 1000,
+    );
+  });
 });

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -47,7 +47,9 @@ export const retry = async <T>(
   ) {
     await setTimeout(delay);
     try {
-      return fn();
+      // To catch an error in this try-catch block, we need to await this function before return
+      // ref. https://zenn.dev/azukiazusa/articles/difference-between-return-and-return-await
+      return await fn();
     } catch (e) {
       finalError = e;
 

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,27 +1,44 @@
 import { setTimeout } from "timers/promises";
 
 /**
- * Retry given function with exponential backoff with jitter strategy
- * Delay time before retry increases exponentially until it reaches maxDelay
- * @param fn function to run
- * @param onError callback function on rejection on each attempt
- * @param maxAttempt max attempt count
- * @param initialDelay initial delay time before retry (milliseconds)
- * @param maxDelay maximum delay time before retry (milliseconds) (The maxDelay is inclusive)
- * @param maxJitter maximum jitter (milliseconds) (The maxJitter is exclusive)
+ * Retry given function with exponential backoff with jitter strategy.
+ * Delay time before retry increases exponentially until it reaches maxDelay.
+ * @param fn A function to run.
+ * @param options Options.
+ * @param options.onError Callback function on rejection on each attempt.
+ * @param options.retryCondition Condition function for whether to retry.
+ * @param options.maxAttempt Max attempt count. Default to 5.
+ * @param options.initialDelay Initial delay milliseconds before retry. Default to 1000ms.
+ * @param options.maxDelay Maximum delay milliseconds before retry. Default to 60,000ms. The maxDelay value is inclusive.
+ * @param options.maxJitter Maximum jitter milliseconds. Default to 1000ms. The maxJitter value is exclusive.
  */
 export const retry = async <T>(
   fn: () => Promise<T> | T,
-  onError?: (
-    e: unknown,
-    attemptCount: number,
-    nextDelay: number,
-  ) => void | Promise<void>,
-  maxAttempt: number = 5,
-  initialDelay: number = 1000,
-  maxDelay: number = 60 * 1000,
-  maxJitter: number = 1000,
+  options?: {
+    onError?: (
+      e: unknown,
+      attemptCount: number,
+      toRetry: boolean,
+      nextDelay: number,
+    ) => void | Promise<void>;
+    retryCondition?: (error: unknown) => boolean;
+    maxAttempt?: number;
+    initialDelay?: number;
+    maxDelay?: number;
+    maxJitter?: number;
+  },
 ): Promise<T> => {
+  const onError =
+    options?.onError ??
+    (() => {
+      /* noop */
+    });
+  const retryCondition = options?.retryCondition ?? defaultRetryCondition;
+  const maxAttempt = options?.maxAttempt ?? 5;
+  const initialDelay = options?.initialDelay ?? 1000;
+  const maxDelay = options?.maxDelay ?? 60 * 1000;
+  const maxJitter = options?.maxJitter ?? 1000;
+
   let finalError: unknown;
   for (
     let attemptCount = 1, delay = 0;
@@ -32,14 +49,23 @@ export const retry = async <T>(
     try {
       return fn();
     } catch (e) {
+      finalError = e;
+
+      // Plan next retry
+      const retryCond = retryCondition(e);
       const jitter = Math.floor(Math.random() * maxJitter);
       delay =
         Math.min(initialDelay * 2 ** (attemptCount - 1), maxDelay) + jitter;
-      finalError = e;
-      if (typeof onError === "function") {
-        await onError(e, attemptCount, delay);
+
+      await onError(e, attemptCount, retryCond, delay);
+
+      // Throw immediately if retry conditions are not met
+      if (!retryCond) {
+        throw e;
       }
     }
   }
   throw finalError;
 };
+
+const defaultRetryCondition = (_e: unknown) => true;

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,45 @@
+import { setTimeout } from "timers/promises";
+
+/**
+ * Retry given function with exponential backoff with jitter strategy
+ * Delay time before retry increases exponentially until it reaches maxDelay
+ * @param fn function to run
+ * @param onError callback function on rejection on each attempt
+ * @param maxAttempt max attempt count
+ * @param initialDelay initial delay time before retry (milliseconds)
+ * @param maxDelay maximum delay time before retry (milliseconds) (The maxDelay is inclusive)
+ * @param maxJitter maximum jitter (milliseconds) (The maxJitter is exclusive)
+ */
+export const retry = async <T>(
+  fn: () => Promise<T> | T,
+  onError?: (
+    e: unknown,
+    attemptCount: number,
+    nextDelay: number,
+  ) => void | Promise<void>,
+  maxAttempt: number = 5,
+  initialDelay: number = 1000,
+  maxDelay: number = 60 * 1000,
+  maxJitter: number = 1000,
+): Promise<T> => {
+  let finalError: unknown;
+  for (
+    let attemptCount = 1, delay = 0;
+    attemptCount < maxAttempt;
+    attemptCount++
+  ) {
+    await setTimeout(delay);
+    try {
+      return fn();
+    } catch (e) {
+      const jitter = Math.floor(Math.random() * maxJitter);
+      delay =
+        Math.min(initialDelay * 2 ** (attemptCount - 1), maxDelay) + jitter;
+      finalError = e;
+      if (typeof onError === "function") {
+        await onError(e, attemptCount, delay);
+      }
+    }
+  }
+  throw finalError;
+};

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -20,6 +20,12 @@ export const retry = async <T>(
       attemptCount: number,
       toRetry: boolean,
       nextDelay: number,
+      config: {
+        maxAttempt: number;
+        initialDelay: number;
+        maxDelay: number;
+        maxJitter: number;
+      },
     ) => void | Promise<void>;
     retryCondition?: (error: unknown) => boolean;
     maxAttempt?: number;
@@ -42,7 +48,7 @@ export const retry = async <T>(
   let finalError: unknown;
   for (
     let attemptCount = 1, delay = 0;
-    attemptCount < maxAttempt;
+    attemptCount <= maxAttempt;
     attemptCount++
   ) {
     await setTimeout(delay);
@@ -58,8 +64,12 @@ export const retry = async <T>(
       const jitter = Math.floor(Math.random() * maxJitter);
       delay =
         Math.min(initialDelay * 2 ** (attemptCount - 1), maxDelay) + jitter;
-
-      await onError(e, attemptCount, retryCond, delay);
+      await onError(e, attemptCount, retryCond, delay, {
+        maxAttempt,
+        initialDelay,
+        maxDelay,
+        maxJitter,
+      });
 
       // Throw immediately if retry conditions are not met
       if (!retryCond) {

--- a/website/blog/2025-02-19-cli-kintone-v1-14-0.md
+++ b/website/blog/2025-02-19-cli-kintone-v1-14-0.md
@@ -12,8 +12,8 @@ We are happy to announce the release of **cli-kintone v1.14.0** 🎉
 ### cli-kintone retries download/upload attachment files on 5xx error
 
 File upload/download API requests may occasionally fail for various reasons.
-Because cli-kintone cannot resume in the middle of the process, users need to retry from the beginning on error.
-To reduce having to retry the entire process, cli-kintone starts to retry following API requests.
+This update helps avoid having to redo the entire process due to these failures.
+Now, cli-kintone automatically retries on the following API errors.
 
 - [Download File](https://kintone.dev/en/docs/kintone/rest-api/files/download-file/) (`GET /k/v1/file.json`)
   - 5xx errors

--- a/website/blog/2025-02-19-cli-kintone-v1-14-0.md
+++ b/website/blog/2025-02-19-cli-kintone-v1-14-0.md
@@ -1,0 +1,27 @@
+---
+slug: cli-kintone-v1-14-0
+title: cli-kintone v1.14.0
+authors: [tasshi, extensions-platform-team]
+tags: [release]
+---
+
+We are happy to announce the release of **cli-kintone v1.14.0** 🎉
+
+## What's new?
+
+### cli-kintone retries download/upload attachment files on 5xx error
+
+File upload/download API requests may occasionally fail for various reasons.
+Because cli-kintone cannot resume in the middle of the process, users need to retry from the beginning on error.
+To reduce having to retry the entire process, cli-kintone starts to retry following API requests.
+
+- [Download File](https://kintone.dev/en/docs/kintone/rest-api/files/download-file/) (`GET /k/v1/file.json`)
+  - 5xx errors
+- [Upload File](https://kintone.dev/en/docs/kintone/rest-api/files/upload-file/) (`POST /k/v1/file.json`)
+  - 5xx errors
+
+We use [an exponential backoff with jitter](https://aws.amazon.com/jp/blogs/architecture/exponential-backoff-and-jitter/) as our retry strategy.
+
+## Miscellaneous
+
+See the [changelog](https://github.com/kintone/cli-kintone/blob/main/CHANGELOG.md#1140-2025-02-19) for an exhaustive list of changes.

--- a/website/docs/reference/errors/retry-api-requests.md
+++ b/website/docs/reference/errors/retry-api-requests.md
@@ -4,9 +4,9 @@ For some types of API requests, cli-kintone retries request on error.
 
 ## Target API requests
 
-- Download File (`GET /k/v1/file.json`)
+- [Download File](https://kintone.dev/en/docs/kintone/rest-api/files/download-file/) (`GET /k/v1/file.json`)
   - 5xx errors
-- Upload File (`POST /k/v1/file.json`)
+- [Upload File](https://kintone.dev/en/docs/kintone/rest-api/files/upload-file/) (`POST /k/v1/file.json`)
   - 5xx errors
 
 ## Strategy

--- a/website/docs/reference/errors/retry-api-requests.md
+++ b/website/docs/reference/errors/retry-api-requests.md
@@ -2,6 +2,10 @@
 
 For some types of API requests, cli-kintone retries request on error.
 
+## Retry units
+
+Retries are performed for each API request. When requests are wrapped in Bulk Request (`bulkRequest.json`), retries will be performed for each bulkRequest unit.
+
 ## Target API requests
 
 - [Download File](https://kintone.dev/en/docs/kintone/rest-api/files/download-file/) (`GET /k/v1/file.json`)

--- a/website/docs/reference/errors/retry-api-requests.md
+++ b/website/docs/reference/errors/retry-api-requests.md
@@ -1,0 +1,14 @@
+# Retry API Requests
+
+For some types of API requests, cli-kintone retries request on error.
+
+## Target API requests
+
+- Download File (`GET /k/v1/file.json`)
+  - 5xx errors
+- Upload File (`POST /k/v1/file.json`)
+  - 5xx errors
+
+## Strategy
+
+We use [an exponential backoff with jitter](https://aws.amazon.com/jp/blogs/architecture/exponential-backoff-and-jitter/).

--- a/website/docs/reference/errors/retry-api-requests.md
+++ b/website/docs/reference/errors/retry-api-requests.md
@@ -12,3 +12,14 @@ For some types of API requests, cli-kintone retries request on error.
 ## Strategy
 
 We use [an exponential backoff with jitter](https://aws.amazon.com/jp/blogs/architecture/exponential-backoff-and-jitter/).
+
+Delay time is calculated as follows:
+
+```
+delay = Math.min(initialDelay * 2 ** (attemptCount - 1), maxDelay) + jitter;
+
+- initialDelay: Initial delay time. Default to 1,000ms.
+- attemptCount: Number of request attempt. Maximum 5.
+- maxDelay: Maximum delay time. Default to 60,000ms.
+- jitter: Randomly determined per attempt. Between 0 - 1,000ms.
+```


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

File upload/download API requests may occasionally fail for various reasons.
Because cli-kintone cannot resume in the middle of the process, users need to retry from the beginning on error.
In this PR, we added a retry function for some API requests to reduce having to retry the entire process.

![Screen Shot 2025-02-14 22 16 42](https://github.com/user-attachments/assets/05b5c3ab-56dc-4cad-93dd-45326c8c2ec1)

## What

<!-- What is a solution you want to add? -->

- [x] impl: retry file upload/download request on 5xx error
- [x] update reference
- [x] add release blog for v1.14.0

## How to test

<!-- How can we test this pull request? -->

### Run unit tests

```shell
pnpm install
pnpm build
pnpm test
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
