### PR TITLE
fix: retry transient kintone API errors

### DIFF
--- a/features/step_definitions/customize/common.ts
+++ b/features/step_definitions/customize/common.ts
@@ -164,6 +164,9 @@ const waitForDeploy = async (
   for (let i = 0; i < maxRetries; i++) {
     const { apps } = await client.app.getDeployStatus({ apps: [appId] });
     if (apps[0].status === "SUCCESS") {
+      // Grace period: a subsequent customize update right after SUCCESS can
+      // intermittently fail with GAIA_DA02. Wait briefly before returning.
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       return;
     }
     if (apps[0].status === "FAIL") {

--- a/src/customize/apply/index.ts
+++ b/src/customize/apply/index.ts
@@ -1,12 +1,9 @@
 import fs from "fs";
 import path from "path";
 import { confirm } from "@inquirer/prompts";
-import {
-  KintoneRestAPIError,
-  type KintoneRestAPIClient,
-} from "@kintone/rest-api-client";
+import { type KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { logger } from "../../utils/log";
-import { retry } from "../../utils/retry";
+import { isRetryableKintoneError, retry } from "../../utils/retry";
 import {
   buildRestAPIClient,
   type RestAPIClientOptions,
@@ -95,8 +92,7 @@ export const apply = async (
       }
     },
     {
-      retryCondition: (e: unknown) =>
-        e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,
+      retryCondition: isRetryableKintoneError,
       onError: (e, attemptCount, toRetry, nextDelay, config) => {
         logger.debug(`Error occurred: ${e}`);
         if (toRetry) {

--- a/src/customize/export/index.ts
+++ b/src/customize/export/index.ts
@@ -1,12 +1,9 @@
 import fs from "fs/promises";
 import path from "path";
 import { confirm } from "@inquirer/prompts";
-import {
-  KintoneRestAPIError,
-  type KintoneRestAPIClient,
-} from "@kintone/rest-api-client";
+import { type KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { logger } from "../../utils/log";
-import { retry } from "../../utils/retry";
+import { isRetryableKintoneError, retry } from "../../utils/retry";
 import {
   buildRestAPIClient,
   type RestAPIClientOptions,
@@ -73,8 +70,7 @@ export const exportCustomizeSetting = async (
       await downloadCustomizeFiles(apiClient, destDir, resp);
     },
     {
-      retryCondition: (e: unknown) =>
-        e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,
+      retryCondition: isRetryableKintoneError,
       onError: (e, attemptCount, toRetry, _nextDelay, config) => {
         logger.debug(`Error occurred: ${e}`);
         if (toRetry) {

--- a/src/record/export/usecases/get.ts
+++ b/src/record/export/usecases/get.ts
@@ -6,7 +6,6 @@ import type {
   KintoneRecordField,
   KintoneRestAPIClient,
 } from "@kintone/rest-api-client";
-import { KintoneRestAPIError } from "@kintone/rest-api-client";
 
 import path from "path";
 
@@ -15,7 +14,7 @@ import { getAllRecords } from "./get/getAllRecords";
 import type { LocalRecordRepository } from "./interface";
 import { replaceSpecialCharacters } from "../utils/file";
 import { logger } from "../../../utils/log";
-import { retry } from "../../../utils/retry";
+import { isRetryableKintoneError, retry } from "../../../utils/retry";
 
 export const NO_RECORDS_WARNING =
   "No records exist in the app or match the condition.";
@@ -260,8 +259,7 @@ const downloadAndSaveFile: (
           }
         }
       },
-      retryCondition: (e: unknown) =>
-        e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,
+      retryCondition: isRetryableKintoneError,
     },
   );
 

--- a/src/record/import/usecases/add/field.ts
+++ b/src/record/import/usecases/add/field.ts
@@ -1,10 +1,9 @@
 import type { KintoneRecordForParameter } from "../../../../kintone/types";
 import type { KintoneRestAPIClient } from "@kintone/rest-api-client";
-import { KintoneRestAPIError } from "@kintone/rest-api-client";
 import type * as Fields from "../../types/field";
 import type { FieldSchema } from "../../types/schema";
 import path from "path";
-import { retry } from "../../../../utils/retry";
+import { isRetryableKintoneError, retry } from "../../../../utils/retry";
 import { logger } from "../../../../utils/log";
 
 export const fieldProcessor: (
@@ -78,8 +77,7 @@ const fileFieldProcessor = async (
             );
           }
         },
-        retryCondition: (e: unknown) =>
-          e instanceof KintoneRestAPIError && e.status >= 500 && e.status < 600,
+        retryCondition: isRetryableKintoneError,
       },
     );
 

--- a/src/utils/__tests__/retry.test.ts
+++ b/src/utils/__tests__/retry.test.ts
@@ -1,5 +1,6 @@
 import { vi } from "vitest";
-import { retry } from "../retry";
+import { KintoneRestAPIError } from "@kintone/rest-api-client";
+import { isRetryableKintoneError, retry } from "../retry";
 
 // Mock setTimeout because we don't need to really wait.
 vi.mock("timers/promises", () => ({
@@ -155,5 +156,47 @@ describe("retry", () => {
       },
       5 * 1000,
     );
+  });
+});
+
+describe("isRetryableKintoneError", () => {
+  const buildKintoneRestAPIError = (
+    status: number,
+    code: string,
+  ): KintoneRestAPIError =>
+    new KintoneRestAPIError({
+      data: { id: "some id", code, message: "some error" },
+      status,
+      statusText: "",
+      headers: {},
+    });
+
+  it("retries on 5xx KintoneRestAPIError", () => {
+    expect(
+      isRetryableKintoneError(buildKintoneRestAPIError(500, "GAIA_XX01")),
+    ).toBe(true);
+    expect(
+      isRetryableKintoneError(buildKintoneRestAPIError(503, "GAIA_XX01")),
+    ).toBe(true);
+  });
+
+  it("retries on 400 GAIA_DA02", () => {
+    expect(
+      isRetryableKintoneError(buildKintoneRestAPIError(400, "GAIA_DA02")),
+    ).toBe(true);
+  });
+
+  it("does not retry on other 4xx errors", () => {
+    expect(
+      isRetryableKintoneError(buildKintoneRestAPIError(400, "GAIA_IL01")),
+    ).toBe(false);
+    expect(
+      isRetryableKintoneError(buildKintoneRestAPIError(404, "GAIA_AP01")),
+    ).toBe(false);
+  });
+
+  it("does not retry on non-KintoneRestAPIError", () => {
+    expect(isRetryableKintoneError(new Error("plain"))).toBe(false);
+    expect(isRetryableKintoneError(undefined)).toBe(false);
   });
 });

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,4 +1,32 @@
 import { setTimeout } from "timers/promises";
+import { KintoneRestAPIError } from "@kintone/rest-api-client";
+
+/**
+ * Transient kintone REST API errors that should be retried even though they
+ * are not 5xx. Extend this list as new retryable codes are found.
+ *
+ * - GAIA_DA02: returned with the message "Please wait a while and try again."
+ */
+const RETRYABLE_KINTONE_ERRORS: ReadonlyArray<{
+  status: number;
+  code: string;
+}> = [{ status: 400, code: "GAIA_DA02" }];
+
+/**
+ * Returns true if the given error is a transient kintone REST API error
+ * worth retrying: any 5xx, or an entry in RETRYABLE_KINTONE_ERRORS.
+ */
+export const isRetryableKintoneError = (e: unknown): boolean => {
+  if (!(e instanceof KintoneRestAPIError)) {
+    return false;
+  }
+  if (e.status >= 500 && e.status < 600) {
+    return true;
+  }
+  return RETRYABLE_KINTONE_ERRORS.some(
+    (entry) => entry.status === e.status && entry.code === e.code,
+  );
+};
 
 /**
  * Retry given function with exponential backoff with jitter strategy.

--- a/website/docs/reference/errors/retry-api-requests.md
+++ b/website/docs/reference/errors/retry-api-requests.md
@@ -14,10 +14,10 @@ Retries are performed for each API request. When requests are wrapped in Bulk Re
 - [Upload File](https://kintone.dev/en/docs/kintone/rest-api/files/upload-file/) (`POST /k/v1/file.json`)
   - 5xx errors
   - Retryable 4xx errors
-- [Get JavaScript and CSS Customization](https://kintone.dev/en/docs/kintone/rest-api/apps/get-javascript-and-css-customization/) (`GET /k/v1/preview/app/customize.json`)
+- [Get Customization](https://kintone.dev/en/docs/kintone/rest-api/apps/settings/get-customization/) (`GET /k/v1/preview/app/customize.json`)
   - 5xx errors
   - Retryable 4xx errors
-- [Update JavaScript and CSS Customization](https://kintone.dev/en/docs/kintone/rest-api/apps/update-javascript-and-css-customization/) (`PUT /k/v1/preview/app/customize.json`)
+- [Update Customization](https://kintone.dev/en/docs/kintone/rest-api/apps/update-customization/) (`PUT /k/v1/preview/app/customize.json`)
   - 5xx errors
   - Retryable 4xx errors
 

--- a/website/docs/reference/errors/retry-api-requests.md
+++ b/website/docs/reference/errors/retry-api-requests.md
@@ -10,8 +10,16 @@ Retries are performed for each API request. When requests are wrapped in Bulk Re
 
 - [Download File](https://kintone.dev/en/docs/kintone/rest-api/files/download-file/) (`GET /k/v1/file.json`)
   - 5xx errors
+  - Retryable 4xx errors
 - [Upload File](https://kintone.dev/en/docs/kintone/rest-api/files/upload-file/) (`POST /k/v1/file.json`)
   - 5xx errors
+  - Retryable 4xx errors
+- [Get JavaScript and CSS Customization](https://kintone.dev/en/docs/kintone/rest-api/apps/get-javascript-and-css-customization/) (`GET /k/v1/preview/app/customize.json`)
+  - 5xx errors
+  - Retryable 4xx errors
+- [Update JavaScript and CSS Customization](https://kintone.dev/en/docs/kintone/rest-api/apps/update-javascript-and-css-customization/) (`PUT /k/v1/preview/app/customize.json`)
+  - 5xx errors
+  - Retryable 4xx errors
 
 ## Strategy
 


### PR DESCRIPTION
## Why

The kintone REST API can occasionally return `[400] [GAIA_DA02] Failed to save the changes because the database could not be locked. Please wait a while and try again.` for write operations such as `PUT /preview/app/customize.json`. The response message itself indicates the caller is expected to retry.

The existing `retry()` calls in `customize apply` / `customize export` / `record import` / `record export` only retried on 5xx, so a single `GAIA_DA02` would fail the command immediately. This was also visible as a recurring flaky failure of the E2E job "Apply customization from manifest file" in `test.yml` across `main` and several Renovate PRs (always the same scenario, always the same API response).

## What

- Extract a shared `isRetryableKintoneError(e)` helper in `src/utils/retry.ts`. Returns `true` for any 5xx and for entries listed in a new `RETRYABLE_KINTONE_ERRORS` array. The array currently holds `{ status: 400, code: "GAIA_DA02" }` and is intended to be extended as additional transient codes are observed.
- Replace the inline `retryCondition` at the four call sites with the helper so transient kintone errors are handled consistently.
- E2E: in `features/step_definitions/customize/common.ts`, wait briefly after `getDeployStatus` reports `SUCCESS` before returning. A subsequent customize update issued immediately after `SUCCESS` can intermittently fail with `GAIA_DA02`; this reduces how often the test trips that window.

Behavior:

- `customize apply`, `customize export`, `record import`, `record export` now transparently retry `400 GAIA_DA02` with the existing exponential backoff + jitter (max 5 attempts).
- Other 4xx responses (e.g. validation errors, `GAIA_AP01`) continue to fail fast — unchanged.

## How to test

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` — new unit tests for `isRetryableKintoneError` cover: 5xx / 400 GAIA_DA02 / other 4xx / non-`KintoneRestAPIError`.
- The regression target is the E2E job (`test.yml` "E2E test - Node.js ubuntu-latest 24"), specifically `features/customize/apply.feature` "Apply customization from manifest file".

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed \`pnpm lint\` and \`pnpm test\` on the root directory.