### PR TITLE
fix: run `keygen` on `plugin init`

### DIFF
--- a/src/plugin/init/usecases/init.ts
+++ b/src/plugin/init/usecases/init.ts
@@ -7,6 +7,7 @@ import { logger } from "../../../utils/log";
 import path from "path";
 import fs from "fs";
 import { installDependencies } from "../utils/deps";
+import { runKeygen } from "../utils/keygen";
 import { isDirectory } from "../../../utils/file";
 
 const getSuccessCreatedPluginMessage = (
@@ -91,6 +92,7 @@ export const initPlugin = async (options: InitPluginOptions) => {
     });
     logger.info(m("templateSetupCompleted"));
     installDependencies(answers.projectName, options.lang);
+    runKeygen(answers.projectName, options.lang);
     logger.info(
       getSuccessCreatedPluginMessage(
         packageName,

--- a/src/plugin/init/utils/keygen.ts
+++ b/src/plugin/init/utils/keygen.ts
@@ -1,0 +1,26 @@
+import { spawnSync } from "child_process";
+import type { Lang } from "./lang";
+import { getMessage } from "./messages";
+import { logger } from "../../../utils/log";
+
+/**
+ * Run npm run keygen to generate private key
+ * @param targetDirectory
+ * @param lang
+ */
+export const runKeygen = (targetDirectory: string, lang: Lang): void => {
+  logger.info(getMessage(lang, "generatingPrivateKey"));
+  logger.debug(`targetDirectory: ${targetDirectory}`);
+
+  const result = spawnSync("npm", ["run", "keygen"], {
+    cwd: targetDirectory,
+    stdio: "inherit",
+    // TODO: Consider to remove shell option to avoid security vulnerability
+    shell: true,
+  });
+  if (result.status !== 0) {
+    logger.debug("private key generation failed");
+    throw new Error("Generating private key failed");
+  }
+  logger.info(getMessage(lang, "privateKeyGenerated"));
+};

--- a/src/plugin/init/utils/messages.ts
+++ b/src/plugin/init/utils/messages.ts
@@ -124,6 +124,14 @@ const messages = {
     en: "Dependencies installed successfully",
     ja: "依存パッケージのインストールが完了しました",
   },
+  generatingPrivateKey: {
+    en: "Starting to generate private key...",
+    ja: "秘密鍵の生成を開始します...",
+  },
+  privateKeyGenerated: {
+    en: "Private key generated successfully",
+    ja: "秘密鍵の生成が完了しました",
+  },
   introduction: {
     en: `
 Please answer some questions to create your Kintone plug-in project :)


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Currently, after running `plugin init` to create a new plugin project, users must manually run `npm run
keygen` to generate the private key required for building the plugin. If users forget this step, they will
encounter errors when running `npm run build` or `npm start`.

This change improves the developer experience by automating the private key generation, allowing users to
start development immediately after project creation.

## What

<!-- What is a solution you want to add? -->

- Added `runKeygen` function in `src/plugin/init/utils/keygen.ts` that executes `npm run keygen`
- Modified `src/plugin/init/usecases/init.ts` to call `runKeygen` after `installDependencies`
- Added messages for private key generation (English and Japanese) in `src/plugin/init/utils/messages.ts`

Now the `plugin init` command automatically:
1. Sets up the project template
2. Installs dependencies (`npm install`)
3. Generates private key (`npm run keygen`) ← **New**
4. Shows success message

## How to test

<!-- How can we test this pull request? -->

```
# Build cli-kintone
pnpm install
pnpm build

# Create a new plugin project
node cli.js plugin init --name hello-kintone

# Follow the prompts to create a project

# Verify that private.ppk file is generated
ls -la hello-kintone/private.ppk

# Verify that build works without additional setup
cd hello-kintone
npm run build

# The build should succeed without errors
```

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.
