### PR TITLE
ci: use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -1,7 +1,7 @@
 name: "Lint PR"
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
## Why

`pull_request_target` runs in the context of the base repository (with write-scoped secrets), which is risky when combined with PRs from forks. This PR drops `pull_request_target` in favor of `pull_request`.

## What

- `.github/workflows/lint_pr.yml`: `pull_request_target` → `pull_request`

`lint_pr.yml` only validates the PR title and needs read access only, so this change has no functional impact.

## How to test

After this PR is opened, confirm that the Action triggered by the `pull_request` event runs as expected (PR title lint).

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [ ] Passed \`pnpm lint\` and \`pnpm test\` on the root directory.