### PR TITLE
chore: enable erasableSyntaxOnly

### DIFF
--- a/features/utils/credentials.ts
+++ b/features/utils/credentials.ts
@@ -68,7 +68,7 @@ type UserCredentialRecord = {
   };
 };
 
-export const TOKEN_PERMISSIONS = <const>["view", "add", "edit", "delete"];
+export const TOKEN_PERMISSIONS = ["view", "add", "edit", "delete"] as const;
 
 export type Permission = (typeof TOKEN_PERMISSIONS)[number];
 

--- a/features/utils/helper.ts
+++ b/features/utils/helper.ts
@@ -2,7 +2,7 @@ import { spawn, spawnSync } from "child_process";
 import path from "path";
 import { QueryBuilder } from "./queryBuilder";
 
-export const SUPPORTED_ENCODING = <const>["utf8", "sjis"];
+export const SUPPORTED_ENCODING = ["utf8", "sjis"] as const;
 export type SupportedEncoding = (typeof SUPPORTED_ENCODING)[number];
 
 export type ReplacementValue = string | string[] | number | number[] | boolean;

--- a/features/utils/queryBuilder/record/command.ts
+++ b/features/utils/queryBuilder/record/command.ts
@@ -22,7 +22,7 @@ import {
 import type { Command, Subcommand } from "../index";
 
 export const RECORD = "record";
-export const SUPPORTED_COMMANDS = <const>[RECORD];
+export const SUPPORTED_COMMANDS = [RECORD] as const;
 
 export type CommandType = (typeof SUPPORTED_COMMANDS)[number];
 

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -10,7 +10,7 @@ export interface Logger {
   fatal: (message: any) => void;
 }
 
-export const LOG_CONFIG_LEVELS = <const>[
+export const LOG_CONFIG_LEVELS = [
   "trace",
   "debug",
   "info",
@@ -18,7 +18,7 @@ export const LOG_CONFIG_LEVELS = <const>[
   "error",
   "fatal",
   "none",
-];
+] as const;
 
 export type LogConfigLevel = (typeof LOG_CONFIG_LEVELS)[number];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
      "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+     "erasableSyntaxOnly": true,            /* Only allow erasable syntax (no enums, namespaces with runtime code, etc.). */
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

  ## Why

  <!-- Why do you want the feature and why does it make sense for the package? -->

  To improve compatibility with Node.js's `--experimental-strip-types` flag and transpilers like tsx by enforcing erasable-only TypeScript syntax.

  ## What

  <!-- What is a solution you want to add? -->

  - Add `erasableSyntaxOnly: true` to `tsconfig.json`
  - This option disallows non-erasable TypeScript syntax such as enums and namespaces that generate runtime code

  ## How to test

  <!-- How can we test this pull request? -->

  - Run `pnpm tsc --noEmit` and verify no errors occur

  ## Checklist

  - [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
  - [x] Updated documentation if it is required.
  - [x] Added/updated tests if it is required. (or tested manually)
  - [x] Passed `pnpm lint` and `pnpm test` on the root directory.