### PR TITLE
test: fix flaky tests

### DIFF
--- a/features/utils/__tests__/fileGenerator.test.ts
+++ b/features/utils/__tests__/fileGenerator.test.ts
@@ -15,8 +15,8 @@ describe("File Generator functions", () => {
       const filePath = path.join(tempDir, "/tmp/test.png");
       await generateFile(filePath, {});
 
-      const actual = fs.stat(filePath);
-      expect(actual).toBeTruthy();
+      const stats = await fs.stat(filePath);
+      expect(stats.isFile()).toBeTruthy();
     });
 
     it("should generate file correctly with baseDir", async () => {
@@ -24,8 +24,8 @@ describe("File Generator functions", () => {
       const baseDir = path.join(tempDir, "./tmp");
       await generateFile(filePath, { baseDir });
 
-      const actual = fs.stat(`${baseDir}/${filePath}`);
-      expect(actual).toBeTruthy();
+      const stats = await fs.stat(`${baseDir}/${filePath}`);
+      expect(stats.isFile()).toBeTruthy();
     });
 
     afterEach(() => {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

ファイル操作のテストが頻繁に落ちている

https://github.com/kintone/cli-kintone/blob/cfebe22463dd5283059b865168834a4548437d89/features/utils/__tests__/fileGenerator.test.ts#L14

```log
PASS features/utils/__tests__/fileGenerator.test.ts
node:internal/fs/promises:1040
  const result = await PromisePrototypeThen(
                 ^

Error: ENOENT: no such file or directory, stat '/var/folders/xc/cl1fyykn2pj4ryhdw6r1mqtc0000gn/T/cli-kintone-jGda3d/tmp/test.png'
 ELIFECYCLE  Command failed with exit code 1.
    at Object.stat (node:internal/fs/promises:1040:18) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/var/folders/xc/cl1fyykn2pj4ryhdw6r1mqtc0000gn/T/cli-kintone-jGda3d/tmp/test.png'
}

Node.js v24.10.0
```

ref. https://github.com/kintone/cli-kintone/actions/runs/18973124236/job/54185566404

## What

<!-- What is a solution you want to add? -->

- 該当テストを修正した

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
