### PR TITLE
chore(ci): pin npm to 11.x to avoid sigstore bundling bug in npm 12.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,9 +131,10 @@ jobs:
           npm config set --location=user registry https://npm.flatt.tech/
           npm config set --location=user //npm.flatt.tech/:_authToken "${TAKUMI_GUARD_TOKEN}"
 
-      # Ensure npm 11.5.1 or later is installed
+      # Ensure npm >=11.5.1 is installed (Trusted Publishers requirement).
+      # Pinned to 11.x because npm 12.0.0 has a sigstore bundling bug (npm/cli#9722).
       # ref. https://docs.npmjs.com/trusted-publishers#github-actions-configuration
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - run: pnpm publish --access public --registry https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

- `npm install -g npm@latest` を `npm install -g npm@11` に固定

## Background

npm v12.0.0 (2026-07-08 リリース) で非スコープの `sigstore` パッケージが bundledDependencies から脱落しており、`npm publish --provenance` が `Cannot find module 'sigstore'` で失敗します。

- 失敗した run: https://github.com/kintone/cli-kintone/actions/runs/28984947716
- upstream issue: https://github.com/npm/cli/issues/9722 (Needs Triage)

| npm version | `node_modules/sigstore/` | Result |
|---|---|---|
| 11.17.0 | present | OK |
| 12.0.0 | **missing** | MODULE_NOT_FOUND |

npm 12 のパッチで修正されるまで 11.x に固定します。

## Test plan

- [ ] 次回リリース時に publish-npm ジョブが成功すること