### PR TITLE
fix: adjustment server-side-upsert

### DIFF
--- a/src/cli/record/import.ts
+++ b/src/cli/record/import.ts
@@ -45,6 +45,13 @@ const builder = (args: yargs.Argv) =>
       describe: "The fields to be imported in comma-separated",
       type: "string",
       requiresArg: true,
+    })
+    .option("experimental-use-server-side-upsert", {
+      describe:
+        "Use server-side upsert. This option is under early development.",
+      type: "boolean",
+      hidden: true,
+      default: false,
     });
 
 type Args = yargs.Arguments<
@@ -65,6 +72,7 @@ const handler = (args: Args) => {
     filePath: args["file-path"],
     updateKey: args["update-key"],
     fields: args.fields?.split(","),
+    useServerSideUpsert: args["experimental-use-server-side-upsert"],
     encoding: args.encoding,
     pfxFilePath: args["pfx-file-path"],
     pfxFilePassword: args["pfx-file-password"],

--- a/src/record/import/index.ts
+++ b/src/record/import/index.ts
@@ -11,6 +11,7 @@ import { logger } from "../../utils/log";
 import { LocalRecordRepositoryFromStream } from "./repositories/localRecordRepositoryFromStream";
 import { RunError } from "../error";
 import { isMismatchEncoding } from "../../utils/encoding";
+import { emitDeprecationWarning } from "../../utils/stability";
 
 export type Options = {
   app: string;
@@ -19,6 +20,7 @@ export type Options = {
   updateKey?: string;
   encoding?: SupportedImportEncoding;
   fields?: string[];
+  useServerSideUpsert?: boolean;
 };
 
 export const run: (
@@ -32,6 +34,7 @@ export const run: (
       attachmentsDir,
       updateKey,
       fields,
+      useServerSideUpsert,
       ...restApiClientOptions
     } = argv;
 
@@ -60,6 +63,12 @@ export const run: (
 
     const skipMissingFields = !fields;
     if (updateKey) {
+      if (useServerSideUpsert) {
+        emitDeprecationWarning(
+          "Server-side upsert is now the default behavior. This flag is no longer needed and will be removed in a future version.",
+          logger,
+        );
+      }
       await upsertRecords(
         apiClient,
         app,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why
In #1125, we changed the default behavior to --experimental-use-server-side-upsert and removed this setting, but several differences in behavior were observed. Therefore, we have fixed this issue.
Additionally, we have reintroduced --experimental-use-server-side-upsert and marked it as deprecated.
<!-- Why do you want the feature and why does it make sense for the package? -->

## What
- revised the behavior differences caused by the presence or absence of the option.
  - This is a temporary measure before the API is updated.
- reintroduced --experimental-use-server-side-upsert option and it mark as deprecated.
<!-- What is a solution you want to add? -->

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
