### PR TITLE
fix(ci): remove unused id-token: write and pnpm cache from release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ jobs:
     name: Build
     permissions:
       contents: read
-      id-token: write
     # ubuntu上でビルドしたmacOS向けの実行ファイルが正常に動作しないため、
     # macOSランナー上でビルドする
     # ref. https://github.com/yao-pkg/pkg/issues/183
@@ -44,7 +43,6 @@ jobs:
     name: Build website
     permissions:
       contents: read
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: Kesin11/actions-timeline@54d513e0b5ff1158f1cf8321108d666a5a6c1fca # v2

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -11,7 +11,6 @@ jobs:
     name: Analyze and extract licenses
     permissions:
       contents: read
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: Kesin11/actions-timeline@54d513e0b5ff1158f1cf8321108d666a5a6c1fca # v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,6 @@ jobs:
     name: Lint
     permissions:
       contents: read
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: Kesin11/actions-timeline@54d513e0b5ff1158f1cf8321108d666a5a6c1fca # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,6 @@ jobs:
     name: Upload executables
     permissions:
       contents: write
-      id-token: write
     # ubuntu上でビルドしたmacOS向けの実行ファイルが正常に動作しないため、
     # macOSランナー上でビルドする
     # ref. https://github.com/yao-pkg/pkg/issues/183

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
-          cache: "pnpm"
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
         with:
@@ -102,7 +101,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
-          cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1

--- a/.github/workflows/test-executables.yml
+++ b/.github/workflows/test-executables.yml
@@ -11,7 +11,6 @@ jobs:
     name: Build executables
     permissions:
       contents: read
-      id-token: write
     # ubuntu上でビルドしたmacOS向けの実行ファイルが正常に動作しないため、
     # macOSランナー上でビルドする
     # ref. https://github.com/yao-pkg/pkg/issues/183

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -12,7 +12,6 @@ jobs:
     name: Prepare npm package
     permissions:
       contents: read
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
     name: Unit test - Node.js ${{ matrix.os }} ${{ matrix.node-version }}
     permissions:
       contents: read
-      id-token: write
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -72,7 +71,6 @@ jobs:
     name: E2E test - Node.js ${{ matrix.os }} ${{ matrix.node-version }}
     permissions:
       contents: read
-      id-token: write
     runs-on: ${{ matrix.os }}
     concurrency:
       group: test-e2e-workflow-concurrency-group

--- a/.github/workflows/validate-plugin-templates.yml
+++ b/.github/workflows/validate-plugin-templates.yml
@@ -29,7 +29,6 @@ jobs:
     name: Validate ${{ matrix.template }}
     permissions:
       contents: read
-      id-token: write
     runs-on: ubuntu-latest
     needs: find-templates
     strategy:


### PR DESCRIPTION
## 概要

[TanStack の npm サプライチェーン侵害事案（2026-05-11）](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) と同型の攻撃ベクトルを緩和する予防的なハードニング。本リポジトリで侵害痕跡（IOC）は検出されていない。

TanStack 事案は以下3つの脆弱性を連鎖させた攻撃だった:
1. `pull_request_target` ワークフローで fork のコードが実行される（Pwn Request）
2. **PR ↔ release ワークフロー間で GitHub Actions キャッシュが汚染される**
3. **`id-token: write` を持つランナーから OIDC トークンが抽出される**

このPRでは項目 2 と 3 の経路を遮断する。

## 変更内容

- **`release.yml` の `upload` および `publish-npm` 両ジョブから `cache: "pnpm"` を削除。** `cache: "pnpm"` を有効にすると `setup-node` は `pnpm-lock.yaml` のハッシュからキャッシュキーを導出するため、悪意ある fork PR がキャッシュを汚染した場合、次の `release.yml` 実行（main 上）が汚染キャッシュを復元してから `pnpm install --frozen-lockfile && pnpm build && pnpm publish` を走らせるという経路が成立してしまう。キャッシュを使わなければこの経路自体が消える。
- **publish 以外のジョブから `id-token: write` を削除**:
  - `test.yml`, `lint.yml`, `build.yml`, `license.yml`, `test-npm.yml`, `test-executables.yml`, `validate-plugin-templates.yml`: これらのジョブは OIDC を使わない
  - `release.yml` の `upload` ジョブ: `pnpm build:artifacts` は `clean / build:executables / license:extract / compress` の連鎖のみで Sigstore 等の署名は行わず、`gh release upload` も `GITHUB_TOKEN` で認証するため OIDC 不要
- 最小権限の原則に従い、`release.yml` の `publish-npm` ジョブのみ `id-token: write` を残す（npm Trusted Publishing と provenance に必須）。

## Trusted Publishing を使っていてもなぜ重要か

Trusted Publishing なので長期 `NODE_AUTH_TOKEN` の窃取リスクはない。しかしキャッシュ汚染攻撃はトークンを盗む必要がない — release ランナー上で `pnpm install` / `pnpm build` 中に悪意あるコードを実行させれば、`pnpm publish` がそのコードを正規の OIDC トークンで npm に公開してしまう。キャッシュを切ればこの連鎖が断たれる。

## テスト方針

- [ ] このPRで test, lint, build, license, test-npm, test-executables, validate-plugin-templates の各ワークフローを再実行し、権限を絞った状態でもパスすることを確認
- [ ] マージ後、次のリリースで publish / upload 挙動にリグレッションがないか監視

BEGIN_COMMIT_OVERRIDE
chore(ci): remove unused id-token: write and pnpm cache from release
END_COMMIT_OVERRIDE