### PR TITLE
feat(customize): add --watch option to customize apply command

### DIFF
--- a/src/cli/customize/apply.ts
+++ b/src/cli/customize/apply.ts
@@ -29,6 +29,11 @@ const builder = (args: yargs.Argv) =>
       describe: "Skip confirmation prompts",
       type: "boolean",
       default: false,
+    })
+    .option("watch", {
+      describe: "Watch for file changes and re-apply",
+      type: "boolean",
+      default: false,
     });
 
 type Args = yargs.Arguments<
@@ -41,6 +46,7 @@ const handler = async (args: Args) => {
       appId: args.app,
       inputPath: args.input,
       yes: args.yes,
+      watch: args.watch,
       baseUrl: args["base-url"],
       username: args.username,
       password: args.password,

--- a/src/customize/apply/index.ts
+++ b/src/customize/apply/index.ts
@@ -275,7 +275,8 @@ const getLocalFiles = (
     ...manifest.mobile.css,
   ]
     .filter((file) => !isUrlString(file))
-    .map((file) => path.resolve(manifestDir, file));
+    .map((file) => path.resolve(manifestDir, file))
+    .filter((file, index, self) => self.indexOf(file) === index);
 };
 
 export const runApply = async (params: ApplyParams) => {
@@ -307,7 +308,14 @@ export const runApply = async (params: ApplyParams) => {
 
   const apiClient = buildRestAPIClient(restApiClientOptions);
 
-  await apply(apiClient, appId, manifest, manifestDir, boundMessage);
+  try {
+    await apply(apiClient, appId, manifest, manifestDir, boundMessage);
+  } catch (error) {
+    if (!watch) {
+      throw error;
+    }
+    logger.error(error);
+  }
 
   if (watch) {
     const watchOptions =

--- a/src/customize/apply/index.ts
+++ b/src/customize/apply/index.ts
@@ -1,6 +1,8 @@
 import fs from "fs";
 import path from "path";
+import os from "os";
 import { confirm } from "@inquirer/prompts";
+import * as chokidar from "chokidar";
 import { type KintoneRestAPIClient } from "@kintone/rest-api-client";
 import { logger } from "../../utils/log";
 import { isRetryableKintoneError, retry } from "../../utils/retry";
@@ -15,6 +17,7 @@ export type ApplyParams = RestAPIClientOptions & {
   appId: string;
   inputPath: string;
   yes: boolean;
+  watch?: boolean;
 };
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -252,26 +255,45 @@ const createUpdatedManifest = (
   };
 };
 
+const loadManifest = (inputPath: string): CustomizeManifest => {
+  const manifest: CustomizeManifest = JSON.parse(
+    fs.readFileSync(inputPath, "utf8"),
+  );
+  // support an old format for customize-manifest.json that doesn't have mobile.css
+  manifest.mobile.css = manifest.mobile.css || [];
+  return manifest;
+};
+
+const getLocalFiles = (
+  manifest: CustomizeManifest,
+  manifestDir: string,
+): string[] => {
+  return [
+    ...manifest.desktop.js,
+    ...manifest.desktop.css,
+    ...manifest.mobile.js,
+    ...manifest.mobile.css,
+  ]
+    .filter((file) => !isUrlString(file))
+    .map((file) => path.resolve(manifestDir, file));
+};
+
 export const runApply = async (params: ApplyParams) => {
-  const { appId, inputPath, yes, ...restApiClientOptions } = params;
+  const { appId, inputPath, yes, watch, ...restApiClientOptions } = params;
   const boundMessage = getBoundMessage("en");
 
   logger.debug(`Starting apply for app ${appId}`);
   logger.debug(`Input path: ${inputPath}`);
 
-  const manifestDir = path.dirname(path.resolve(inputPath));
+  const resolvedInputPath = path.resolve(inputPath);
+  const manifestDir = path.dirname(resolvedInputPath);
   logger.debug(`Manifest directory: ${manifestDir}`);
 
-  const manifest: CustomizeManifest = JSON.parse(
-    fs.readFileSync(inputPath, "utf8"),
-  );
+  const manifest = loadManifest(resolvedInputPath);
   logger.debug(`Manifest loaded: scope=${manifest.scope}`);
 
-  // support an old format for customize-manifest.json that doesn't have mobile.css
-  manifest.mobile.css = manifest.mobile.css || [];
-
   // Confirmation prompt before applying
-  if (!yes) {
+  if (!yes && !watch) {
     logger.debug("Prompting for confirmation...");
     const shouldApply = await confirm({
       message: `Apply customization to app ${appId}?`,
@@ -286,4 +308,51 @@ export const runApply = async (params: ApplyParams) => {
   const apiClient = buildRestAPIClient(restApiClientOptions);
 
   await apply(apiClient, appId, manifest, manifestDir, boundMessage);
+
+  if (watch) {
+    const watchOptions =
+      os.platform() === "win32"
+        ? {
+            awaitWriteFinish: {
+              stabilityThreshold: 1000,
+              pollInterval: 250,
+            },
+          }
+        : {};
+    let watchedFiles = getLocalFiles(manifest, manifestDir);
+    const watcher = chokidar.watch(
+      [resolvedInputPath, ...watchedFiles],
+      watchOptions,
+    );
+    logger.info(boundMessage("M_Watching"));
+
+    watcher.on("change", async () => {
+      try {
+        const updatedManifest = loadManifest(resolvedInputPath);
+        const newLocalFiles = getLocalFiles(updatedManifest, manifestDir);
+
+        const removed = watchedFiles.filter((f) => !newLocalFiles.includes(f));
+        const added = newLocalFiles.filter((f) => !watchedFiles.includes(f));
+        if (removed.length > 0) {
+          watcher.unwatch(removed);
+        }
+        if (added.length > 0) {
+          watcher.add(added);
+        }
+        watchedFiles = newLocalFiles;
+
+        await apply(
+          apiClient,
+          appId,
+          updatedManifest,
+          manifestDir,
+          boundMessage,
+        );
+        logger.info(boundMessage("M_Watching"));
+      } catch (error) {
+        logger.error(error);
+        logger.info(boundMessage("M_Watching"));
+      }
+    });
+  }
 };


### PR DESCRIPTION
## Why

The old `@kintone/customize-uploader` (in js-sdk) had a `--watch` option that watched for file changes and automatically re-applied customizations. This feature was not carried over when the functionality was migrated to cli-kintone. Developers working on kintone customizations need to manually re-run `customize apply` every time they make a change, which slows down the development workflow.

## What

Add `--watch` option to the `customize apply` command, matching the existing watch mode in `plugin upload` and `plugin pack`.

Key improvements over the old `@kintone/customize-uploader` implementation:
- **Manifest is reloaded on every change** — the old implementation loaded the manifest once and never updated it, so adding new files to the manifest required restarting the command
- **Watch targets are dynamically updated** — when the manifest changes, files that were removed from the manifest are unwatched and newly added files are watched

Behavior:
- Watches the manifest file (`customize-manifest.json`) and all local files referenced in it (URLs are excluded)
- On file change, reloads the manifest, updates watch targets, and re-runs the apply flow
- Skips the confirmation prompt in watch mode (same as `plugin upload --watch`)
- On Windows, uses `awaitWriteFinish` to avoid reading incomplete files (same pattern as `plugin pack`/`plugin upload`)
- On error, logs the error and continues watching (does not exit the process)

## How to test

```bash
# Basic watch mode
cli-kintone customize apply \
  --base-url https://example.cybozu.com \
  --username user \
  --password pass \
  --app 1 \
  --input customize-manifest.json \
  --watch

# Edit a JS/CSS file referenced in the manifest → should auto-apply
# Edit customize-manifest.json to add a new file → should pick up the new file
```

## Checklist

- [x] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [x] Passed `pnpm lint` and `pnpm test` on the root directory.