### PR TITLE
feat: official release of plugin and customize commands

### DIFF
--- a/src/cli/customize/apply.ts
+++ b/src/cli/customize/apply.ts
@@ -2,7 +2,6 @@ import type yargs from "yargs";
 import type { CommandModule } from "yargs";
 import { logger } from "../../utils/log";
 import { RunError } from "../../record/error";
-import { setStability } from "../stability";
 import { commonOptions } from "../commonOptions";
 import { runApply } from "../../customize/apply";
 
@@ -63,13 +62,9 @@ const handler = async (args: Args) => {
   }
 };
 
-export const applyCommand: CommandModule<{}, Args> = setStability(
-  {
-    command,
-    describe,
-    builder,
-    handler,
-  },
-  "experimental",
-  "This feature is under early development",
-);
+export const applyCommand: CommandModule<{}, Args> = {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/src/cli/customize/export.ts
+++ b/src/cli/customize/export.ts
@@ -2,7 +2,6 @@ import type yargs from "yargs";
 import type { CommandModule } from "yargs";
 import { logger } from "../../utils/log";
 import { RunError } from "../../record/error";
-import { setStability } from "../stability";
 import { commonOptions } from "../commonOptions";
 import { runExport } from "../../customize/export";
 
@@ -64,13 +63,9 @@ const handler = async (args: Args) => {
   }
 };
 
-export const exportCommand: CommandModule<{}, Args> = setStability(
-  {
-    command,
-    describe,
-    builder,
-    handler,
-  },
-  "experimental",
-  "This feature is under early development",
-);
+export const exportCommand: CommandModule<{}, Args> = {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/src/cli/customize/index.ts
+++ b/src/cli/customize/index.ts
@@ -3,7 +3,6 @@ import type yargs from "yargs";
 import { applyCommand } from "./apply";
 import { initCommand } from "./init";
 import { exportCommand } from "./export";
-import { setStability } from "../stability";
 
 const command = "customize";
 
@@ -20,13 +19,9 @@ const handler = () => {
   /** noop **/
 };
 
-export const customizeCommand: CommandModule = setStability(
-  {
-    command,
-    describe,
-    builder,
-    handler,
-  },
-  "experimental",
-  "This feature is under early development",
-);
+export const customizeCommand: CommandModule = {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/src/cli/customize/init.ts
+++ b/src/cli/customize/init.ts
@@ -2,7 +2,6 @@ import type yargs from "yargs";
 import type { CommandModule } from "yargs";
 import { logger } from "../../utils/log";
 import { RunError } from "../../record/error";
-import { setStability } from "../stability";
 import { runInit } from "../../customize/init";
 
 const command = "init";
@@ -42,13 +41,9 @@ const handler = async (args: Args) => {
   }
 };
 
-export const initCommand: CommandModule<{}, Args> = setStability(
-  {
-    command,
-    describe,
-    builder,
-    handler,
-  },
-  "experimental",
-  "This feature is under early development",
-);
+export const initCommand: CommandModule<{}, Args> = {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/src/cli/plugin/index.ts
+++ b/src/cli/plugin/index.ts
@@ -4,7 +4,6 @@ import { keygenCommand } from "./keygen";
 import { packCommand } from "./pack";
 import { infoCommand } from "./info";
 import { uploadCommand } from "./upload";
-import { setStability } from "../stability";
 import { initCommand } from "./init";
 
 const command = "plugin";
@@ -24,13 +23,9 @@ const handler = () => {
   /** noop **/
 };
 
-export const pluginCommand: CommandModule = setStability(
-  {
-    command,
-    describe,
-    builder,
-    handler,
-  },
-  "experimental",
-  "This feature is under early development",
-);
+export const pluginCommand: CommandModule = {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/src/cli/plugin/info.ts
+++ b/src/cli/plugin/info.ts
@@ -4,7 +4,6 @@ import type { OutputFormat } from "../../plugin/info/";
 import { run } from "../../plugin/info/";
 import { logger } from "../../utils/log";
 import { RunError } from "../../record/error";
-import { setStability } from "../stability";
 
 const command = "info";
 
@@ -42,13 +41,9 @@ const handler = async (args: Args) => {
   }
 };
 
-export const infoCommand: CommandModule<{}, Args> = setStability(
-  {
-    command,
-    describe,
-    builder,
-    handler,
-  },
-  "experimental",
-  "This feature is under early development",
-);
+export const infoCommand: CommandModule<{}, Args> = {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/src/cli/plugin/init.ts
+++ b/src/cli/plugin/init.ts
@@ -3,7 +3,6 @@ import type { CommandModule } from "yargs";
 
 import { logger } from "../../utils/log";
 import { RunError } from "../../record/error";
-import { setStability } from "../stability";
 import { run } from "../../plugin/init";
 
 const command = "init";
@@ -48,13 +47,9 @@ const handler = async (args: Args) => {
   }
 };
 
-export const initCommand: CommandModule<{}, Args> = setStability(
-  {
-    command,
-    describe,
-    builder,
-    handler,
-  },
-  "experimental",
-  "This feature is under early development",
-);
+export const initCommand: CommandModule<{}, Args> = {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/src/cli/plugin/keygen.ts
+++ b/src/cli/plugin/keygen.ts
@@ -2,7 +2,6 @@ import type yargs from "yargs";
 import type { CommandModule } from "yargs";
 import { logger } from "../../utils/log";
 import { RunError } from "../../record/error";
-import { setStability } from "../stability";
 import { keygen } from "../../plugin/keygen";
 
 const command = "keygen";
@@ -32,13 +31,9 @@ const handler = async (args: Args) => {
   }
 };
 
-export const keygenCommand: CommandModule<{}, Args> = setStability(
-  {
-    command,
-    describe,
-    builder,
-    handler,
-  },
-  "experimental",
-  "This feature is under early development",
-);
+export const keygenCommand: CommandModule<{}, Args> = {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/src/cli/plugin/pack.ts
+++ b/src/cli/plugin/pack.ts
@@ -3,7 +3,6 @@ import type { CommandModule } from "yargs";
 import { pack } from "../../plugin/packer/";
 import { logger } from "../../utils/log";
 import { RunError } from "../../record/error";
-import { setStability } from "../stability";
 
 const command = "pack";
 
@@ -62,13 +61,9 @@ const handler = async (args: Args) => {
   }
 };
 
-export const packCommand: CommandModule<{}, Args> = setStability(
-  {
-    command,
-    describe,
-    builder,
-    handler,
-  },
-  "experimental",
-  "This feature is under early development",
-);
+export const packCommand: CommandModule<{}, Args> = {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/src/cli/plugin/upload.ts
+++ b/src/cli/plugin/upload.ts
@@ -2,7 +2,6 @@ import type yargs from "yargs";
 import type { CommandModule } from "yargs";
 import { logger } from "../../utils/log";
 import { RunError } from "../../record/error";
-import { setStability } from "../stability";
 import { commonOptions } from "../commonOptions";
 import type { Params } from "../../plugin/upload";
 import { upload } from "../../plugin/upload";
@@ -70,13 +69,9 @@ const handler = async (args: Args) => {
   }
 };
 
-export const uploadCommand: CommandModule<{}, Args> = setStability(
-  {
-    command,
-    describe,
-    builder,
-    handler,
-  },
-  "experimental",
-  "This feature is under early development",
-);
+export const uploadCommand: CommandModule<{}, Args> = {
+  command,
+  describe,
+  builder,
+  handler,
+};

--- a/src/plugin/init/utils/deps.ts
+++ b/src/plugin/init/utils/deps.ts
@@ -15,10 +15,9 @@ export const installDependencies = (
   logger.info(getMessage(lang, "installDependencies"));
   logger.debug(`targetDirectory: ${targetDirectory}`);
 
-  const result = spawnSync("npm", ["install"], {
+  const result = spawnSync("npm install", {
     cwd: targetDirectory,
     stdio: "inherit",
-    // TODO: Consider to remove shell option to avoid security vulnerability
     shell: true,
   });
   if (result.status !== 0) {

--- a/src/plugin/init/utils/keygen.ts
+++ b/src/plugin/init/utils/keygen.ts
@@ -12,10 +12,9 @@ export const runKeygen = (targetDirectory: string, lang: Lang): void => {
   logger.info(getMessage(lang, "generatingPrivateKey"));
   logger.debug(`targetDirectory: ${targetDirectory}`);
 
-  const result = spawnSync("npm", ["run", "keygen"], {
+  const result = spawnSync("npm run keygen", {
     cwd: targetDirectory,
     stdio: "inherit",
-    // TODO: Consider to remove shell option to avoid security vulnerability
     shell: true,
   });
   if (result.status !== 0) {

--- a/website/docs/guide/commands/customize-apply.md
+++ b/website/docs/guide/commands/customize-apply.md
@@ -6,12 +6,6 @@ sidebar_position: 600
 
 The `customize apply` command allows you to apply JavaScript/CSS customization to a Kintone app from a manifest file.
 
-:::experimental
-
-This feature is under early development.
-
-:::
-
 ## Example
 
 ```shell

--- a/website/docs/guide/commands/customize-export.md
+++ b/website/docs/guide/commands/customize-export.md
@@ -6,12 +6,6 @@ sidebar_position: 500
 
 The `customize export` command allows you to export JavaScript/CSS customization settings from a Kintone app.
 
-:::experimental
-
-This feature is under early development.
-
-:::
-
 ## Example
 
 ```shell

--- a/website/docs/guide/commands/customize-init.md
+++ b/website/docs/guide/commands/customize-init.md
@@ -6,12 +6,6 @@ sidebar_position: 400
 
 The `customize init` command allows you to initialize a manifest file for JavaScript/CSS customization.
 
-:::experimental
-
-This feature is under early development.
-
-:::
-
 ## Example
 
 ```shell

--- a/website/docs/guide/commands/plugin-info.md
+++ b/website/docs/guide/commands/plugin-info.md
@@ -6,12 +6,6 @@ sidebar_position: 1100
 
 The `plugin info` command allows you to see information of the plugin zip file.
 
-:::experimental
-
-This feature is under early development.
-
-:::
-
 ## Example
 
 ```shell

--- a/website/docs/guide/commands/plugin-init.md
+++ b/website/docs/guide/commands/plugin-init.md
@@ -6,12 +6,6 @@ sidebar_position: 1200
 
 The `plugin init` command allows you to initialize a new kintone plugin project.
 
-:::experimental
-
-This feature is under early development.
-
-:::
-
 ## Example
 
 ```shell

--- a/website/docs/guide/commands/plugin-keygen.md
+++ b/website/docs/guide/commands/plugin-keygen.md
@@ -6,12 +6,6 @@ sidebar_position: 1300
 
 The `plugin keygen` command generates private key for a plugin.
 
-:::experimental
-
-This feature is under early development.
-
-:::
-
 ## Example
 
 ```shell

--- a/website/docs/guide/commands/plugin-pack.md
+++ b/website/docs/guide/commands/plugin-pack.md
@@ -6,12 +6,6 @@ sidebar_position: 1400
 
 The `plugin pack` command allows you to packaging kintone plugin project.
 
-:::experimental
-
-This feature is under early development.
-
-:::
-
 ## Example
 
 ```shell

--- a/website/docs/guide/commands/plugin-upload.md
+++ b/website/docs/guide/commands/plugin-upload.md
@@ -6,12 +6,6 @@ sidebar_position: 1600
 
 The `plugin upload` command allows you to upload a plugin to a kintone environment.
 
-:::experimental
-
-This feature is under early development.
-
-:::
-
 **Notice**
 
 - This command only supports password authentication.

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/customize-apply.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/customize-apply.md
@@ -6,12 +6,6 @@ sidebar_position: 600
 
 `customize apply`コマンドは、マニフェストファイルからKintoneアプリにJavaScript/CSSカスタマイズを適用します。
 
-:::experimental
-
-この機能は開発初期段階です。
-
-:::
-
 ## 例
 
 ```shell

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/customize-export.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/customize-export.md
@@ -6,12 +6,6 @@ sidebar_position: 500
 
 `customize export`コマンドは、KintoneアプリからJavaScript/CSSカスタマイズ設定をエクスポートします。
 
-:::experimental
-
-この機能は開発初期段階です。
-
-:::
-
 ## 例
 
 ```shell

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/customize-init.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/customize-init.md
@@ -6,12 +6,6 @@ sidebar_position: 400
 
 `customize init`コマンドは、JavaScript/CSSカスタマイズ用のマニフェストファイルを初期化します。
 
-:::experimental
-
-この機能は開発初期段階です。
-
-:::
-
 ## 例
 
 ```shell

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/plugin-info.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/plugin-info.md
@@ -6,12 +6,6 @@ sidebar_position: 1100
 
 `plugin info`コマンドは、プラグインzipファイルの情報を表示します。
 
-:::experimental
-
-この機能は開発初期段階です。
-
-:::
-
 ## 例
 
 ```shell

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/plugin-init.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/plugin-init.md
@@ -6,12 +6,6 @@ sidebar_position: 1200
 
 `plugin init`コマンドは、新しいkintoneプラグイン開発プロジェクトを初期化します。
 
-:::experimental
-
-この機能は開発初期段階です。
-
-:::
-
 ## 例
 
 ```shell

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/plugin-keygen.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/plugin-keygen.md
@@ -6,12 +6,6 @@ sidebar_position: 1300
 
 `plugin keygen`コマンドは、プラグイン用の秘密鍵を生成します。
 
-:::experimental
-
-この機能は開発初期段階です。
-
-:::
-
 ## 例
 
 ```shell

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/plugin-pack.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/plugin-pack.md
@@ -6,12 +6,6 @@ sidebar_position: 1400
 
 `plugin pack`コマンドは、kintoneプラグインプロジェクトをパッケージ化します。
 
-:::experimental
-
-この機能は開発初期段階です。
-
-:::
-
 ## 例
 
 ```shell

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/plugin-upload.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/plugin-upload.md
@@ -6,12 +6,6 @@ sidebar_position: 1600
 
 `plugin upload`コマンドは、プラグインをkintone環境にアップロードします。
 
-:::experimental
-
-この機能は開発初期段階です。
-
-:::
-
 **注意**
 
 - このコマンドはパスワード認証のみをサポートしています。


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

The `plugin` and `customize` commands have been stable and well-tested since their initial release. Removing the experimental flag will encourage wider adoption and signal to users that these features are ready for production use.

## What

<!-- What is a solution you want to add? -->

Remove the `experimental` stability flag from `plugin` and `customize` commands to promote them to stable status.

### CLI (10 files)
- Removed `setStability` import and wrapper from all plugin subcommands (`index.ts`, `init.ts`, `pack.ts`, `keygen.ts`, `upload.ts`, `info.ts`)
- Removed `setStability` import and wrapper from all customize subcommands (`index.ts`, `init.ts`, `apply.ts`, `export.ts`)

### Documentation (16 files)
- Removed `:::experimental` admonition blocks from English docs (8 files)
- Removed `:::experimental` admonition blocks from Japanese docs (8 files)

## How to test

<!-- How can we test this pull request? -->

```bash
# Build and verify help output (no [Experimental: ...] prefix)
pnpm build
./cli.js plugin --help
./cli.js customize --help

# Run tests
pnpm test

# Build and verify documentation site
cd website && pnpm build
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
