### PR TITLE
feat: plugin init prompts update

### DIFF
--- a/src/cli/plugin/init.ts
+++ b/src/cli/plugin/init.ts
@@ -13,9 +13,9 @@ const describe = "Initialize plugin project";
 const builder = (args: yargs.Argv) =>
   args
     .option("name", {
-      describe: "The name of your plugin",
+      describe:
+        "The name of your plugin (and the target directory). If omitted, you will be prompted to input interactively.",
       type: "string",
-      demandOption: true,
       requiresArg: true,
     })
     .option("template", {

--- a/src/plugin/init/index.ts
+++ b/src/plugin/init/index.ts
@@ -6,5 +6,9 @@ type Options = {
 };
 
 export const run: (argv: Options) => Promise<void> = async (argv) => {
-  initPlugin(argv.name, "en", argv.template);
+  initPlugin({
+    name: argv.name,
+    lang: "en",
+    template: argv.template,
+  });
 };

--- a/src/plugin/init/index.ts
+++ b/src/plugin/init/index.ts
@@ -1,7 +1,7 @@
 import { initPlugin } from "./usecases/init";
 
 type Options = {
-  name: string;
+  name: string | undefined;
   template: string;
 };
 

--- a/src/plugin/init/usecases/init.ts
+++ b/src/plugin/init/usecases/init.ts
@@ -60,7 +60,7 @@ export const initPlugin = async (options: InitPluginOptions) => {
 
   `);
 
-  const answers = await runPrompt(m, options.name, options.lang);
+  const answers = await runPrompt(m, options.name);
 
   // outputDirを決定: CLI引数があればそれを使用、なければQAで入力されたプロジェクト名を使用
   const outputDir = options.name ?? `./${answers.projectName}`;

--- a/src/plugin/init/usecases/init.ts
+++ b/src/plugin/init/usecases/init.ts
@@ -42,33 +42,38 @@ ${m("developerSite")}
       `;
 };
 
+type InitPluginOptions = {
+  /** project name passed by CLI argument (undefined if not specified) */
+  name?: string;
+  lang: Lang;
+  template: string;
+};
+
 /**
  * Run create-kintone-plugin script
- * @param outputDir
- * @param lang
- * @param templateName
  */
-export const initPlugin = async (
-  outputDir: string,
-  lang: Lang,
-  templateName: string,
-) => {
-  const m = getBoundMessage(lang);
+export const initPlugin = async (options: InitPluginOptions) => {
+  const m = getBoundMessage(options.lang);
   logger.info(`
 
   ${m("introduction")}
 
   `);
 
-  const answers = await runPrompt(m, outputDir, lang);
+  const answers = await runPrompt(m, options.name, options.lang);
+
+  // outputDirを決定: CLI引数があればそれを使用、なければQAで入力されたプロジェクト名を使用
+  const outputDir = options.name ?? `./${answers.projectName}`;
   const packageName = path.basename(outputDir);
   logger.info(m("settingUpTemplate"));
-  logger.debug(`templateName: ${templateName}`);
+  logger.debug(`template: ${options.template}`);
 
   // Verify output directory does not exist
   const directoryExists = await isDirectory(outputDir);
   if (directoryExists) {
-    logger.error(`${outputDir} ${getMessage(lang, "Error_alreadyExists")}`);
+    logger.error(
+      `${outputDir} ${getMessage(options.lang, "Error_alreadyExists")}`,
+    );
     // eslint-disable-next-line n/no-process-exit
     process.exit(1);
   }
@@ -76,7 +81,7 @@ export const initPlugin = async (
   try {
     await setupTemplate({
       outputDir,
-      templateName,
+      templateName: options.template,
       manifestPatch: {
         name: answers.name,
         description: answers.description,
@@ -87,8 +92,10 @@ export const initPlugin = async (
       },
     });
     logger.info(m("templateSetupCompleted"));
-    installDependencies(outputDir, lang);
-    logger.info(getSuccessCreatedPluginMessage(packageName, outputDir, lang));
+    installDependencies(outputDir, options.lang);
+    logger.info(
+      getSuccessCreatedPluginMessage(packageName, outputDir, options.lang),
+    );
   } catch (error) {
     try {
       await fs.promises.rm(outputDir, { recursive: true, force: true });

--- a/src/plugin/init/utils/__tests__/qa.test.ts
+++ b/src/plugin/init/utils/__tests__/qa.test.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import * as prompt from "../qa/prompt";
 import type { LangAnswers, SupportLang } from "../qa/prompt";
 import { validateForDescription, validateForName } from "../qa/validator";
-import { getDefaultName, runPrompt } from "../qa";
+import { runPrompt } from "../qa";
 import { getBoundMessage } from "../messages";
 
 const MOCK_ANSWERS: LangAnswers = {
@@ -35,11 +35,6 @@ describe("qa", () => {
       assert(validateForDescription("a".repeat(200)));
       assert(!validateForDescription(""));
       assert(!validateForDescription("a".repeat(201)));
-    });
-  });
-  describe("getDefaultName", () => {
-    it("should be set the default value of name.en based on the passed directory", () => {
-      assert.equal(getDefaultName("foo/bar/dist"), "dist");
     });
   });
   describe("runPrompt", () => {

--- a/src/plugin/init/utils/__tests__/qa.test.ts
+++ b/src/plugin/init/utils/__tests__/qa.test.ts
@@ -1,5 +1,6 @@
 import assert from "assert";
 import * as prompt from "../qa/prompt";
+import type { OptionalLangAnswers, SupportLang } from "../qa/prompt";
 import { validateForDescription, validateForName } from "../qa/validator";
 import { getDefaultName, runPrompt } from "../qa";
 import type { BoundMessage } from "../messages";
@@ -30,20 +31,20 @@ describe("qa", () => {
       beforeEach(() => {
         jest.spyOn(prompt, "promptForName").mockResolvedValue("pass");
         jest.spyOn(prompt, "promptForDescription").mockResolvedValue("pass");
-        jest.spyOn(prompt, "promptForOptionalName").mockResolvedValue("pass");
-        jest
-          .spyOn(prompt, "promptForOptionalDescription")
-          .mockResolvedValue("pass");
         jest.spyOn(prompt, "promptForHomepage").mockResolvedValue("pass");
-        jest.spyOn(prompt, "promptForSupportLang").mockResolvedValue(true);
-        jest.spyOn(prompt, "promptForSupportMobile").mockResolvedValue(true);
       });
       it("should be set ja parameters in supportJa is true", async () => {
         jest
-          .spyOn(prompt, "promptForSupportLang")
+          .spyOn(prompt, "promptForOptionalLang")
           .mockImplementation(
-            async (m: BoundMessage, supportLang: prompt.SupportLang) => {
-              return supportLang === "Ja";
+            async (
+              _m: BoundMessage,
+              supportLang: Exclude<SupportLang, "En">,
+            ): Promise<OptionalLangAnswers> => {
+              if (supportLang === "Ja") {
+                return { name: "pass", description: "pass", homepage: "pass" };
+              }
+              return {};
             },
           );
         const result1 = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
@@ -54,10 +55,16 @@ describe("qa", () => {
       });
       it("should not be set ja parameters in supportJa is false", async () => {
         jest
-          .spyOn(prompt, "promptForSupportLang")
+          .spyOn(prompt, "promptForOptionalLang")
           .mockImplementation(
-            async (m: BoundMessage, supportLang: prompt.SupportLang) => {
-              return !(supportLang === "Ja");
+            async (
+              _m: BoundMessage,
+              supportLang: Exclude<SupportLang, "En">,
+            ): Promise<OptionalLangAnswers> => {
+              if (supportLang === "Ja") {
+                return {};
+              }
+              return { name: "pass", description: "pass", homepage: "pass" };
             },
           );
         const result2 = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
@@ -66,10 +73,16 @@ describe("qa", () => {
       });
       it("should be set zh parameters in supportZh is true", async () => {
         jest
-          .spyOn(prompt, "promptForSupportLang")
+          .spyOn(prompt, "promptForOptionalLang")
           .mockImplementation(
-            async (m: BoundMessage, supportLang: prompt.SupportLang) => {
-              return supportLang === "Zh";
+            async (
+              _m: BoundMessage,
+              supportLang: Exclude<SupportLang, "En">,
+            ): Promise<OptionalLangAnswers> => {
+              if (supportLang === "Zh") {
+                return { name: "pass", description: "pass", homepage: "pass" };
+              }
+              return {};
             },
           );
         const result1 = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
@@ -80,10 +93,16 @@ describe("qa", () => {
       });
       it("should not be set zh parameters in supportZh is false", async () => {
         jest
-          .spyOn(prompt, "promptForSupportLang")
+          .spyOn(prompt, "promptForOptionalLang")
           .mockImplementation(
-            async (m: BoundMessage, supportLang: prompt.SupportLang) => {
-              return !(supportLang === "Zh");
+            async (
+              _m: BoundMessage,
+              supportLang: Exclude<SupportLang, "En">,
+            ): Promise<OptionalLangAnswers> => {
+              if (supportLang === "Zh") {
+                return {};
+              }
+              return { name: "pass", description: "pass", homepage: "pass" };
             },
           );
         const result2 = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
@@ -92,10 +111,16 @@ describe("qa", () => {
       });
       it("should be set es parameters in supportEs is true", async () => {
         jest
-          .spyOn(prompt, "promptForSupportLang")
+          .spyOn(prompt, "promptForOptionalLang")
           .mockImplementation(
-            async (m: BoundMessage, supportLang: prompt.SupportLang) => {
-              return supportLang === "Es";
+            async (
+              _m: BoundMessage,
+              supportLang: Exclude<SupportLang, "En">,
+            ): Promise<OptionalLangAnswers> => {
+              if (supportLang === "Es") {
+                return { name: "pass", description: "pass", homepage: "pass" };
+              }
+              return {};
             },
           );
         const result1 = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
@@ -106,10 +131,16 @@ describe("qa", () => {
       });
       it("should not be set es parameters in supportEs is false", async () => {
         jest
-          .spyOn(prompt, "promptForSupportLang")
+          .spyOn(prompt, "promptForOptionalLang")
           .mockImplementation(
-            async (m: BoundMessage, supportLang: prompt.SupportLang) => {
-              return !(supportLang === "Es");
+            async (
+              _m: BoundMessage,
+              supportLang: Exclude<SupportLang, "En">,
+            ): Promise<OptionalLangAnswers> => {
+              if (supportLang === "Es") {
+                return {};
+              }
+              return { name: "pass", description: "pass", homepage: "pass" };
             },
           );
         const result2 = await runPrompt(getBoundMessage("en"), "foo/bar/dist");

--- a/src/plugin/init/utils/__tests__/qa.test.ts
+++ b/src/plugin/init/utils/__tests__/qa.test.ts
@@ -1,10 +1,26 @@
 import assert from "assert";
 import * as prompt from "../qa/prompt";
-import type { OptionalLangAnswers, SupportLang } from "../qa/prompt";
+import type { LangAnswers, SupportLang } from "../qa/prompt";
 import { validateForDescription, validateForName } from "../qa/validator";
 import { getDefaultName, runPrompt } from "../qa";
-import type { BoundMessage } from "../messages";
 import { getBoundMessage } from "../messages";
+
+const MOCK_ANSWERS: LangAnswers = {
+  name: "pass",
+  description: "pass",
+  homepage: "pass",
+};
+
+const mockPromptForLang = (supportedLangs: SupportLang[]) => {
+  jest
+    .spyOn(prompt, "promptForLang")
+    .mockImplementation(async (_m, options) => {
+      if (options.required || supportedLangs.includes(options.supportLang)) {
+        return MOCK_ANSWERS;
+      }
+      return {};
+    });
+};
 
 describe("qa", () => {
   describe("validator", () => {
@@ -28,124 +44,47 @@ describe("qa", () => {
   });
   describe("runPrompt", () => {
     describe("optional lang parameters", () => {
-      beforeEach(() => {
-        jest.spyOn(prompt, "promptForName").mockResolvedValue("pass");
-        jest.spyOn(prompt, "promptForDescription").mockResolvedValue("pass");
-        jest.spyOn(prompt, "promptForHomepage").mockResolvedValue("pass");
-      });
       it("should be set ja parameters in supportJa is true", async () => {
-        jest
-          .spyOn(prompt, "promptForOptionalLang")
-          .mockImplementation(
-            async (
-              _m: BoundMessage,
-              supportLang: Exclude<SupportLang, "En">,
-            ): Promise<OptionalLangAnswers> => {
-              if (supportLang === "Ja") {
-                return { name: "pass", description: "pass", homepage: "pass" };
-              }
-              return {};
-            },
-          );
-        const result1 = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
-        assert.notEqual(result1.name.ja, undefined);
-        assert.notEqual(result1.description?.ja, undefined);
-        assert.notEqual(result1.homepage_url, undefined);
-        assert.notEqual(result1.homepage_url?.ja, undefined);
+        mockPromptForLang(["Ja"]);
+        const result = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
+        assert.notEqual(result.name.ja, undefined);
+        assert.notEqual(result.description?.ja, undefined);
+        assert.notEqual(result.homepage_url, undefined);
+        assert.notEqual(result.homepage_url?.ja, undefined);
       });
       it("should not be set ja parameters in supportJa is false", async () => {
-        jest
-          .spyOn(prompt, "promptForOptionalLang")
-          .mockImplementation(
-            async (
-              _m: BoundMessage,
-              supportLang: Exclude<SupportLang, "En">,
-            ): Promise<OptionalLangAnswers> => {
-              if (supportLang === "Ja") {
-                return {};
-              }
-              return { name: "pass", description: "pass", homepage: "pass" };
-            },
-          );
-        const result2 = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
-        assert.equal(result2.name.ja, undefined);
-        assert.equal(result2.description?.ja, undefined);
+        mockPromptForLang(["Zh", "Es"]);
+        const result = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
+        assert.equal(result.name.ja, undefined);
+        assert.equal(result.description?.ja, undefined);
       });
       it("should be set zh parameters in supportZh is true", async () => {
-        jest
-          .spyOn(prompt, "promptForOptionalLang")
-          .mockImplementation(
-            async (
-              _m: BoundMessage,
-              supportLang: Exclude<SupportLang, "En">,
-            ): Promise<OptionalLangAnswers> => {
-              if (supportLang === "Zh") {
-                return { name: "pass", description: "pass", homepage: "pass" };
-              }
-              return {};
-            },
-          );
-        const result1 = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
-        assert.notEqual(result1.name.zh, undefined);
-        assert.notEqual(result1.description?.zh, undefined);
-        assert.notEqual(result1.homepage_url, undefined);
-        assert.notEqual(result1.homepage_url?.zh, undefined);
+        mockPromptForLang(["Zh"]);
+        const result = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
+        assert.notEqual(result.name.zh, undefined);
+        assert.notEqual(result.description?.zh, undefined);
+        assert.notEqual(result.homepage_url, undefined);
+        assert.notEqual(result.homepage_url?.zh, undefined);
       });
       it("should not be set zh parameters in supportZh is false", async () => {
-        jest
-          .spyOn(prompt, "promptForOptionalLang")
-          .mockImplementation(
-            async (
-              _m: BoundMessage,
-              supportLang: Exclude<SupportLang, "En">,
-            ): Promise<OptionalLangAnswers> => {
-              if (supportLang === "Zh") {
-                return {};
-              }
-              return { name: "pass", description: "pass", homepage: "pass" };
-            },
-          );
-        const result2 = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
-        assert.equal(result2.name.zh, undefined);
-        assert.equal(result2.description?.zh, undefined);
+        mockPromptForLang(["Ja", "Es"]);
+        const result = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
+        assert.equal(result.name.zh, undefined);
+        assert.equal(result.description?.zh, undefined);
       });
       it("should be set es parameters in supportEs is true", async () => {
-        jest
-          .spyOn(prompt, "promptForOptionalLang")
-          .mockImplementation(
-            async (
-              _m: BoundMessage,
-              supportLang: Exclude<SupportLang, "En">,
-            ): Promise<OptionalLangAnswers> => {
-              if (supportLang === "Es") {
-                return { name: "pass", description: "pass", homepage: "pass" };
-              }
-              return {};
-            },
-          );
-        const result1 = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
-        assert.notEqual(result1.name.es, undefined);
-        assert.notEqual(result1.description?.es, undefined);
-        assert.notEqual(result1.homepage_url, undefined);
-        assert.notEqual(result1.homepage_url?.es, undefined);
+        mockPromptForLang(["Es"]);
+        const result = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
+        assert.notEqual(result.name.es, undefined);
+        assert.notEqual(result.description?.es, undefined);
+        assert.notEqual(result.homepage_url, undefined);
+        assert.notEqual(result.homepage_url?.es, undefined);
       });
       it("should not be set es parameters in supportEs is false", async () => {
-        jest
-          .spyOn(prompt, "promptForOptionalLang")
-          .mockImplementation(
-            async (
-              _m: BoundMessage,
-              supportLang: Exclude<SupportLang, "En">,
-            ): Promise<OptionalLangAnswers> => {
-              if (supportLang === "Es") {
-                return {};
-              }
-              return { name: "pass", description: "pass", homepage: "pass" };
-            },
-          );
-        const result2 = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
-        assert.equal(result2.name.es, undefined);
-        assert.equal(result2.description?.es, undefined);
+        mockPromptForLang(["Ja", "Zh"]);
+        const result = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
+        assert.equal(result.name.es, undefined);
+        assert.equal(result.description?.es, undefined);
       });
     });
   });

--- a/src/plugin/init/utils/__tests__/qa.test.ts
+++ b/src/plugin/init/utils/__tests__/qa.test.ts
@@ -46,11 +46,7 @@ describe("qa", () => {
               return supportLang === "Ja";
             },
           );
-        const result1 = await runPrompt(
-          getBoundMessage("ja"),
-          "foo/bar/dist",
-          "ja",
-        );
+        const result1 = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
         assert.notEqual(result1.name.ja, undefined);
         assert.notEqual(result1.description?.ja, undefined);
         assert.notEqual(result1.homepage_url, undefined);
@@ -64,11 +60,7 @@ describe("qa", () => {
               return !(supportLang === "Ja");
             },
           );
-        const result2 = await runPrompt(
-          getBoundMessage("en"),
-          "foo/bar/dist",
-          "en",
-        );
+        const result2 = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
         assert.equal(result2.name.ja, undefined);
         assert.equal(result2.description?.ja, undefined);
       });
@@ -80,11 +72,7 @@ describe("qa", () => {
               return supportLang === "Zh";
             },
           );
-        const result1 = await runPrompt(
-          getBoundMessage("ja"),
-          "foo/bar/dist",
-          "ja",
-        );
+        const result1 = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
         assert.notEqual(result1.name.zh, undefined);
         assert.notEqual(result1.description?.zh, undefined);
         assert.notEqual(result1.homepage_url, undefined);
@@ -98,11 +86,7 @@ describe("qa", () => {
               return !(supportLang === "Zh");
             },
           );
-        const result2 = await runPrompt(
-          getBoundMessage("en"),
-          "foo/bar/dist",
-          "en",
-        );
+        const result2 = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
         assert.equal(result2.name.zh, undefined);
         assert.equal(result2.description?.zh, undefined);
       });
@@ -114,11 +98,7 @@ describe("qa", () => {
               return supportLang === "Es";
             },
           );
-        const result1 = await runPrompt(
-          getBoundMessage("ja"),
-          "foo/bar/dist",
-          "ja",
-        );
+        const result1 = await runPrompt(getBoundMessage("ja"), "foo/bar/dist");
         assert.notEqual(result1.name.es, undefined);
         assert.notEqual(result1.description?.es, undefined);
         assert.notEqual(result1.homepage_url, undefined);
@@ -132,11 +112,7 @@ describe("qa", () => {
               return !(supportLang === "Es");
             },
           );
-        const result2 = await runPrompt(
-          getBoundMessage("en"),
-          "foo/bar/dist",
-          "en",
-        );
+        const result2 = await runPrompt(getBoundMessage("en"), "foo/bar/dist");
         assert.equal(result2.name.es, undefined);
         assert.equal(result2.description?.es, undefined);
       });

--- a/src/plugin/init/utils/messages.ts
+++ b/src/plugin/init/utils/messages.ts
@@ -4,6 +4,14 @@ type LangMap = { [lang in Lang]: string };
 type MessageMap = { [key in keyof typeof messages]: LangMap };
 
 const messages = {
+  Q_ProjectName: {
+    en: "Input your project name (target directory)",
+    ja: "プロジェクト名（出力先ディレクトリ）を入力してください",
+  },
+  Q_ProjectNameError: {
+    en: "Project name must be at least 1 character",
+    ja: "プロジェクト名は1文字以上で入力してください",
+  },
   Q_NameEn: {
     en: "Input your plug-in name in English [1-64chars]",
     ja: "プラグインの英語名を入力してください [1-64文字]",

--- a/src/plugin/init/utils/qa.ts
+++ b/src/plugin/init/utils/qa.ts
@@ -1,5 +1,6 @@
 import type { BoundMessage } from "./messages";
 import { promptForLang, promptForProjectName } from "../utils/qa/prompt";
+import path from "path";
 
 export type Answers = {
   projectName: string;
@@ -25,9 +26,6 @@ export type Answers = {
 
 export const DEFAULT_PROJECT_NAME = "kintone-plugin";
 
-export const getDefaultName = (outputDir: string) =>
-  outputDir.replace(/.*\//, "");
-
 export const runPrompt = async (
   m: BoundMessage,
   inputName: string | undefined,
@@ -37,7 +35,7 @@ export const runPrompt = async (
       ? await promptForProjectName(m, `./${DEFAULT_PROJECT_NAME}`)
       : inputName;
 
-  const defaultName = getDefaultName(projectName);
+  const defaultName = path.basename(projectName);
 
   const en = await promptForLang(m, {
     supportLang: "En",

--- a/src/plugin/init/utils/qa.ts
+++ b/src/plugin/init/utils/qa.ts
@@ -1,13 +1,10 @@
-import type { Lang } from "./lang";
 import type { BoundMessage } from "./messages";
 import {
   promptForDescription,
   promptForHomepage,
   promptForName,
-  promptForOptionalDescription,
-  promptForOptionalName,
+  promptForOptionalLang,
   promptForProjectName,
-  promptForSupportLang,
 } from "../utils/qa/prompt";
 
 export type Answers = {
@@ -40,9 +37,7 @@ export const getDefaultName = (outputDir: string) =>
 export const runPrompt = async (
   m: BoundMessage,
   outputDir: string | undefined,
-  lang: Lang,
 ): Promise<Answers> => {
-  // プロジェクト名の質問（outputDirが未指定の場合のみ）
   const projectName =
     outputDir === undefined
       ? await promptForProjectName(m, DEFAULT_PROJECT_NAME)
@@ -50,51 +45,33 @@ export const runPrompt = async (
 
   const enName = await promptForName(m, "En", projectName);
   const enDescription = await promptForDescription(m, "En", enName);
-
-  const supportJa = await promptForSupportLang(m, "Ja", lang === "ja");
-  const jaName = supportJa ? await promptForOptionalName(m, "Ja") : undefined;
-  const jaDescription = supportJa
-    ? await promptForOptionalDescription(m, "Ja")
-    : undefined;
-
-  const supportZh = await promptForSupportLang(m, "Zh");
-  const zhName = supportZh ? await promptForOptionalName(m, "Zh") : undefined;
-  const zhDescription = supportZh
-    ? await promptForOptionalDescription(m, "Zh")
-    : undefined;
-
-  const supportEs = await promptForSupportLang(m, "Es");
-  const esName = supportEs ? await promptForOptionalName(m, "Es") : undefined;
-  const esDescription = supportEs
-    ? await promptForOptionalDescription(m, "Es")
-    : undefined;
-
   const enHomepage = await promptForHomepage(m, "En");
-  const jaHomepage = supportJa ? await promptForHomepage(m, "Ja") : undefined;
-  const zhHomepage = supportZh ? await promptForHomepage(m, "Zh") : undefined;
-  const esHomepage = supportEs ? await promptForHomepage(m, "Es") : undefined;
+
+  const ja = await promptForOptionalLang(m, "Ja", enName, enDescription);
+  const zh = await promptForOptionalLang(m, "Zh", enName, enDescription);
+  const es = await promptForOptionalLang(m, "Es", enName, enDescription);
 
   const result: Answers = {
-    projectName: projectName,
+    projectName,
     name: {
       en: enName,
-      ja: jaName,
-      zh: zhName,
-      es: esName,
+      ja: ja.name,
+      zh: zh.name,
+      es: es.name,
     },
     description: {
       en: enDescription,
-      ja: jaDescription,
-      zh: zhDescription,
-      es: esDescription,
+      ja: ja.description,
+      zh: zh.description,
+      es: es.description,
     },
   };
   if (enHomepage) {
     result.homepage_url = {
       en: enHomepage,
-      ja: jaHomepage,
-      zh: zhHomepage,
-      es: esHomepage,
+      ja: ja.homepage,
+      zh: zh.homepage,
+      es: es.homepage,
     };
   }
   return result;

--- a/src/plugin/init/utils/qa.ts
+++ b/src/plugin/init/utils/qa.ts
@@ -36,14 +36,16 @@ export const getDefaultName = (outputDir: string) =>
 
 export const runPrompt = async (
   m: BoundMessage,
-  outputDir: string | undefined,
+  inputName: string | undefined,
 ): Promise<Answers> => {
   const projectName =
-    outputDir === undefined
-      ? await promptForProjectName(m, DEFAULT_PROJECT_NAME)
-      : getDefaultName(outputDir);
+    inputName === undefined
+      ? await promptForProjectName(m, `./${DEFAULT_PROJECT_NAME}`)
+      : inputName;
 
-  const enName = await promptForName(m, "En", projectName);
+  const defaultName = getDefaultName(projectName);
+
+  const enName = await promptForName(m, "En", defaultName);
   const enDescription = await promptForDescription(m, "En", enName);
   const enHomepage = await promptForHomepage(m, "En");
 

--- a/src/plugin/init/utils/qa.ts
+++ b/src/plugin/init/utils/qa.ts
@@ -6,10 +6,12 @@ import {
   promptForName,
   promptForOptionalDescription,
   promptForOptionalName,
+  promptForProjectName,
   promptForSupportLang,
 } from "../utils/qa/prompt";
 
 export type Answers = {
+  projectName: string;
   name: {
     ja?: string;
     en: string;
@@ -30,15 +32,23 @@ export type Answers = {
   };
 };
 
+export const DEFAULT_PROJECT_NAME = "kintone-plugin";
+
 export const getDefaultName = (outputDir: string) =>
   outputDir.replace(/.*\//, "");
 
 export const runPrompt = async (
   m: BoundMessage,
-  outputDir: string,
+  outputDir: string | undefined,
   lang: Lang,
 ): Promise<Answers> => {
-  const enName = await promptForName(m, "En", getDefaultName(outputDir));
+  // プロジェクト名の質問（outputDirが未指定の場合のみ）
+  const projectName =
+    outputDir === undefined
+      ? await promptForProjectName(m, DEFAULT_PROJECT_NAME)
+      : getDefaultName(outputDir);
+
+  const enName = await promptForName(m, "En", projectName);
   const enDescription = await promptForDescription(m, "En", enName);
 
   const supportJa = await promptForSupportLang(m, "Ja", lang === "ja");
@@ -65,6 +75,7 @@ export const runPrompt = async (
   const esHomepage = supportEs ? await promptForHomepage(m, "Es") : undefined;
 
   const result: Answers = {
+    projectName: projectName,
     name: {
       en: enName,
       ja: jaName,

--- a/src/plugin/init/utils/qa.ts
+++ b/src/plugin/init/utils/qa.ts
@@ -1,11 +1,5 @@
 import type { BoundMessage } from "./messages";
-import {
-  promptForDescription,
-  promptForHomepage,
-  promptForName,
-  promptForOptionalLang,
-  promptForProjectName,
-} from "../utils/qa/prompt";
+import { promptForLang, promptForProjectName } from "../utils/qa/prompt";
 
 export type Answers = {
   projectName: string;
@@ -45,32 +39,45 @@ export const runPrompt = async (
 
   const defaultName = getDefaultName(projectName);
 
-  const enName = await promptForName(m, "En", defaultName);
-  const enDescription = await promptForDescription(m, "En", enName);
-  const enHomepage = await promptForHomepage(m, "En");
-
-  const ja = await promptForOptionalLang(m, "Ja", enName, enDescription);
-  const zh = await promptForOptionalLang(m, "Zh", enName, enDescription);
-  const es = await promptForOptionalLang(m, "Es", enName, enDescription);
+  const en = await promptForLang(m, {
+    supportLang: "En",
+    required: true,
+    defaultName: defaultName,
+  });
+  const ja = await promptForLang(m, {
+    supportLang: "Ja",
+    defaultName: en.name,
+    defaultDescription: en.description,
+  });
+  const zh = await promptForLang(m, {
+    supportLang: "Zh",
+    defaultName: en.name,
+    defaultDescription: en.description,
+  });
+  const es = await promptForLang(m, {
+    supportLang: "Es",
+    defaultName: en.name,
+    defaultDescription: en.description,
+  });
 
   const result: Answers = {
     projectName,
     name: {
-      en: enName,
+      en: en.name,
       ja: ja.name,
       zh: zh.name,
       es: es.name,
     },
     description: {
-      en: enDescription,
+      en: en.description,
       ja: ja.description,
       zh: zh.description,
       es: es.description,
     },
   };
-  if (enHomepage) {
+  if (en.homepage) {
     result.homepage_url = {
-      en: enHomepage,
+      en: en.homepage,
       ja: ja.homepage,
       zh: zh.homepage,
       es: es.homepage,

--- a/src/plugin/init/utils/qa/prompt.ts
+++ b/src/plugin/init/utils/qa/prompt.ts
@@ -53,9 +53,11 @@ export const promptForDescription = async (
 export const promptForOptionalName = async (
   m: BoundMessage,
   supportLang: SupportLang,
+  defaultAnswer: string,
 ) => {
   return input({
     message: m(`Q_Name${supportLang}`),
+    default: defaultAnswer,
     validate: (value) =>
       validateForOptionalName(value) ? true : m(`Q_Name${supportLang}Error`),
   });
@@ -64,9 +66,11 @@ export const promptForOptionalName = async (
 export const promptForOptionalDescription = async (
   m: BoundMessage,
   supportLang: SupportLang,
+  defaultAnswer: string,
 ) => {
   return input({
     message: m(`Q_Description${supportLang}`),
+    default: defaultAnswer,
     validate: (value) =>
       validateForOptionalDescription(value)
         ? true
@@ -99,4 +103,30 @@ export const promptForSupportMobile = async (m: BoundMessage) => {
     default: true,
     message: m("Q_MobileSupport"),
   });
+};
+
+export type OptionalLangAnswers = {
+  name?: string;
+  description?: string;
+  homepage?: string;
+};
+
+export const promptForOptionalLang = async (
+  m: BoundMessage,
+  supportLang: Exclude<SupportLang, "En">,
+  defaultName: string,
+  defaultDescription: string,
+): Promise<OptionalLangAnswers> => {
+  const support = await promptForSupportLang(m, supportLang);
+  if (!support) {
+    return {};
+  }
+  const name = await promptForOptionalName(m, supportLang, defaultName);
+  const description = await promptForOptionalDescription(
+    m,
+    supportLang,
+    defaultDescription,
+  );
+  const homepage = await promptForHomepage(m, supportLang);
+  return { name, description, homepage };
 };

--- a/src/plugin/init/utils/qa/prompt.ts
+++ b/src/plugin/init/utils/qa/prompt.ts
@@ -5,9 +5,22 @@ import {
   validateForName,
   validateForOptionalDescription,
   validateForOptionalName,
+  validateForProjectName,
 } from "./validator";
 
 export type SupportLang = "En" | "Ja" | "Zh" | "Es";
+
+export const promptForProjectName = async (
+  m: BoundMessage,
+  defaultAnswer: string,
+) => {
+  return input({
+    message: m("Q_ProjectName"),
+    default: defaultAnswer,
+    validate: (value) =>
+      validateForProjectName(value) ? true : m("Q_ProjectNameError"),
+  });
+};
 
 export const promptForName = async (
   m: BoundMessage,

--- a/src/plugin/init/utils/qa/prompt.ts
+++ b/src/plugin/init/utils/qa/prompt.ts
@@ -50,7 +50,7 @@ export const promptForDescription = async (
   });
 };
 
-export const promptForOptionalName = async (
+const promptForOptionalName = async (
   m: BoundMessage,
   supportLang: SupportLang,
   defaultAnswer: string,
@@ -63,7 +63,7 @@ export const promptForOptionalName = async (
   });
 };
 
-export const promptForOptionalDescription = async (
+const promptForOptionalDescription = async (
   m: BoundMessage,
   supportLang: SupportLang,
   defaultAnswer: string,
@@ -78,7 +78,7 @@ export const promptForOptionalDescription = async (
   });
 };
 
-export const promptForSupportLang = async (
+const promptForSupportLang = async (
   m: BoundMessage,
   supportLang: Exclude<SupportLang, "En">,
   defaultAnswer: boolean = false,
@@ -95,13 +95,6 @@ export const promptForHomepage = async (
 ) => {
   return input({
     message: m(`Q_WebsiteUrl${supportLang}`),
-  });
-};
-
-export const promptForSupportMobile = async (m: BoundMessage) => {
-  return confirm({
-    default: true,
-    message: m("Q_MobileSupport"),
   });
 };
 

--- a/src/plugin/init/utils/qa/prompt.ts
+++ b/src/plugin/init/utils/qa/prompt.ts
@@ -98,28 +98,38 @@ export const promptForHomepage = async (
   });
 };
 
-export type OptionalLangAnswers = {
-  name?: string;
-  description?: string;
+export type LangAnswers = {
+  name: string;
+  description: string;
   homepage?: string;
 };
 
-export const promptForOptionalLang = async (
+export const promptForLang = async <R extends boolean = false>(
   m: BoundMessage,
-  supportLang: Exclude<SupportLang, "En">,
-  defaultName: string,
-  defaultDescription: string,
-): Promise<OptionalLangAnswers> => {
-  const support = await promptForSupportLang(m, supportLang);
-  if (!support) {
-    return {};
+  options: {
+    required?: R;
+    supportLang: SupportLang;
+    defaultName: string;
+    defaultDescription?: string;
+  },
+): Promise<R extends true ? LangAnswers : Partial<LangAnswers>> => {
+  // NOTE: lang en is always required
+  if (!options.required && options.supportLang !== "En") {
+    const support = await promptForSupportLang(m, options.supportLang);
+    if (!support) {
+      return {} as R extends true ? LangAnswers : Partial<LangAnswers>;
+    }
   }
-  const name = await promptForOptionalName(m, supportLang, defaultName);
+  const name = await promptForOptionalName(
+    m,
+    options.supportLang,
+    options.defaultName,
+  );
   const description = await promptForOptionalDescription(
     m,
-    supportLang,
-    defaultDescription,
+    options.supportLang,
+    options.defaultDescription || name,
   );
-  const homepage = await promptForHomepage(m, supportLang);
+  const homepage = await promptForHomepage(m, options.supportLang);
   return { name, description, homepage };
 };

--- a/src/plugin/init/utils/qa/validator.ts
+++ b/src/plugin/init/utils/qa/validator.ts
@@ -12,3 +12,5 @@ export const validateForOptionalName = (value: string) =>
 
 export const validateForOptionalDescription = (value: string) =>
   value.length === 0 || value.length <= DESCRIPTION_MAX_LENGTH;
+
+export const validateForProjectName = (value: string) => value.length > 0;


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

  ## Why

  <!-- Why do you want the feature and why does it make sense for the package? -->
  Change the `--name` option of the `plugin init` command from required to optional, allowing users to input the project name interactively for a better
  user experience.

  ## What

  <!-- What is a solution you want to add? -->
  - Make `--name` option optional
  - Add project name input prompt (`Q_ProjectName`)
  - Improve multi-language support (ja/zh/es) question flow
    - Add `promptForOptionalLang` to ask name/description/homepage together for each language
    - Set English name/description as default values
  - Remove unused prompt functions (`promptForSupportMobile`, etc.)
  - Change `initPlugin` arguments to object format

  ## How to test

  <!-- How can we test this pull request? -->
  - Run `pnpm test` to verify unit tests pass
  - Run `cli-kintone plugin init` without `--name` option and confirm project name prompt appears
## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
