### PR TITLE
test: fix flaky npm installation tests

### DIFF
--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -40,12 +40,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
-          package-manager-cache: false
-        # Update npm to version >=11.6.1 to avoid the ECOMPROMISED error.
-        # ref. https://github.com/npm/cli/pull/8577
-      - run: npm -v
-      - run: npm install -g npm@latest
-      - run: npm -v
       - uses: actions/download-artifact@v6
         with:
           name: kintone-cli.tgz
@@ -68,9 +62,11 @@ jobs:
         # Update npm to version >=11.6.1 to avoid the ECOMPROMISED error.
         # ref. https://github.com/npm/cli/pull/8577
       - run: npm -v
+      - run: npx -v
       - run: npm install -g npm@latest
       - run: npm -v
+      - run: npx -v
       - uses: actions/download-artifact@v6
         with:
           name: kintone-cli.tgz
-      - run: npx kintone-cli.tgz --version
+      - run: npx --yes kintone-cli.tgz --version

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -43,7 +43,9 @@ jobs:
           package-manager-cache: false
         # Update npm to version >=11.6.1 to avoid the ECOMPROMISED error.
         # ref. https://github.com/npm/cli/pull/8577
+      - run: npm -v
       - run: npm install -g npm@latest
+      - run: npm -v
       - uses: actions/download-artifact@v6
         with:
           name: kintone-cli.tgz
@@ -65,7 +67,9 @@ jobs:
           package-manager-cache: false
         # Update npm to version >=11.6.1 to avoid the ECOMPROMISED error.
         # ref. https://github.com/npm/cli/pull/8577
+      - run: npm -v
       - run: npm install -g npm@latest
+      - run: npm -v
       - uses: actions/download-artifact@v6
         with:
           name: kintone-cli.tgz

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
         # Update npm to version >=11.6.1 to avoid the ECOMPROMISED error.
         # ref. https://github.com/npm/cli/pull/8577
       - run: npm install -g npm@latest
@@ -61,6 +62,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
         # Update npm to version >=11.6.1 to avoid the ECOMPROMISED error.
         # ref. https://github.com/npm/cli/pull/8577
       - run: npm install -g npm@latest

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm install -g npm@latest
       - uses: actions/download-artifact@v6
         with:
           name: kintone-cli.tgz
@@ -58,6 +59,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+      - run: npm install -g npm@latest
       - uses: actions/download-artifact@v6
         with:
           name: kintone-cli.tgz

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -40,6 +40,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+        # Update npm to version >=11.6.1 to avoid the ECOMPROMISED error.
+        # ref. https://github.com/npm/cli/pull/8577
       - run: npm install -g npm@latest
       - uses: actions/download-artifact@v6
         with:
@@ -59,6 +61,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+        # Update npm to version >=11.6.1 to avoid the ECOMPROMISED error.
+        # ref. https://github.com/npm/cli/pull/8577
       - run: npm install -g npm@latest
       - uses: actions/download-artifact@v6
         with:


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->


```log
Run npx kintone-cli.tgz --version
npm warn exec The following package was not found and will be installed: file:kintone-cli.tgz
npm error code ECOMPROMISED
npm error Lock compromised
npm error A complete log of this run can be found in: C:\npm\cache\_logs\2025-10-31T14_40_33_216Z-debug-0.log
Error: Process completed with exit code 1.
```

ref. https://github.com/kintone/cli-kintone/actions/runs/18975906273/job/54195407404

この `ECOMPROMISED` エラーが頻発する現象は https://github.com/npm/cli/pull/8577 で修正されて、 npm@11.6.1 にてリリースされている。

そのため、テストで使用するnpmのバージョンを11.6.1以上にする。

## What

<!-- What is a solution you want to add? -->

## How to test

<!-- How can we test this pull request? -->

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
