### PR TITLE
test: fix flaky test

### DIFF
--- a/features/step_definitions/record/common.ts
+++ b/features/step_definitions/record/common.ts
@@ -207,11 +207,12 @@ When("I type {string}", function (userInput) {
 
 When("I press Enter", function () {
   return new Promise<void>((resolve) => {
-    this.childProcess.stdin.write("\n");
-    this.childProcess.stdin.end();
     this.childProcess.on("close", () => {
       resolve();
     });
+
+    this.childProcess.stdin.write("\n");
+    this.childProcess.stdin.end();
   });
 });
 

--- a/features/utils/world.ts
+++ b/features/utils/world.ts
@@ -114,21 +114,27 @@ export class OurWorld extends World {
       },
     );
 
-    let stdout: Buffer;
-    let stderr: Buffer;
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
 
     this.childProcess.stdout.on("data", (data: Buffer) => {
-      stdout = data;
+      stdoutChunks.push(data);
     });
 
     this.childProcess.stderr.on("data", (data: Buffer) => {
-      stderr = data;
+      stderrChunks.push(data);
     });
 
     this.childProcess.on("exit", (code: number) => {
       this.response = {
-        stdout: stdout ?? Buffer.from(""),
-        stderr: stderr ?? Buffer.from(""),
+        stdout:
+          stdoutChunks.length > 0
+            ? Buffer.concat(stdoutChunks)
+            : Buffer.from(""),
+        stderr:
+          stderrChunks.length > 0
+            ? Buffer.concat(stderrChunks)
+            : Buffer.from(""),
         status: code,
       };
     });


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Flaky E2E tests were occurring. This PR fixes the root cause and a potential issue:

1. Race condition caused by the order of `childProcess` event listener registration
2. Potential data loss when stdout/stderr `data` events fire multiple times

## What

<!-- What is a solution you want to add? -->

- `features/step_definitions/record/common.ts`: Register `on("close")` event listener before stdin operations in `When("I press Enter")` to prevent event loss
- `features/utils/world.ts`: Accumulate all stdout/stderr chunks in arrays in `execCliKintone` method and concatenate them with `Buffer.concat()` on `exit` event

## How to test

<!-- How can we test this pull request? -->

```bash
pnpm test:e2e:dev
```

Run E2E tests multiple times and verify that flaky tests no longer occur.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
