### PR TITLE
fix: add undici-types license override for Node.js 18 CI compatibility

### DIFF
--- a/license-manager.config.js
+++ b/license-manager.config.js
@@ -61,6 +61,10 @@ const OVERRIDE_LICENSES_TEXT = {
     // License text is written in README.md
     licenseText: "See https://github.com/rzcoder/node-rsa#license",
   },
+  "undici-types": {
+    licensePageUrl:
+      "https://raw.githubusercontent.com/nodejs/undici/main/LICENSE",
+  },
 };
 
 module.exports = config;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

- Resolves license verification failure in Node.js 18 CI environment
- undici-types is indirectly required by @inquirer/prompts 7.x via @types/node

<!-- Why do you want the feature and why does it make sense for the package? -->

## What

- Add licensePageUrl override for undici-types pointing to undici's MIT license

<!-- What is a solution you want to add? -->

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
