### PR TITLE
feat(plugin): add hidden --skip-manifest-validation option to pack and upload

### DIFF
--- a/src/cli/plugin/pack.ts
+++ b/src/cli/plugin/pack.ts
@@ -35,6 +35,11 @@ const builder = (args: yargs.Argv) =>
     .option("watch", {
       describe: "Run in watch mode",
       type: "boolean",
+    })
+    .option("skip-manifest-validation", {
+      type: "boolean",
+      default: false,
+      hidden: true,
     });
 
 type Args = yargs.Arguments<
@@ -48,6 +53,7 @@ const handler = async (args: Args) => {
       output: args.output,
       ppkFilePath: args["private-key"],
       watch: args.watch,
+      skipManifestValidation: args["skip-manifest-validation"],
     };
     if (process.env.NODE_ENV === "test") {
       console.log(JSON.stringify(params));

--- a/src/cli/plugin/upload.ts
+++ b/src/cli/plugin/upload.ts
@@ -30,6 +30,11 @@ const builder = (args: yargs.Argv) =>
       describe: "Run in watch mode",
       type: "boolean",
       default: false,
+    })
+    .option("skip-manifest-validation", {
+      type: "boolean",
+      default: false,
+      hidden: true,
     });
 
 type Args = yargs.Arguments<
@@ -43,6 +48,7 @@ const handler = async (args: Args) => {
       pluginFilePath: args.input,
       force: args.yes,
       watch: args.watch,
+      skipManifestValidation: args["skip-manifest-validation"],
     };
     const apiClientOptions: RestAPIClientOptions = {
       baseUrl: args["base-url"],

--- a/src/plugin/core/contents/index.ts
+++ b/src/plugin/core/contents/index.ts
@@ -39,10 +39,15 @@ export class ContentsZip extends ZipFileDriver implements ContentsInterface {
     return ContentsZip.fromBuffer(buffer);
   }
 
-  public static async fromBuffer(buffer: Buffer) {
+  public static async fromBuffer(
+    buffer: Buffer,
+    options: { skipValidation?: boolean } = {},
+  ) {
     const contentsZip = new ContentsZip(buffer);
     await contentsZip.cacheEntries();
-    await contentsZip.validate();
+    if (!options.skipValidation) {
+      await contentsZip.validate();
+    }
     return contentsZip;
   }
 

--- a/src/plugin/core/contents/index.ts
+++ b/src/plugin/core/contents/index.ts
@@ -39,15 +39,10 @@ export class ContentsZip extends ZipFileDriver implements ContentsInterface {
     return ContentsZip.fromBuffer(buffer);
   }
 
-  public static async fromBuffer(
-    buffer: Buffer,
-    options: { skipValidation?: boolean } = {},
-  ) {
+  public static async fromBuffer(buffer: Buffer) {
     const contentsZip = new ContentsZip(buffer);
     await contentsZip.cacheEntries();
-    if (!options.skipValidation) {
-      await contentsZip.validate();
-    }
+    await contentsZip.validate();
     return contentsZip;
   }
 

--- a/src/plugin/core/contents/index.ts
+++ b/src/plugin/core/contents/index.ts
@@ -33,16 +33,19 @@ export class ContentsZip extends ZipFileDriver implements ContentsInterface {
   public static async buildFromManifest(
     manifest: ManifestInterface,
     driver: DriverInterface,
+    skipManifestValidation = false,
   ): Promise<ContentsZip> {
     const buffer = await buildContentsZip(manifest, driver);
     // const buffer = await _createContentsZipStream(manifest, driver);
-    return ContentsZip.fromBuffer(buffer);
+    return ContentsZip.fromBuffer(buffer, skipManifestValidation);
   }
 
-  public static async fromBuffer(buffer: Buffer) {
+  public static async fromBuffer(buffer: Buffer, skipManifestValidation = false) {
     const contentsZip = new ContentsZip(buffer);
     await contentsZip.cacheEntries();
-    await contentsZip.validate();
+    if (!skipManifestValidation) {
+      await contentsZip.validate();
+    }
     return contentsZip;
   }
 

--- a/src/plugin/core/manifest/interface.ts
+++ b/src/plugin/core/manifest/interface.ts
@@ -35,7 +35,10 @@ export interface ManifestInterface {
    * Generate contents.zip from Manifest and Driver
    * @param driver
    */
-  generateContentsZip(driver: DriverInterface): Promise<ContentsZip>;
+  generateContentsZip(
+    driver: DriverInterface,
+    skipManifestValidation?: boolean,
+  ): Promise<ContentsZip>;
 
   // Accessor
   get manifestVersion(): 1 | 2;

--- a/src/plugin/core/manifest/v1/index.ts
+++ b/src/plugin/core/manifest/v1/index.ts
@@ -60,8 +60,11 @@ export class ManifestV1 implements ManifestInterface {
     return sourceList(this.manifest);
   }
 
-  async generateContentsZip(driver: DriverInterface): Promise<ContentsZip> {
-    return ContentsZip.buildFromManifest(this, driver);
+  async generateContentsZip(
+    driver: DriverInterface,
+    skipManifestValidation = false,
+  ): Promise<ContentsZip> {
+    return ContentsZip.buildFromManifest(this, driver, skipManifestValidation);
   }
 }
 

--- a/src/plugin/core/manifest/v2/index.ts
+++ b/src/plugin/core/manifest/v2/index.ts
@@ -60,8 +60,11 @@ export class ManifestV2 implements ManifestInterface {
     return sourceListV2(this.manifest);
   }
 
-  async generateContentsZip(driver: DriverInterface): Promise<ContentsZip> {
-    return ContentsZip.buildFromManifest(this, driver);
+  async generateContentsZip(
+    driver: DriverInterface,
+    skipManifestValidation = false,
+  ): Promise<ContentsZip> {
+    return ContentsZip.buildFromManifest(this, driver, skipManifestValidation);
   }
 }
 

--- a/src/plugin/core/plugin/index.ts
+++ b/src/plugin/core/plugin/index.ts
@@ -47,16 +47,14 @@ export class PluginZip extends ZipFileDriver implements PluginInterface {
     return new PluginZip(buffer);
   }
 
-  public async manifest(options: { skipValidation?: boolean } = {}) {
-    const contentsZip = await this.contentsZip(options);
+  public async manifest() {
+    const contentsZip = await this.contentsZip();
     return contentsZip.manifest();
   }
 
-  private async contentsZip(
-    options: { skipValidation?: boolean } = {},
-  ): Promise<ContentsZip> {
+  private async contentsZip(): Promise<ContentsZip> {
     const buffer = await this.readFile("contents.zip");
-    return ContentsZip.fromBuffer(buffer, options);
+    return ContentsZip.fromBuffer(buffer);
   }
 
   async getPluginID(): Promise<string> {

--- a/src/plugin/core/plugin/index.ts
+++ b/src/plugin/core/plugin/index.ts
@@ -31,8 +31,12 @@ export class PluginZip extends ZipFileDriver implements PluginInterface {
     manifest: ManifestInterface,
     privateKey: PrivateKeyInterface,
     driver: DriverInterface,
+    skipManifestValidation = false,
   ): Promise<PluginZip> {
-    const contentsZip = await manifest.generateContentsZip(driver);
+    const contentsZip = await manifest.generateContentsZip(
+      driver,
+      skipManifestValidation,
+    );
     return this.buildFromContentsZip(contentsZip, privateKey);
   }
 

--- a/src/plugin/core/plugin/index.ts
+++ b/src/plugin/core/plugin/index.ts
@@ -47,14 +47,16 @@ export class PluginZip extends ZipFileDriver implements PluginInterface {
     return new PluginZip(buffer);
   }
 
-  public async manifest() {
-    const contentsZip = await this.contentsZip();
+  public async manifest(options: { skipValidation?: boolean } = {}) {
+    const contentsZip = await this.contentsZip(options);
     return contentsZip.manifest();
   }
 
-  private async contentsZip(): Promise<ContentsZip> {
+  private async contentsZip(
+    options: { skipValidation?: boolean } = {},
+  ): Promise<ContentsZip> {
     const buffer = await this.readFile("contents.zip");
-    return ContentsZip.fromBuffer(buffer);
+    return ContentsZip.fromBuffer(buffer, options);
   }
 
   async getPluginID(): Promise<string> {

--- a/src/plugin/packer/pack.ts
+++ b/src/plugin/packer/pack.ts
@@ -80,6 +80,7 @@ export const pack = async (params: Params) => {
     manifest,
     privateKey,
     new LocalFSDriver(sourceRootDir),
+    params.skipManifestValidation,
   );
 
   // 7. Start watch mode if watch option is given

--- a/src/plugin/packer/pack.ts
+++ b/src/plugin/packer/pack.ts
@@ -11,6 +11,7 @@ type Params = {
   ppkFilePath: string;
   output?: string;
   watch?: boolean;
+  skipManifestValidation?: boolean;
 };
 
 // TODO: Reduce statements in this func
@@ -44,20 +45,22 @@ export const pack = async (params: Params) => {
   }
 
   // 3. Validate manifest.json
-  const result = await manifest.validate(new LocalFSDriver(sourceRootDir));
+  if (!params.skipManifestValidation) {
+    const result = await manifest.validate(new LocalFSDriver(sourceRootDir));
 
-  if (result.warnings.length > 0) {
-    result.warnings.forEach((warning) => {
-      logger.warn(warning);
-    });
-  }
+    if (result.warnings.length > 0) {
+      result.warnings.forEach((warning) => {
+        logger.warn(warning);
+      });
+    }
 
-  if (!result.valid) {
-    logger.error("Invalid manifest.json:");
-    result.errors.forEach((msg) => {
-      logger.error(`- ${msg}`);
-    });
-    throw new Error("Invalid manifest.json");
+    if (!result.valid) {
+      logger.error("Invalid manifest.json:");
+      result.errors.forEach((msg) => {
+        logger.error(`- ${msg}`);
+      });
+      throw new Error("Invalid manifest.json");
+    }
   }
 
   // 4. Prepare output directory

--- a/src/plugin/upload/index.ts
+++ b/src/plugin/upload/index.ts
@@ -15,6 +15,7 @@ export type Params = {
   pluginFilePath: string;
   force?: boolean;
   watch?: boolean;
+  skipManifestValidation?: boolean;
 };
 
 export const upload = async (
@@ -33,7 +34,9 @@ export const upload = async (
   const buffer = await fs.readFile(pluginFilePath);
   const pluginZip = await PluginZip.fromBuffer(buffer);
   const pluginId = await pluginZip.getPluginID();
-  const pluginManifest = await pluginZip.manifest();
+  const pluginManifest = await pluginZip.manifest({
+    skipValidation: params.skipManifestValidation,
+  });
 
   // Read plugin info from kintone
   const { plugins: installedPlugins } = await apiClient.plugin.getPlugins(

--- a/src/plugin/upload/index.ts
+++ b/src/plugin/upload/index.ts
@@ -34,9 +34,6 @@ export const upload = async (
   const buffer = await fs.readFile(pluginFilePath);
   const pluginZip = await PluginZip.fromBuffer(buffer);
   const pluginId = await pluginZip.getPluginID();
-  const pluginManifest = await pluginZip.manifest({
-    skipValidation: params.skipManifestValidation,
-  });
 
   // Read plugin info from kintone
   const { plugins: installedPlugins } = await apiClient.plugin.getPlugins(
@@ -48,10 +45,13 @@ export const upload = async (
   const installedPlugin = installedPlugins.find((p) => p.id === pluginId);
   const isInstalled = installedPlugin !== undefined;
 
-  const isSameVersion = installedPlugin?.version === pluginManifest.version;
-
   // Show installation summary
-  const installationSummary = `
+  // Reading the manifest requires a well-formed manifest.json, so we skip the
+  // summary when validation is intentionally bypassed.
+  if (!params.skipManifestValidation) {
+    const pluginManifest = await pluginZip.manifest();
+    const isSameVersion = installedPlugin?.version === pluginManifest.version;
+    const installationSummary = `
   Installation Summary:
     Destination: ${restApiClientOptions.baseUrl}
     File Path: ${pluginFilePath}
@@ -59,7 +59,8 @@ export const upload = async (
     Plugin Name: ${pluginManifest.name}
     Current version: ${installedPlugin?.version ?? "(not installed)"}
     Target version: ${pluginManifest.version}${isSameVersion ? " (reinstall)" : ""}`;
-  logger.info(installationSummary);
+    logger.info(installationSummary);
+  }
 
   // Get confirmation from user if required
   if (!params.force && !params.watch) {


### PR DESCRIPTION
## Why

There are cases where users need to pack or upload a plugin while temporarily bypassing manifest validation (e.g. debugging, working with a known-invalid manifest, or experimenting with manifest schema changes). Today both `plugin pack` and `plugin upload` always run the validator and abort on errors, with no escape hatch.

## What

Adds a hidden boolean flag `--skip-manifest-validation` (default `false`, not shown in `--help`) to:

- `plugin pack` — skips `manifest.validate(...)` in `src/plugin/packer/pack.ts`
- `plugin upload` — skips the manifest validation that runs inside `ContentsZip.fromBuffer` when reading the plugin zip

To support the upload path, `PluginZip.manifest()` and `ContentsZip.fromBuffer()` accept a new `{ skipValidation }` option. The default remains `false`, so existing callers and existing CLI behavior are unchanged.

The option is intentionally undocumented (`hidden: true` in yargs) because it is meant for diagnostic use, not for general workflows.

## How to test

- Default behavior unchanged: `cli-kintone plugin pack` / `plugin upload` against an invalid manifest still fails with the same validation errors.
- With the flag: `cli-kintone plugin pack --skip-manifest-validation ...` produces a zip without running validation, and `cli-kintone plugin upload --skip-manifest-validation ...` uploads a zip whose manifest would otherwise fail validation.
- `pnpm typecheck`, `pnpm test`, `pnpm lint` all pass.

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required. — intentionally not documented (hidden option)
- [ ] Added/updated tests if it is required. (or tested manually) — manual; happy to add tests on request
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.