### PR TITLE
test: add e2e tests of customize commands

### DIFF
--- a/features/assets/customize_manifest/customize-manifest.json
+++ b/features/assets/customize_manifest/customize-manifest.json
@@ -1,0 +1,11 @@
+{
+  "scope": "ALL",
+  "desktop": {
+    "js": ["desktop/js/sample.js"],
+    "css": []
+  },
+  "mobile": {
+    "js": [],
+    "css": []
+  }
+}

--- a/features/assets/customize_manifest/desktop/js/sample.js
+++ b/features/assets/customize_manifest/desktop/js/sample.js
@@ -1,0 +1,2 @@
+// Sample JavaScript customization for cli-kintone E2E test
+console.log("cli-kintone E2E test customization loaded");

--- a/features/customize/apply.feature
+++ b/features/customize/apply.feature
@@ -1,0 +1,53 @@
+@isolated
+@customize-apply
+Feature: customize apply
+
+  @serial(app_for_customize_apply)
+  Scenario: Apply customization from manifest file
+    Given An asset with key "customize_manifest" is available as "manifest"
+    And The app "app_for_customize_apply" has no customization
+    And Load app ID of the app "app_for_customize_apply" as env var: "APP_ID"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with args "customize apply --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --input manifest/customize-manifest.json --username $USERNAME --password $PASSWORD --yes"
+    Then I should get the exit code is zero
+    # Verify customization was applied by exporting it
+    When I run the command with args "customize export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --username $USERNAME --password $PASSWORD --output exported.json --yes"
+    Then I should get the exit code is zero
+    And The file "exported.json" should exist
+    And The customize-manifest at "exported.json" should be a valid template
+    And The customize-manifest at "exported.json" should have desktop js files
+    And The file "desktop/js/sample.js" should exist
+
+  @serial(app_for_customize_apply)
+  Scenario: Skip confirmation by --yes
+    Given An asset with key "customize_manifest" is available as "manifest"
+    And Load app ID of the app "app_for_customize_apply" as env var: "APP_ID"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with args "customize apply --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --input manifest/customize-manifest.json --username $USERNAME --password $PASSWORD --yes"
+    Then I should get the exit code is zero
+
+  @serial(app_for_customize_apply)
+  Scenario: Cancel the operation at confirmation
+    Given An asset with key "customize_manifest" is available as "manifest"
+    And The app "app_for_customize_apply" has no customization
+    And Load app ID of the app "app_for_customize_apply" as env var: "APP_ID"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with a prompt with args "customize apply --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --input manifest/customize-manifest.json --username $USERNAME --password $PASSWORD"
+    And I press Enter
+    Then I should get the exit code is zero
+
+  @serial(app_in_guest_space_for_customize_apply)
+  Scenario: App in a guest space
+    Given An asset with key "customize_manifest" is available as "manifest"
+    And Load app ID of the app "app_in_guest_space_for_customize_apply" as env var: "APP_ID"
+    And Load guest space ID of the app "app_in_guest_space_for_customize_apply" as env var: "GUEST_SPACE_ID"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with args "customize apply --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --input manifest/customize-manifest.json --username $USERNAME --password $PASSWORD --guest-space-id $GUEST_SPACE_ID --yes"
+    Then I should get the exit code is zero
+
+  Scenario: Specified app does not exist
+    Given An asset with key "customize_manifest" is available as "manifest"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with args "customize apply --base-url $$TEST_KINTONE_BASE_URL --app 999999999 --input manifest/customize-manifest.json --username $USERNAME --password $PASSWORD --yes"
+    Then I should get the exit code is non-zero
+    And The output error message should match with the pattern: "GAIA_AP01|not found|404"

--- a/features/customize/apply.feature
+++ b/features/customize/apply.feature
@@ -41,7 +41,7 @@ Feature: customize apply
     Given An asset with key "customize_manifest" is available as "manifest"
     And Load app ID of the app "app_in_guest_space_for_customize_apply" as env var: "APP_ID"
     And Load guest space ID of the app "app_in_guest_space_for_customize_apply" as env var: "GUEST_SPACE_ID"
-    And Load username and password of user "user_for_guest_space" as env vars: "USERNAME" and "PASSWORD"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
     When I run the command with args "customize apply --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --input manifest/customize-manifest.json --username $USERNAME --password $PASSWORD --guest-space-id $GUEST_SPACE_ID --yes"
     Then I should get the exit code is zero
 

--- a/features/customize/apply.feature
+++ b/features/customize/apply.feature
@@ -41,7 +41,7 @@ Feature: customize apply
     Given An asset with key "customize_manifest" is available as "manifest"
     And Load app ID of the app "app_in_guest_space_for_customize_apply" as env var: "APP_ID"
     And Load guest space ID of the app "app_in_guest_space_for_customize_apply" as env var: "GUEST_SPACE_ID"
-    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    And Load username and password of user "user_for_guest_space" as env vars: "USERNAME" and "PASSWORD"
     When I run the command with args "customize apply --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --input manifest/customize-manifest.json --username $USERNAME --password $PASSWORD --guest-space-id $GUEST_SPACE_ID --yes"
     Then I should get the exit code is zero
 

--- a/features/customize/export.feature
+++ b/features/customize/export.feature
@@ -1,0 +1,59 @@
+@isolated
+@customize-export
+Feature: customize export
+
+  @serial(app_for_customize_export)
+  Scenario: Export customization settings
+    Given The app "app_for_customize_export" has customization from asset "customize_manifest"
+    And Load app ID of the app "app_for_customize_export" as env var: "APP_ID"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with args "customize export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --username $USERNAME --password $PASSWORD --yes"
+    Then I should get the exit code is zero
+    And The file "customize-manifest.json" should exist
+    And The customize-manifest at "customize-manifest.json" should be a valid template
+    And The customize-manifest at "customize-manifest.json" should have desktop js files
+    And The file "desktop/js/sample.js" should exist
+
+  @serial(app_for_customize_export)
+  Scenario: Specify output path
+    Given The app "app_for_customize_export" has no customization
+    And Load app ID of the app "app_for_customize_export" as env var: "APP_ID"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with args "customize export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --username $USERNAME --password $PASSWORD --output test.json --yes"
+    Then I should get the exit code is zero
+    And The file "test.json" should exist
+
+  @serial(app_for_customize_export)
+  Scenario: Skip confirmation by --yes when file exists
+    Given I have an empty file at "customize-manifest.json"
+    And Load app ID of the app "app_for_customize_export" as env var: "APP_ID"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with args "customize export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --username $USERNAME --password $PASSWORD --yes"
+    Then I should get the exit code is zero
+    And The file "customize-manifest.json" should exist
+    And The customize-manifest at "customize-manifest.json" should be a valid template
+
+  @serial(app_for_customize_export)
+  Scenario: Cancel the operation at confirmation
+    Given I have a customize-manifest.json file at "customize-manifest.json" with content "EXISTING"
+    And Load app ID of the app "app_for_customize_export" as env var: "APP_ID"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with a prompt with args "customize export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --username $USERNAME --password $PASSWORD"
+    And I press Enter
+    Then I should get the exit code is zero
+    And The customize-manifest at "customize-manifest.json" should have content "EXISTING"
+
+  @serial(app_in_guest_space_for_customize_export)
+  Scenario: App in a guest space
+    Given Load app ID of the app "app_in_guest_space_for_customize_export" as env var: "APP_ID"
+    And Load guest space ID of the app "app_in_guest_space_for_customize_export" as env var: "GUEST_SPACE_ID"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with args "customize export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --username $USERNAME --password $PASSWORD --guest-space-id $GUEST_SPACE_ID --yes"
+    Then I should get the exit code is zero
+    And The file "customize-manifest.json" should exist
+
+  Scenario: Specified app does not exist
+    Given Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    When I run the command with args "customize export --base-url $$TEST_KINTONE_BASE_URL --app 999999999 --username $USERNAME --password $PASSWORD --yes"
+    Then I should get the exit code is non-zero
+    And The output error message should match with the pattern: "GAIA_AP01|not found|404"

--- a/features/customize/export.feature
+++ b/features/customize/export.feature
@@ -47,7 +47,7 @@ Feature: customize export
   Scenario: App in a guest space
     Given Load app ID of the app "app_in_guest_space_for_customize_export" as env var: "APP_ID"
     And Load guest space ID of the app "app_in_guest_space_for_customize_export" as env var: "GUEST_SPACE_ID"
-    And Load username and password of user "user_for_guest_space" as env vars: "USERNAME" and "PASSWORD"
+    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
     When I run the command with args "customize export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --username $USERNAME --password $PASSWORD --guest-space-id $GUEST_SPACE_ID --yes"
     Then I should get the exit code is zero
     And The file "customize-manifest.json" should exist

--- a/features/customize/export.feature
+++ b/features/customize/export.feature
@@ -47,7 +47,7 @@ Feature: customize export
   Scenario: App in a guest space
     Given Load app ID of the app "app_in_guest_space_for_customize_export" as env var: "APP_ID"
     And Load guest space ID of the app "app_in_guest_space_for_customize_export" as env var: "GUEST_SPACE_ID"
-    And Load username and password of user "kintone_admin" as env vars: "USERNAME" and "PASSWORD"
+    And Load username and password of user "user_for_guest_space" as env vars: "USERNAME" and "PASSWORD"
     When I run the command with args "customize export --base-url $$TEST_KINTONE_BASE_URL --app $APP_ID --username $USERNAME --password $PASSWORD --guest-space-id $GUEST_SPACE_ID --yes"
     Then I should get the exit code is zero
     And The file "customize-manifest.json" should exist

--- a/features/customize/init.feature
+++ b/features/customize/init.feature
@@ -1,0 +1,28 @@
+@isolated
+@customize-init
+Feature: customize init
+
+  Scenario: Generate template file with default path
+    When I run the command with args "customize init --yes"
+    Then I should get the exit code is zero
+    And The file "customize-manifest.json" should exist
+    And The customize-manifest at "customize-manifest.json" should be a valid template
+
+  Scenario: Specify output path
+    When I run the command with args "customize init --output test.json --yes"
+    Then I should get the exit code is zero
+    And The file "test.json" should exist
+    And The customize-manifest at "test.json" should be a valid template
+
+  Scenario: Skip confirmation by --yes when file exists
+    Given I have a customize-manifest.json file at "customize-manifest.json"
+    When I run the command with args "customize init --output customize-manifest.json --yes"
+    Then I should get the exit code is zero
+    And The customize-manifest at "customize-manifest.json" should be a valid template
+
+  Scenario: Cancel the operation at confirmation
+    Given I have a customize-manifest.json file at "customize-manifest.json" with content "EXISTING"
+    When I run the command with a prompt with args "customize init"
+    And I press Enter
+    Then I should get the exit code is zero
+    And The customize-manifest at "customize-manifest.json" should have content "EXISTING"

--- a/features/step_definitions/customize/common.ts
+++ b/features/step_definitions/customize/common.ts
@@ -1,0 +1,163 @@
+import { Given, Then } from "../../utils/world";
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import { getAssetPath } from "../file";
+
+Then("The file {string} should exist", function (filePath: string) {
+  const fullPath = path.join(this.workingDir, filePath);
+  assert.ok(fs.existsSync(fullPath), `File does not exist: ${filePath}`);
+});
+
+Then("The file {string} should not exist", function (filePath: string) {
+  const fullPath = path.join(this.workingDir, filePath);
+  assert.ok(!fs.existsSync(fullPath), `File should not exist: ${filePath}`);
+});
+
+Then(
+  "The customize-manifest at {string} should be a valid template",
+  function (filePath: string) {
+    const fullPath = path.join(this.workingDir, filePath);
+    const content = JSON.parse(fs.readFileSync(fullPath, "utf8"));
+    assert.ok(content.scope !== undefined, "Missing 'scope' property");
+    assert.ok(content.desktop !== undefined, "Missing 'desktop' property");
+    assert.ok(content.mobile !== undefined, "Missing 'mobile' property");
+  },
+);
+
+Then(
+  "The customize-manifest at {string} should have desktop js files",
+  function (filePath: string) {
+    const fullPath = path.join(this.workingDir, filePath);
+    const content = JSON.parse(fs.readFileSync(fullPath, "utf8"));
+    assert.ok(
+      content.desktop?.js?.length > 0,
+      "Expected desktop.js to have at least one file",
+    );
+  },
+);
+
+Given(
+  "I have a customize-manifest.json file at {string}",
+  async function (filePath: string) {
+    const fullPath = path.join(this.workingDir, filePath);
+    const dir = path.dirname(fullPath);
+    await fs.promises.mkdir(dir, { recursive: true });
+    await fs.promises.writeFile(fullPath, "{}");
+  },
+);
+
+Given(
+  "I have a customize-manifest.json file at {string} with content {string}",
+  async function (filePath: string, marker: string) {
+    const fullPath = path.join(this.workingDir, filePath);
+    const dir = path.dirname(fullPath);
+    await fs.promises.mkdir(dir, { recursive: true });
+    await fs.promises.writeFile(fullPath, JSON.stringify({ marker }));
+  },
+);
+
+Then(
+  "The customize-manifest at {string} should have content {string}",
+  function (filePath: string, marker: string) {
+    const fullPath = path.join(this.workingDir, filePath);
+    const content = JSON.parse(fs.readFileSync(fullPath, "utf8"));
+    assert.strictEqual(content.marker, marker);
+  },
+);
+
+Given("I have an empty file at {string}", async function (filePath: string) {
+  const fullPath = path.join(this.workingDir, filePath);
+  const dir = path.dirname(fullPath);
+  await fs.promises.mkdir(dir, { recursive: true });
+  await fs.promises.writeFile(fullPath, "");
+});
+
+Given(
+  "The app {string} has customization from asset {string}",
+  async function (appKey: string, assetKey: string) {
+    const appCredential = this.getAppCredentialByAppKey(appKey);
+    const userCredential = this.getUserCredentialByUserKey("kintone_admin");
+    const assetPath = getAssetPath(assetKey);
+    const manifestPath = path.join(assetPath, "customize-manifest.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+    const client = new KintoneRestAPIClient({
+      baseUrl: process.env.TEST_KINTONE_BASE_URL,
+      auth: {
+        username: userCredential.username,
+        password: userCredential.password,
+      },
+    });
+
+    const uploadFiles = async (files: string[]) => {
+      const result = [];
+      for (const filePath of files) {
+        const fullPath = path.join(assetPath, filePath);
+        const fileContent = fs.readFileSync(fullPath);
+        const { fileKey } = await client.file.uploadFile({
+          file: { name: path.basename(filePath), data: fileContent },
+        });
+        result.push({ type: "FILE" as const, file: { fileKey } });
+      }
+      return result;
+    };
+
+    const desktopJs = await uploadFiles(manifest.desktop?.js || []);
+    const desktopCss = await uploadFiles(manifest.desktop?.css || []);
+    const mobileJs = await uploadFiles(manifest.mobile?.js || []);
+    const mobileCss = await uploadFiles(manifest.mobile?.css || []);
+
+    await client.app.updateAppCustomize({
+      app: appCredential.appId,
+      scope: manifest.scope || "ALL",
+      desktop: { js: desktopJs, css: desktopCss },
+      mobile: { js: mobileJs, css: mobileCss },
+    });
+
+    await client.app.deployApp({ apps: [{ app: appCredential.appId }] });
+    await waitForDeploy(client, appCredential.appId);
+  },
+);
+
+Given("The app {string} has no customization", async function (appKey: string) {
+  const appCredential = this.getAppCredentialByAppKey(appKey);
+  const userCredential = this.getUserCredentialByUserKey("kintone_admin");
+
+  const client = new KintoneRestAPIClient({
+    baseUrl: process.env.TEST_KINTONE_BASE_URL,
+    auth: {
+      username: userCredential.username,
+      password: userCredential.password,
+    },
+  });
+
+  await client.app.updateAppCustomize({
+    app: appCredential.appId,
+    scope: "NONE",
+    desktop: { js: [], css: [] },
+    mobile: { js: [], css: [] },
+  });
+
+  await client.app.deployApp({ apps: [{ app: appCredential.appId }] });
+  await waitForDeploy(client, appCredential.appId);
+});
+
+const waitForDeploy = async (
+  client: KintoneRestAPIClient,
+  appId: string,
+): Promise<void> => {
+  const maxRetries = 30;
+  for (let i = 0; i < maxRetries; i++) {
+    const { apps } = await client.app.getDeployStatus({ apps: [appId] });
+    if (apps[0].status === "SUCCESS") {
+      return;
+    }
+    if (apps[0].status === "FAIL") {
+      throw new Error(`Deploy failed for app ${appId}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+  throw new Error(`Deploy timeout for app ${appId}`);
+};

--- a/features/step_definitions/customize/common.ts
+++ b/features/step_definitions/customize/common.ts
@@ -23,6 +23,16 @@ Then(
     assert.ok(content.scope !== undefined, "Missing 'scope' property");
     assert.ok(content.desktop !== undefined, "Missing 'desktop' property");
     assert.ok(content.mobile !== undefined, "Missing 'mobile' property");
+    assert.ok(Array.isArray(content.desktop?.js), "desktop.js should be array");
+    assert.ok(
+      Array.isArray(content.desktop?.css),
+      "desktop.css should be array",
+    );
+    assert.ok(Array.isArray(content.mobile?.js), "mobile.js should be array");
+    assert.ok(
+      Array.isArray(content.mobile?.css),
+      "mobile.css should be array",
+    );
   },
 );
 

--- a/features/step_definitions/customize/common.ts
+++ b/features/step_definitions/customize/common.ts
@@ -29,10 +29,7 @@ Then(
       "desktop.css should be array",
     );
     assert.ok(Array.isArray(content.mobile?.js), "mobile.js should be array");
-    assert.ok(
-      Array.isArray(content.mobile?.css),
-      "mobile.css should be array",
-    );
+    assert.ok(Array.isArray(content.mobile?.css), "mobile.css should be array");
   },
 );
 

--- a/features/step_definitions/customize/common.ts
+++ b/features/step_definitions/customize/common.ts
@@ -83,6 +83,7 @@ Given("I have an empty file at {string}", async function (filePath: string) {
 
 Given(
   "The app {string} has customization from asset {string}",
+  { timeout: 100000 },
   async function (appKey: string, assetKey: string) {
     const appCredential = this.getAppCredentialByAppKey(appKey);
     const userCredential = this.getUserCredentialByUserKey("kintone_admin");
@@ -128,28 +129,32 @@ Given(
   },
 );
 
-Given("The app {string} has no customization", async function (appKey: string) {
-  const appCredential = this.getAppCredentialByAppKey(appKey);
-  const userCredential = this.getUserCredentialByUserKey("kintone_admin");
+Given(
+  "The app {string} has no customization",
+  { timeout: 100000 },
+  async function (appKey: string) {
+    const appCredential = this.getAppCredentialByAppKey(appKey);
+    const userCredential = this.getUserCredentialByUserKey("kintone_admin");
 
-  const client = new KintoneRestAPIClient({
-    baseUrl: process.env.TEST_KINTONE_BASE_URL,
-    auth: {
-      username: userCredential.username,
-      password: userCredential.password,
-    },
-  });
+    const client = new KintoneRestAPIClient({
+      baseUrl: process.env.TEST_KINTONE_BASE_URL,
+      auth: {
+        username: userCredential.username,
+        password: userCredential.password,
+      },
+    });
 
-  await client.app.updateAppCustomize({
-    app: appCredential.appId,
-    scope: "NONE",
-    desktop: { js: [], css: [] },
-    mobile: { js: [], css: [] },
-  });
+    await client.app.updateAppCustomize({
+      app: appCredential.appId,
+      scope: "NONE",
+      desktop: { js: [], css: [] },
+      mobile: { js: [], css: [] },
+    });
 
-  await client.app.deployApp({ apps: [{ app: appCredential.appId }] });
-  await waitForDeploy(client, appCredential.appId);
-});
+    await client.app.deployApp({ apps: [{ app: appCredential.appId }] });
+    await waitForDeploy(client, appCredential.appId);
+  },
+);
 
 const waitForDeploy = async (
   client: KintoneRestAPIClient,

--- a/features/step_definitions/file.ts
+++ b/features/step_definitions/file.ts
@@ -22,6 +22,15 @@ const assetMap: Record<string, string | undefined> = {
     assetsRootPath,
     "plugin_chjjmgadianhfiopehkbjlfkfioglafk_v2.zip",
   ),
+  customize_manifest: path.resolve(assetsRootPath, "customize_manifest"),
+};
+
+export const getAssetPath = (assetKey: string): string => {
+  const srcPath = assetMap[assetKey];
+  if (!srcPath) {
+    throw new Error(`Unknown asset key: ${assetKey}`);
+  }
+  return srcPath;
 };
 
 Given(


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->
E2E tests for customize commands (init/export/apply) were missing, and automated tests were needed to verify command behavior.

## What

<!-- What is a solution you want to add? -->
- Add E2E tests for `customize init` command (template generation, output path specification, overwrite confirmation)
- Add E2E tests for `customize export` command (settings export, output path specification, overwrite confirmation, guest space support)
- Add E2E tests for `customize apply` command (customization application, confirmation skip, guest space support, non-existent app error handling)
- Add test assets (customize-manifest.json, sample.js)
- Add step definitions for customize tests (file existence check, manifest validation, app customization setup/reset)

## How to test

<!-- How can we test this pull request? -->


## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.
