### PR TITLE
fix: uncaught error caused by missing await

### DIFF
--- a/src/cli/plugin/init.ts
+++ b/src/cli/plugin/init.ts
@@ -39,7 +39,7 @@ const handler = async (args: Args) => {
     if (process.env.NODE_ENV === "test") {
       console.log(JSON.stringify({ flags: flags }));
     } else {
-      run(flags);
+      await run(flags);
     }
   } catch (error) {
     logger.error(new RunError(error));

--- a/src/plugin/init/index.ts
+++ b/src/plugin/init/index.ts
@@ -6,7 +6,7 @@ type Options = {
 };
 
 export const run: (argv: Options) => Promise<void> = async (argv) => {
-  initPlugin({
+  await initPlugin({
     name: argv.name,
     lang: "en",
     template: argv.template,


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

An async function was called without `await`, which caused a rejected Promise to escape error handling and result in an uncaught error at runtime.

This made error behavior inconsistent and harder to debug, especially since the failure did not surface at the expected call site.

## What

This PR fixes the issue by properly awaiting the async call.

By ensuring the Promise is awaited, errors are now handled as intended and no longer result in uncaught errors.

## How to test


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
