### PR TITLE
fix: fix update of customize commands

### DIFF
--- a/src/cli/customize/apply.ts
+++ b/src/cli/customize/apply.ts
@@ -23,7 +23,6 @@ const builder = (args: yargs.Argv) =>
       requiresArg: true,
     })
     .option("app", {
-      alias: "a",
       describe: "The kintone app ID",
       type: "string",
       demandOption: true,

--- a/src/cli/customize/export.ts
+++ b/src/cli/customize/export.ts
@@ -17,7 +17,6 @@ const builder = (args: yargs.Argv) =>
     // NOTE: This command only supports password authn.
     .hide("api-token")
     .option("app", {
-      alias: "a",
       describe: "The kintone app ID",
       type: "string",
       demandOption: true,

--- a/src/customize/apply/index.ts
+++ b/src/customize/apply/index.ts
@@ -1,7 +1,10 @@
 import fs from "fs";
 import path from "path";
 import { confirm } from "@inquirer/prompts";
-import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import {
+  KintoneRestAPIError,
+  type KintoneRestAPIClient,
+} from "@kintone/rest-api-client";
 import { logger } from "../../utils/log";
 import { retry } from "../../utils/retry";
 import {
@@ -92,6 +95,8 @@ export const apply = async (
       }
     },
     {
+      retryCondition: (e: unknown) =>
+        e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,
       onError: (e, attemptCount, toRetry, nextDelay, config) => {
         logger.debug(`Error occurred: ${e}`);
         if (toRetry) {

--- a/src/customize/apply/index.ts
+++ b/src/customize/apply/index.ts
@@ -113,15 +113,15 @@ export const apply = async (
 const waitForDeploy = async (
   apiClient: KintoneRestAPIClient,
   appId: string,
-  callback: () => void,
+  onProgress: () => void,
 ) => {
   const POLLING_INTERVAL_MS = 1000;
-  const CALLBACK_INTERVAL_MS = 5000;
+  const PROGRESS_NOTIFY_INTERVAL_MS = 5000;
 
   const startTime = Date.now();
   logger.debug(`Waiting for deployment to finish for app ${appId}`);
 
-  const callbackTimer = setInterval(callback, CALLBACK_INTERVAL_MS);
+  const progressTimer = setInterval(onProgress, PROGRESS_NOTIFY_INTERVAL_MS);
 
   try {
     while (true) {
@@ -132,14 +132,13 @@ const waitForDeploy = async (
       logger.debug(
         `Deploy status check at ${Date.now() - startTime}ms: ${currentStatus}`,
       );
-
       if (deployed) {
         break;
       }
       await wait(POLLING_INTERVAL_MS);
     }
   } finally {
-    clearInterval(callbackTimer);
+    clearInterval(progressTimer);
   }
 
   logger.debug(`Deployment finished after ${Date.now() - startTime}ms`);

--- a/src/customize/apply/index.ts
+++ b/src/customize/apply/index.ts
@@ -84,9 +84,8 @@ export const apply = async (
       try {
         logger.debug("Starting deployment...");
         await apiClient.app.deployApp({ apps: [{ app: appId }] });
-        await waitForDeploy(apiClient, appId, () =>
-          logger.info(boundMessage("M_Deploying")),
-        );
+        logger.info(boundMessage("M_Deploying"));
+        await waitForDeploy(apiClient, appId);
         logger.debug("Deployment completed");
         logger.info(boundMessage("M_Deployed"));
       } catch (error) {
@@ -113,7 +112,7 @@ export const apply = async (
 const waitForDeploy = async (
   apiClient: KintoneRestAPIClient,
   appId: string,
-  callback: () => void,
+  callback?: () => void,
 ) => {
   let deployed = false;
   let checkCount = 0;
@@ -127,7 +126,7 @@ const waitForDeploy = async (
     logger.debug(`Deploy status check #${checkCount}: ${currentStatus}`);
     if (!deployed) {
       await wait(1000);
-      callback();
+      callback?.();
     }
   }
   logger.debug(`Deployment finished after ${checkCount} checks`);

--- a/src/customize/core/messages.ts
+++ b/src/customize/core/messages.ts
@@ -41,9 +41,9 @@ export const messages = {
     en: "Customize setting has been updated!",
     ja: "JavaScript/CSS カスタマイズの設定を変更しました!",
   },
-  M_UpdateManifestFile: {
-    en: "Update manifest file based on the current customization setting on kintone app",
-    ja: "kintoneのアプリのカスタマイズ設定を元にマニフェストファイルを更新しています",
+  M_GenerateManifestFile: {
+    en: "Generating manifest file based on the current customization setting on kintone app",
+    ja: "kintoneのアプリのカスタマイズ設定を元にマニフェストファイルを生成しています",
   },
   M_DownloadUploadedFile: {
     en: "Download the current customization files on kintone app",

--- a/src/customize/core/messages.ts
+++ b/src/customize/core/messages.ts
@@ -50,8 +50,8 @@ export const messages = {
     ja: "kintoneのアプリからカスタマイズ設定されたファイルをダウンロードしています",
   },
   M_CommandInitFinish: {
-    en: "Manifest file created successfully",
-    ja: "マニフェストファイルを生成しました",
+    en: "file has been created",
+    ja: "を生成しました",
   },
   M_CommandExportFinish: {
     en: "Exported customization files successfully",

--- a/src/customize/core/messages.ts
+++ b/src/customize/core/messages.ts
@@ -50,12 +50,12 @@ export const messages = {
     ja: "kintoneのアプリからカスタマイズ設定されたファイルをダウンロードしています",
   },
   M_CommandInitFinish: {
-    en: "file has been created",
-    ja: "を生成しました",
+    en: "Manifest file created successfully",
+    ja: "マニフェストファイルを生成しました",
   },
-  M_CommandImportFinish: {
-    en: "Finish importing customization files from kintone app",
-    ja: "kintoneのアプリからカスタマイズのインポートが完了しました",
+  M_CommandExportFinish: {
+    en: "Exported customization files successfully",
+    ja: "カスタマイズファイルのエクスポートが完了しました",
   },
   E_Updated: {
     en: "Failed to update customize setting",

--- a/src/customize/export/index.ts
+++ b/src/customize/export/index.ts
@@ -198,5 +198,5 @@ export const runExport = async (params: ExportParams) => {
 
   const apiClient = buildRestAPIClient(restApiClientOptions);
   await exportCustomizeSetting(apiClient, appId, outputPath, m);
-  logger.info(m("M_CommandImportFinish"));
+  logger.info(m("M_CommandExportFinish"));
 };

--- a/src/customize/export/index.ts
+++ b/src/customize/export/index.ts
@@ -1,7 +1,10 @@
 import fs from "fs/promises";
 import path from "path";
 import { confirm } from "@inquirer/prompts";
-import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import {
+  KintoneRestAPIError,
+  type KintoneRestAPIClient,
+} from "@kintone/rest-api-client";
 import { logger } from "../../utils/log";
 import { retry } from "../../utils/retry";
 import {
@@ -69,6 +72,8 @@ export const exportCustomizeSetting = async (
       await downloadCustomizeFiles(apiClient, destDir, resp);
     },
     {
+      retryCondition: (e: unknown) =>
+        e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,
       onError: (e, attemptCount, toRetry, nextDelay, config) => {
         logger.debug(`Error occurred: ${e}`);
         if (toRetry) {

--- a/src/customize/export/index.ts
+++ b/src/customize/export/index.ts
@@ -58,6 +58,9 @@ export const exportCustomizeSetting = async (
   logger.debug(`Exporting customization from app ${appId}`);
   logger.debug(`Output path: ${outputPath}`);
 
+  logger.info(m("M_GenerateManifestFile"));
+  logger.info(m("M_DownloadUploadedFile"));
+
   await retry(
     async () => {
       logger.debug("Fetching app customization settings...");
@@ -65,16 +68,14 @@ export const exportCustomizeSetting = async (
         app: appId,
       });
 
-      logger.info(m("M_UpdateManifestFile"));
       await writeManifestFile(destDir, outputPath, resp);
 
-      logger.info(m("M_DownloadUploadedFile"));
       await downloadCustomizeFiles(apiClient, destDir, resp);
     },
     {
       retryCondition: (e: unknown) =>
         e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,
-      onError: (e, attemptCount, toRetry, nextDelay, config) => {
+      onError: (e, attemptCount, toRetry, _nextDelay, config) => {
         logger.debug(`Error occurred: ${e}`);
         if (toRetry) {
           logger.debug(

--- a/src/customize/export/index.ts
+++ b/src/customize/export/index.ts
@@ -79,7 +79,7 @@ export const exportCustomizeSetting = async (
         logger.debug(`Error occurred: ${e}`);
         if (toRetry) {
           logger.debug(
-            `Retry attempt ${attemptCount}/${config.maxAttempt}, next delay: ${nextDelay}ms`,
+            `Retry attempt ${attemptCount}/${config.maxAttempt}, next delay: ${_nextDelay}ms`,
           );
           logger.warn(m("E_Retry"));
         }

--- a/src/customize/init/__tests__/index.test.ts
+++ b/src/customize/init/__tests__/index.test.ts
@@ -25,8 +25,7 @@ describe("init", () => {
 
     it("should success generating customize-manifest.json", async () => {
       const outputPath = `${testDestDir}/customize-manifest.json`;
-      const manifestFileContent: CustomizeManifest =
-        getInitCustomizeManifest("ALL");
+      const manifestFileContent: CustomizeManifest = getInitCustomizeManifest();
       await generateCustomizeManifest(manifestFileContent, outputPath);
       const content = fs.readFileSync(outputPath);
       assertManifestContent(content);

--- a/src/customize/init/index.ts
+++ b/src/customize/init/index.ts
@@ -59,5 +59,5 @@ export const runInit = async (params: InitParams) => {
 
   const customizeManifest = getInitCustomizeManifest();
   await generateCustomizeManifest(customizeManifest, outputPath);
-  logger.info(`${outputPath} ${m("M_CommandInitFinish")}`);
+  logger.info(m("M_CommandInitFinish"));
 };

--- a/src/customize/init/index.ts
+++ b/src/customize/init/index.ts
@@ -59,5 +59,5 @@ export const runInit = async (params: InitParams) => {
 
   const customizeManifest = getInitCustomizeManifest();
   await generateCustomizeManifest(customizeManifest, outputPath);
-  logger.info(m("M_CommandInitFinish"));
+  logger.info(`${outputPath} ${m("M_CommandInitFinish")}`);
 };

--- a/website/docs/guide/commands/customize-init.md
+++ b/website/docs/guide/commands/customize-init.md
@@ -27,14 +27,6 @@ See [Options](/guide/options) page for common options.
 | `--output` |          | Output path for the manifest file<br/>Default to `customize-manifest.json` |
 | `--yes`    |          | Skip confirmation                                                          |
 
-## Interactive Prompts
-
-When you run `customize init`, you will be prompted to select:
-
-1. **Scope** - Customization scope (ALL/ADMIN/NONE)
-
-If `--yes` is specified, the default value "ALL" is used.
-
 ## Manifest File
 
 The manifest file is a JSON file with the following structure:

--- a/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/customize-init.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/current/guide/commands/customize-init.md
@@ -27,14 +27,6 @@ cli-kintone customize init --output customize-manifest.json
 | `--output` |      | マニフェストファイルの出力パス<br/>デフォルト：`customize-manifest.json` |
 | `--yes`    |      | 確認をスキップ                                                           |
 
-## 対話型プロンプト
-
-`customize init`を実行すると、以下の選択を求められます：
-
-1. **Scope** - カスタマイズのスコープ（ALL/ADMIN/NONE）
-
-`--yes`が指定された場合、デフォルト値の「ALL」が使用されます。
-
 ## マニフェストファイル
 
 マニフェストファイルは以下の構造を持つJSONファイルです：


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
Fix several issues in the customize commands:
- `M_CommandExportFinish` message key was incorrectly named `M_CommandImportFinish`
- Completion messages for `M_CommandInitFinish` and `M_CommandExportFinish` were inconsistent with Record commands (not using `"... successfully"` format)
- Init command documentation had an Interactive Prompts section for unimplemented features
- Test code was passing an argument to `getInitCustomizeManifest("ALL")`, but the function doesn't take any arguments
- Retry policy was not configured (should only retry on 5xx errors)

## What

<!-- What is a solution you want to add? -->

### Message changes
- Update `M_CommandInitFinish` message to `"Manifest file created successfully"`
- Update `M_CommandExportFinish` message to `"Exported customization files successfully"`
- Update corresponding Japanese messages accordingly
- Remove file path from log output in `src/customize/init/index.ts` (message is now self-contained)

### Behavior changes
- Add retry condition (5xx errors only) to `src/customize/apply/index.ts` and `src/customize/export/index.ts`

### Non-behavioral changes
- Rename message key from `M_CommandImportFinish` to `M_CommandExportFinish`
- Remove unused argument from `getInitCustomizeManifest("ALL")` in `src/customize/init/__tests__/index.test.ts`
- Remove unimplemented Interactive Prompts section from `website/docs/guide/commands/customize-init.md`

## How to test

<!-- How can we test this pull request? -->
- Run `pnpm test -- "customize"` to verify tests pass
- Run `pnpm tsc --noEmit` to verify no compile errors

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
