### PR TITLE
chore: add Takumi Guard npm security scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     name: Build
+    permissions:
+      contents: read
+      id-token: write
     # ubuntu上でビルドしたmacOS向けの実行ファイルが正常に動作しないため、
     # macOSランナー上でビルドする
     # ref. https://github.com/yao-pkg/pkg/issues/183
@@ -25,6 +28,10 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - run: pnpm build:all
@@ -35,6 +42,9 @@ jobs:
 
   build-website:
     name: Build website
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: Kesin11/actions-timeline@54d513e0b5ff1158f1cf8321108d666a5a6c1fca # v2
@@ -47,6 +57,10 @@ jobs:
         with:
           node-version: "24"
           cache: "pnpm"
+
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
@@ -58,7 +58,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -60,7 +60,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   analyze-and-extract:
     name: Analyze and extract licenses
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: Kesin11/actions-timeline@54d513e0b5ff1158f1cf8321108d666a5a6c1fca # v2
@@ -22,6 +25,10 @@ jobs:
         with:
           node-version: "24"
           cache: "pnpm"
+
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   lint:
     name: Lint
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: Kesin11/actions-timeline@54d513e0b5ff1158f1cf8321108d666a5a6c1fca # v2
@@ -22,6 +25,10 @@ jobs:
         with:
           node-version: "24"
           cache: "pnpm"
+
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
@@ -105,7 +105,7 @@ jobs:
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
     name: Upload executables
     permissions:
       contents: write
+      id-token: write
     # ubuntu上でビルドしたmacOS向けの実行ファイルが正常に動作しないため、
     # macOSランナー上でビルドする
     # ref. https://github.com/yao-pkg/pkg/issues/183
@@ -58,6 +59,11 @@ jobs:
         with:
           node-version: "24"
           cache: "pnpm"
+
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - run: pnpm build:artifacts
@@ -98,12 +104,17 @@ jobs:
           node-version: "24"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
+
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+
       # Ensure npm 11.5.1 or later is installed
       # ref. https://docs.npmjs.com/trusted-publishers#github-actions-configuration
       - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - run: pnpm publish --access public
+      - run: pnpm publish --access public --registry https://registry.npmjs.org/
         env:
           # https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -107,7 +107,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       # Ensure npm 11.5.1 or later is installed
       # ref. https://docs.npmjs.com/trusted-publishers#github-actions-configuration

--- a/.github/workflows/test-executables.yml
+++ b/.github/workflows/test-executables.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:executables

--- a/.github/workflows/test-executables.yml
+++ b/.github/workflows/test-executables.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-executables:
     name: Build executables
+    permissions:
+      contents: read
+      id-token: write
     # ubuntu上でビルドしたmacOS向けの実行ファイルが正常に動作しないため、
     # macOSランナー上でビルドする
     # ref. https://github.com/yao-pkg/pkg/issues/183
@@ -21,6 +24,10 @@ jobs:
         with:
           node-version: "24"
           cache: "pnpm"
+
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:executables

--- a/.github/workflows/test-executables.yml
+++ b/.github/workflows/test-executables.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   prepare:
     name: Prepare npm package
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -18,6 +21,10 @@ jobs:
         with:
           node-version: "24"
           cache: "pnpm"
+
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: "24"
           cache: "pnpm"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -94,7 +94,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   test-unit:
     name: Unit test - Node.js ${{ matrix.os }} ${{ matrix.node-version }}
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -27,6 +30,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
+
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -63,6 +70,9 @@ jobs:
 
   test-e2e:
     name: E2E test - Node.js ${{ matrix.os }} ${{ matrix.node-version }}
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ${{ matrix.os }}
     concurrency:
       group: test-e2e-workflow-concurrency-group
@@ -81,6 +91,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
+
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - run: pnpm build:executables

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
@@ -92,7 +92,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 

--- a/.github/workflows/validate-plugin-templates.yml
+++ b/.github/workflows/validate-plugin-templates.yml
@@ -27,6 +27,9 @@ jobs:
 
   validate:
     name: Validate ${{ matrix.template }}
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     needs: find-templates
     strategy:
@@ -40,6 +43,10 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
+
+      - uses: flatt-security/setup-takumi-guard-npm@v1
+        with:
+          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 
       - name: Validate manifest.json
         run: |

--- a/.github/workflows/validate-plugin-templates.yml
+++ b/.github/workflows/validate-plugin-templates.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           node-version: "24"
 
-      - uses: flatt-security/setup-takumi-guard-npm@v1
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
           bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
 

--- a/.github/workflows/validate-plugin-templates.yml
+++ b/.github/workflows/validate-plugin-templates.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
-          bot-id: ${{ secrets.TAKUMI_GUARD_BOT_ID }}
+          bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
 
       - name: Validate manifest.json
         run: |


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

To strengthen supply chain security for npm packages by integrating Takumi Guard npm security scanning into the CI/CD pipeline.

## What

- Added `flatt-security/setup-takumi-guard-npm` (SHA-pinned, v1.1.1) to all GitHub Actions workflows (build, license, lint, release, test, test-executables, test-npm, validate-plugin-templates)
- Added `id-token: write` and `contents: read` permissions to each job for OIDC authentication
- Fork PRs fall back to anonymous mode (empty bot-id) since secrets are not available
- Added `--registry https://registry.npmjs.org/` to the `pnpm publish` command in `release.yml` to bypass the read-only proxy

## How to test

- [ ] Verify that all workflows run successfully in CI
- [ ] Confirm that the `TAKUMI_GUARD_BOT_ID` secret is configured in the repository
- [ ] Confirm that the release workflow publishes to `https://registry.npmjs.org/`

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [x] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.