### PR TITLE
fix: adjust import path for v5 update

### DIFF
--- a/src/record/delete/parsers/parseCsv/index.ts
+++ b/src/record/delete/parsers/parseCsv/index.ts
@@ -1,7 +1,7 @@
 import type { CsvRow } from "../../../../kintone/types";
 import type { RecordNumber } from "../../types/field";
 
-import csvParse from "csv-parse/lib/sync";
+import csvParse from "csv-parse/sync";
 import { getRecordNumberFromCsvRows } from "./record";
 import { SEPARATOR } from "./constants";
 import { ParserError } from "../error";

--- a/src/types/csv-parse-sync.d.ts
+++ b/src/types/csv-parse-sync.d.ts
@@ -1,0 +1,4 @@
+declare module "csv-parse/sync" {
+  import csvParseSync = require("csv-parse/lib/sync");
+  export = csvParseSync;
+}


### PR DESCRIPTION
Renovate PR #826 で csv-parse を v5 系へ更新する際に発生する破壊的変更への対応です。

## 変更内容
- `csv-parse/lib/sync` → `csv-parse/sync` へ import パスを修正
- 旧パス依存の型解決を維持するため `src/types/csv-parse-sync.d.ts` を追加

## チェックリスト
- [x] `pnpm typecheck` 通過
- [ ] CI (Lint/Build/Test) 通過

ご確認お願いします。