### PR TITLE
fix(plugin): use actual manifest filename from --input instead of hardcoded manifest.json

### DIFF
--- a/src/plugin/core/__tests__/summary.test.ts
+++ b/src/plugin/core/__tests__/summary.test.ts
@@ -3,6 +3,7 @@ import type { ManifestInterface } from "../manifest/interface";
 import { buildPluginSummary } from "../summary";
 
 const baseManifest: ManifestInterface = {
+  manifestFileName: "manifest.json",
   validate: async () => ({ valid: true, warnings: [] }),
   sourceList: () => [],
   generateContentsZip: async () => ({}) as never,

--- a/src/plugin/core/contents/__tests__/index.test.ts
+++ b/src/plugin/core/contents/__tests__/index.test.ts
@@ -52,6 +52,31 @@ describe("ContentsZip", () => {
     });
   });
 
+  describe("should bundle custom manifest filename as manifest.json in zip", () => {
+    it("manifest v1", async () => {
+      const pluginDir = path.join(fixturesDir, "plugin-manifest-v1");
+
+      const customName = "manifest.local.json";
+      fs.copyFileSync(
+        path.join(pluginDir, "manifest.json"),
+        path.join(pluginDir, customName),
+      );
+      try {
+        const manifestJSONPath = path.join(pluginDir, customName);
+        const manifest = await ManifestFactory.loadJsonFile(manifestJSONPath);
+
+        const contentsZip = await ContentsZip.buildFromManifest(
+          manifest,
+          new LocalFSDriver(pluginDir),
+        );
+        const files = await contentsZip.fileList();
+        expect(files).toStrictEqual(["manifest.json", "image/icon.png"]);
+      } finally {
+        fs.unlinkSync(path.join(pluginDir, customName));
+      }
+    });
+  });
+
   describe("invalid contents.zip", () => {
     const invalidMaxFileSizeContentsZipPath = path.join(
       __dirname,

--- a/src/plugin/core/contents/zip.ts
+++ b/src/plugin/core/contents/zip.ts
@@ -17,7 +17,8 @@ export const buildContentsZip = async (
 
   for (const src of manifest.sourceList()) {
     const data = await driver.readFile(src);
-    zipFile.addBuffer(data, src);
+    const entryName = src === manifest.manifestFileName ? "manifest.json" : src;
+    zipFile.addBuffer(data, entryName);
   }
   zipFile.end(undefined, ((finalSize: number) => {
     size = finalSize;

--- a/src/plugin/core/manifest/factory.ts
+++ b/src/plugin/core/manifest/factory.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { DriverInterface } from "../driver";
 import { LocalFSDriver } from "../driver";
 import type { ManifestInterface, ManifestStaticInterface } from "./interface";
@@ -44,7 +45,9 @@ export class ManifestFactory {
   ): Promise<ManifestInterface> {
     const _driver = driver ?? new LocalFSDriver();
     const manifestJson = await _driver.readFile(jsonFilePath, "utf-8");
-    return this.parseJson(manifestJson);
+    const manifest = this.parseJson(manifestJson);
+    manifest.manifestFileName = path.basename(jsonFilePath);
+    return manifest;
   }
 }
 const _ = ManifestFactory satisfies ManifestStaticInterface;

--- a/src/plugin/core/manifest/interface.ts
+++ b/src/plugin/core/manifest/interface.ts
@@ -25,6 +25,8 @@ export interface ManifestStaticInterface {
 }
 
 export interface ManifestInterface {
+  manifestFileName: string;
+
   // TODO: Validating file existence and file size are better to be done in contents validation.
   /**
    * Validate Manifest

--- a/src/plugin/core/manifest/v1/__tests__/sourcelist.test.ts
+++ b/src/plugin/core/manifest/v1/__tests__/sourcelist.test.ts
@@ -55,6 +55,20 @@ describe("sourcelist", () => {
       "image/icon.png",
     ]);
   });
+  it("should use the given manifest filename", () => {
+    expect(sourceList(manifest, "manifest.local.json")).toStrictEqual([
+      "js/desktop.js",
+      "js/lib.js",
+      "css/desktop.css",
+      "css/lib.css",
+      "js/mobile.js",
+      "js/config.js",
+      "css/config.css",
+      "html/config.html",
+      "manifest.local.json",
+      "image/icon.png",
+    ]);
+  });
   it("should make the file list unique", () => {
     manifest.desktop.js.push("js/desktop.js");
     manifest.desktop.css.push("css/desktop.css");

--- a/src/plugin/core/manifest/v1/index.ts
+++ b/src/plugin/core/manifest/v1/index.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import { sourceList } from "./sourcelist";
 import type {
   ManifestInterface,
@@ -12,6 +13,7 @@ import { logger } from "../../../../utils/log";
 
 export class ManifestV1 implements ManifestInterface {
   manifest: ManifestV1JsonObject;
+  manifestFileName = "manifest.json";
 
   constructor(manifest: ManifestV1JsonObject) {
     this.manifest = manifest;
@@ -27,7 +29,9 @@ export class ManifestV1 implements ManifestInterface {
   ): Promise<ManifestV1> {
     const _driver = driver ?? new LocalFSDriver();
     const manifestJson = await _driver.readFile(jsonFilePath, "utf-8");
-    return this.parseJson(manifestJson);
+    const manifest = this.parseJson(manifestJson);
+    manifest.manifestFileName = path.basename(jsonFilePath);
+    return manifest;
   }
 
   get manifestVersion(): 1 {
@@ -73,7 +77,7 @@ export class ManifestV1 implements ManifestInterface {
   }
 
   sourceList(): string[] {
-    return sourceList(this.manifest);
+    return sourceList(this.manifest, this.manifestFileName);
   }
 
   async generateContentsZip(driver: DriverInterface): Promise<ContentsZip> {

--- a/src/plugin/core/manifest/v1/sourcelist.ts
+++ b/src/plugin/core/manifest/v1/sourcelist.ts
@@ -3,7 +3,10 @@ import type { ManifestV1JsonObject } from "./index";
 /**
  * Create contents file list from manifest.json
  */
-export const sourceList = (manifest: ManifestV1JsonObject): string[] => {
+export const sourceList = (
+  manifest: ManifestV1JsonObject,
+  manifestFileName = "manifest.json",
+): string[] => {
   const list = ([] as string[]).concat(
     manifest.desktop?.js?.filter((s) => !isURL(s)) ?? [],
     manifest.desktop?.css?.filter((s) => !isURL(s)) ?? [],
@@ -12,7 +15,7 @@ export const sourceList = (manifest: ManifestV1JsonObject): string[] => {
     manifest.config?.js?.filter((s) => !isURL(s)) ?? [],
     manifest.config?.css?.filter((s) => !isURL(s)) ?? [],
     manifest.config?.html ?? [],
-    ["manifest.json", manifest.icon],
+    [manifestFileName, manifest.icon],
   );
 
   // Make the file list unique

--- a/src/plugin/core/manifest/v2/__tests__/sourcelist.test.ts
+++ b/src/plugin/core/manifest/v2/__tests__/sourcelist.test.ts
@@ -65,4 +65,16 @@ describe("sourceListV2", () => {
       "css/config.css",
     ]);
   });
+  it("should use the given manifest filename", () => {
+    expect(sourceListV2(manifest, "manifest.local.json")).toStrictEqual([
+      "manifest.local.json",
+      "image/icon.png",
+      "js/customize.js",
+      "css/customize.css",
+      "html/customize.html",
+      "html/config.html",
+      "js/config.js",
+      "css/config.css",
+    ]);
+  });
 });

--- a/src/plugin/core/manifest/v2/index.ts
+++ b/src/plugin/core/manifest/v2/index.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type {
   ManifestInterface,
   ManifestPermissions,
@@ -10,6 +11,7 @@ import { ContentsZip } from "../../contents";
 
 export class ManifestV2 implements ManifestInterface {
   manifest: ManifestV2JsonObject;
+  manifestFileName = "manifest.json";
 
   constructor(manifest: ManifestV2JsonObject) {
     this.manifest = manifest;
@@ -25,7 +27,9 @@ export class ManifestV2 implements ManifestInterface {
   ): Promise<ManifestV2> {
     const _driver = driver ?? new LocalFSDriver();
     const manifestJson = await _driver.readFile(jsonFilePath, "utf-8");
-    return this.parseJson(manifestJson);
+    const manifest = this.parseJson(manifestJson);
+    manifest.manifestFileName = path.basename(jsonFilePath);
+    return manifest;
   }
 
   get manifestVersion(): 2 {
@@ -74,7 +78,7 @@ export class ManifestV2 implements ManifestInterface {
   }
 
   sourceList(): string[] {
-    return sourceListV2(this.manifest);
+    return sourceListV2(this.manifest, this.manifestFileName);
   }
 
   async generateContentsZip(driver: DriverInterface): Promise<ContentsZip> {

--- a/src/plugin/core/manifest/v2/sourcelist.ts
+++ b/src/plugin/core/manifest/v2/sourcelist.ts
@@ -3,9 +3,12 @@ import type { ManifestV2JsonObject } from "./index";
 /**
  * Create contents file list from manifest.json
  */
-export const sourceListV2 = (manifest: ManifestV2JsonObject): string[] => {
+export const sourceListV2 = (
+  manifest: ManifestV2JsonObject,
+  manifestFileName = "manifest.json",
+): string[] => {
   const list: string[] = [];
-  list.push("manifest.json", manifest.icon);
+  list.push(manifestFileName, manifest.icon);
 
   const filesInComponents =
     manifest.components

--- a/src/plugin/info/__tests__/index.test.ts
+++ b/src/plugin/info/__tests__/index.test.ts
@@ -3,6 +3,7 @@ import type { ManifestInterface } from "../../core/manifest/interface";
 import { buildPluginInfoJson } from "../index";
 
 const baseManifest: ManifestInterface = {
+  manifestFileName: "manifest.json",
   validate: async () => ({ valid: true, warnings: [] }),
   sourceList: () => [],
   generateContentsZip: async () => ({}) as never,


### PR DESCRIPTION
## Why

The `plugin pack` command accepts `--input` for specifying a custom manifest file path, but internally hardcodes `"manifest.json"` in the source list and zip bundling. This causes `pack` to fail or use the wrong file when `--input` points to a differently named manifest (e.g. `manifest.local.json`).

Closes #1507

## What

- Add `manifestFileName` property to `ManifestInterface` (defaults to `"manifest.json"`)
- Set it from `path.basename(jsonFilePath)` in `loadJsonFile` of `ManifestV1`, `ManifestV2`, and `ManifestFactory`
- Thread the actual filename through `sourceList()` / `sourceListV2()` instead of the hardcoded literal
- In `buildContentsZip`, remap the manifest entry name to `"manifest.json"` so the output zip remains compatible with kintone's expected format

## How to test

```bash
# Create a plugin project with a non-standard manifest name
cp plugin/manifest.json plugin/manifest.local.json

# Pack using the custom manifest name — this should succeed
cli-kintone plugin pack \
  --private-key ./key/private.ppk \
  --output dist/plugin_local.zip \
  --input plugin/manifest.local.json

# Verify the zip contains manifest.json (not manifest.local.json)
unzip -l dist/plugin_local.zip
```

Unit tests:

```bash
pnpm test -- --testPathPattern='(sourcelist|contents/__tests__/index)'
```

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [x] Added/updated tests if it is required. (or tested manually)
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.