### PR TITLE
fix(ci): keep working tree clean when Takumi Guard configures registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,26 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
+        id: setup-takumi-guard
         with:
           bot-id: ${{ !github.event.pull_request.head.repo.fork && secrets.TAKUMI_GUARD_BOT_ID || '' }}
+          set-registry: false
+
+      - name: Configure Takumi Guard registry
+        shell: bash
+        run: |
+          # setup-takumi-guard-npm writes an auth token to the project .npmrc even with
+          # set-registry: false. Since .npmrc is tracked in this repository, that modification
+          # makes the working tree dirty and breaks pnpm publish's git-checks.
+          # Restore .npmrc to its committed state and configure the registry globally instead.
+          git restore .npmrc
+
+          # Configure pnpm's global registry to point to Takumi Guard.
+          # pnpm config --global set writes to ~/.config/pnpm/rc, which is outside
+          # the working tree, so it does not cause pnpm publish to fail with
+          # ERR_PNPM_GIT_UNCLEAN due to dirty git-checks.
+          pnpm config --global set registry https://npm.flatt.tech/
+          pnpm config --global set //npm.flatt.tech/:_authToken "${{ steps.setup-takumi-guard.outputs.token }}"
 
       # Ensure npm 11.5.1 or later is installed
       # ref. https://docs.npmjs.com/trusted-publishers#github-actions-configuration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,19 +110,26 @@ jobs:
 
       - name: Configure Takumi Guard registry
         shell: bash
+        env:
+          TAKUMI_GUARD_TOKEN: ${{ steps.setup-takumi-guard.outputs.token }}
         run: |
+          # Mask the token explicitly so it cannot leak into the workflow log even if
+          # echoed by a downstream command.
+          echo "::add-mask::${TAKUMI_GUARD_TOKEN}"
+
           # setup-takumi-guard-npm writes an auth token to the project .npmrc even with
           # set-registry: false. Since .npmrc is tracked in this repository, that modification
           # makes the working tree dirty and breaks pnpm publish's git-checks.
           # Restore .npmrc to its committed state and configure the registry globally instead.
           git restore .npmrc
 
-          # Configure pnpm's global registry to point to Takumi Guard.
-          # pnpm config --global set writes to ~/.config/pnpm/rc, which is outside
-          # the working tree, so it does not cause pnpm publish to fail with
-          # ERR_PNPM_GIT_UNCLEAN due to dirty git-checks.
+          # Configure pnpm and npm to use Takumi Guard via user-scoped config files
+          # (~/.config/pnpm/rc and ~/.npmrc), which are outside the working tree and
+          # therefore do not trigger ERR_PNPM_GIT_UNCLEAN on pnpm publish.
           pnpm config --global set registry https://npm.flatt.tech/
-          pnpm config --global set //npm.flatt.tech/:_authToken "${{ steps.setup-takumi-guard.outputs.token }}"
+          pnpm config --global set //npm.flatt.tech/:_authToken "${TAKUMI_GUARD_TOKEN}"
+          npm config set --location=user registry https://npm.flatt.tech/
+          npm config set --location=user //npm.flatt.tech/:_authToken "${TAKUMI_GUARD_TOKEN}"
 
       # Ensure npm 11.5.1 or later is installed
       # ref. https://docs.npmjs.com/trusted-publishers#github-actions-configuration

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
-minimum-release-age=1440
+# Tracked as a baseline so the release workflow can restore it after
+# `flatt-security/setup-takumi-guard-npm` writes an auth token here.
+# See .github/workflows/release.yml ("Configure Takumi Guard registry").


### PR DESCRIPTION
## Why

The Release workflow's "Publish to npm" job will fail with `ERR_PNPM_GIT_UNCLEAN` once a release-please release fires after Takumi Guard was added (#1438). `flatt-security/setup-takumi-guard-npm` writes an auth token to the project-level `.npmrc`, leaving the working tree dirty, and `pnpm publish`'s default git-checks reject the publish.

This repo has not yet had a release-please release after Takumi Guard was wired up, so the bug is latent here.

## What

- Track an `.npmrc` at the repository root (with `minimum-release-age=1440`, matching other kintone packages) so the file has a committed baseline to restore.
- In `.github/workflows/release.yml`'s publish-npm job:
  - Pass `set-registry: false` to `setup-takumi-guard-npm`.
  - Add a "Configure Takumi Guard registry" step that runs `git restore .npmrc` to discard the action's writes, then configures the Flatt registry via `pnpm config --global set`. The global config is written to `~/.config/pnpm/rc`, which is outside the working tree, so it no longer triggers `ERR_PNPM_GIT_UNCLEAN`.

## How to test

The publish job only runs when release-please creates a release. After merge, the next release-please release should reach "Publish to npm" and succeed without `ERR_PNPM_GIT_UNCLEAN`.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.