### PR TITLE
test: add HTTP-level characterization tests for @kintone/rest-api-client usage

### DIFF
--- a/.dev/contexts/test-http-level-characterization-tests.md
+++ b/.dev/contexts/test-http-level-characterization-tests.md
@@ -1,0 +1,55 @@
+# test/http-level-characterization-tests 対話コンテキスト
+
+- PR: #1582
+- Branch: `test/http-level-characterization-tests`
+- Source commit: 23510199eea
+- Updated at: 2026-08-23 13:05:00
+
+## 目的
+
+`@kintone/rest-api-client` は axios → fetch(undici) への移行が計画されている（[kintone/js-sdk#3937](https://github.com/kintone/js-sdk/pull/3937)）。cli-kintone は現状 axios ベースのこのクライアントに依存しており、移行後も挙動が変わらないことを検証できる自動テストが存在しなかった。このブランチは、axios ベースの現在の挙動を先に「特性化テスト（characterization tests）」として固定する。
+
+## 設計方針
+
+- msw ではなく `node:http` の生ソケットで実サーバーを立てる（`HttpTestServer`）。msw は axios と fetch を別々のコード経路でインターセプトするため、msw ベースの検証では2つのインターセプタ実装を比較するだけになり、js-sdk 側に既に存在する msw ベースのハーネスと重複するだけになると判断した。
+- `HttpTestServer` は1テストファイルにつき1インスタンス（`beforeAll`で起動、`beforeEach`で`reset()`）。
+- レスポンスボディを送る手段を `body`（常にJSON.stringifyされる）と `rawBody`（文字列/Bufferをそのまま送る）の2種類に分離した。当初 `body` のみだったが、sanity-review で「文字列を`body`に渡しても`JSON.stringify`で引用符付きの妥当なJSON文字列になり、意図した『非JSONボディ』を検証できていない」というテストの信頼性バグが発覚し、修正した。
+- リスク領域の選定はjs-sdk側の実際の修正コミットを手がかりにした: `deleteAllRecords`/ファイルアップロード(multipart/stream)は `bd0eb710`、プロキシ検証は `0309c872`（httpsAgent回帰）を狙い撃ちしている。
+
+## 却下した代替案
+
+- **fetch版rest-api-clientをtarball化してoverrideで実差し替え検証する（Tier 0）**: ローカルの js-sdk（`/Users/t003557/work/js-sdk`、ブランチ `fix/undici-dispatcher-version-mismatch`）でビルド・`pnpm pack`まで済ませたが、`package.json`の書き換えをユーザーが明示的に却下した（「そこまではしなくていい」）。理由の詳細な説明はなし。tarball自体は `/tmp/kintone-rest-api-client-6.2.1.tgz` に残っている（セッション終了で消える可能性あり、再現するには js-sdk 側で `pnpm --filter @kintone/rest-api-client build && pnpm pack --pack-destination /tmp` を再実行すればよい）。
+- **`HttpTestServer`の`listen()`を`127.0.0.1`にバインドする**: sanity-reviewで「決定性の観点で`localhost`より`127.0.0.1`が良い」と指摘されたが、`KintoneRestAPIClient`の`validateBaseUrl`が「hostnameが`localhost`以外なら`https`必須」という制約を持つため、`127.0.0.1`にすると全テストがコンストラクタで即エラーになる。この制約は axios版・fetch版（js-sdk側でビルドしたもの）の両方で同一であることを確認済みで、`localhost`のまま維持する判断をした。
+
+## 意図的に対応しないこと
+
+- クライアント証明書（pfx）の検証: 自己署名証明書での実TLSハンドシェイクと、プロセス起動時に設定する必要がある`NODE_EXTRA_CA_CERTS`が必要（テストファイル内からは設定不可）。別のvitestプロジェクト設定が要る。
+- レコードエクスポートのカーソルページング（`/k/v1/records/cursor.json`）: cli-kintoneで最も呼び出し頻度が高い経路の一つだが未着手。
+- リダイレクト時のボディ再送（307/308）: 未着手。
+- fetch版への実差し替え検証（Tier 0/1）: 上記の通りユーザーの意向でスコープ外。
+
+## 発見された制約
+
+- `KintoneRestAPIClient`（6.2.1）の`validateBaseUrl`は `url.hostname !== "localhost" && url.protocol !== "https:"` の場合にthrowする。つまり平文httpが許されるのは hostname が厳密に `"localhost"` の場合のみ（`127.0.0.1`はNG）。これはjs-sdk側でfetch移行後にビルドしたバージョンでも同一のロジックであることを確認済み（`packages/rest-api-client/src/KintoneRestAPIClient.ts`のvalidateBaseUrl相当）。
+- cli-kintoneのe2e（cucumber）は `bin/cli-kintone-<platform>`（`ncc build` → `pkg --sea`）のビルド済みバイナリを子プロセスとして実行する方式で、実kintone環境の認証情報（`.e2e-credentials.json`）が必要。この開発環境には認証情報が無く、e2eはフル実行できない。
+- cli-kintoneの`engines.node`は`>=20`だが、js-sdk側のrest-api-clientはfetch移行に伴い`>=22`に引き上げ済み。サポートポリシー上の判断が別途必要（今回のテスト整備のブロッカーにはしていない）。
+- `src/kintone/client.ts`の`buildRestAPIClient`は、proxy/pfxいずれも未指定の場合でも常に`httpsAgent: new https.Agent({})`を明示的に構築して`KintoneRestAPIClient`に渡している。これはjs-sdk側の`0309c872`（TLSオプションなしのhttpsAgentが渡された場合の回帰）に直接該当するリスク領域。
+
+## 新たに確認できた事実
+
+- cli-kintoneの既存ユニットテストは`KintoneRestAPIClient`の各メソッド（`record.deleteAllRecords`等）を`vi.fn()`で直接差し替えており、HTTP層を一切経由しない。そのためrest-api-client内部の実装がaxiosからfetchに変わっても既存テストは何も検知できない。
+- `deleteAllRecords`は内部で `GET /k/v1/records.json` → `POST /k/v1/bulkRequest.json`（`DELETE /k/v1/records.json`をbulk request化）という2段のリクエストを送る。`addAllRecords`も同様に`POST /k/v1/bulkRequest.json`にラップされ、レスポンス形式は`{"results": [{"ids": [...], "revisions": [...]}]}`。
+- ファイルアップロード（`apiClient.file.uploadFile`）は`multipart/form-data`で`POST /k/v1/file.json`に送信される。
+- axios版でのエラー分類: kintoneのJSON形式500エラー → `KintoneRestAPIError`（status/code/id保持）。ソケット破棄によるトランスポート断 → `AxiosError`（`code: ECONNRESET`, `message: "socket hang up"`）、`KintoneRestAPIError`のinstanceにはならない。502+非JSON(HTML)ボディ → プレーンな`Error`（`message: "502: Bad Gateway"`）、これも`KintoneRestAPIError`にはならない。
+
+## 注意が必要な難所
+
+- `HttpTestServer`で文字列/Bufferの生ボディを送りたい場合は`body`ではなく`rawBody`を使うこと。`body`は常に`JSON.stringify`されるため、文字列を渡しても意図せず「有効なJSON文字列」になってしまい、「非JSONボディ」のテストにならない（このブランチで一度踏んだ）。
+- multipartのテスト用フィクスチャで単調増加バイト列（`i % 256`）を使うと、CRLFやboundary類似バイト（`--`）を一切含まないため、multipartパーサーが実運用で踏みうるエッジケース（バイナリ内にCRLFやboundary類似列が紛れ込むケース）を意図せず回避してしまう。`seededPseudoRandomBytes`のように、決定的だがCRLF/`--`を意図的に混ぜ込む生成方法にすること。
+- fetch/undici移行後はNodeのkeep-aliveが既定で有効になるため、`HttpTestServer.close()`／`ConnectProxyServer.close()`は`closeAllConnections()`を呼んでから`server.close()`する必要がある。呼ばないと、移行後に`afterAll`がkeepAliveTimeout（既定5秒）待ちで詰まりうる。
+
+## 残作業
+
+- fetch版のrest-api-client（js-sdk側、`/Users/t003557/work/js-sdk`のブランチ`fix/undici-dispatcher-version-mismatch`でビルド・pack済み）を実際に差し込んで、この5ファイルのHTTPレベルテストがgreenのまま残るか検証する（未実施、ユーザーの意向で今回はスコープ外）。
+- 上記を実施した場合、`buildRestAPIClient proxy support`のCONNECTテストはjs-sdk側がundiciのdispatcherベースに移行した影響で`HttpsProxyAgent`（`https.Agent`のサブクラス）がそのまま機能しない可能性が高く、redになると予想している。redになった場合はcli-kintone側のバグではなくjs-sdk側へのフィードバック事項として扱う。
+- カーソルページング、リダイレクト再送（307/308）、クライアント証明書（pfx）検証のテストは未着手。

--- a/src/__tests__/helpers/connectProxyServer.ts
+++ b/src/__tests__/helpers/connectProxyServer.ts
@@ -24,6 +24,12 @@ export class ConnectProxyServer {
       res.end("This proxy only supports CONNECT.");
     });
     this.server.on("connect", (req: http.IncomingMessage, socket: Socket) => {
+      // This proxy always destroys the tunnel socket itself, but the client
+      // may also tear its end down concurrently -- without this, that races
+      // into an unhandled 'error' that crashes the test process.
+      socket.on("error", () => {
+        /* client side of the tunnel went away; nothing to do */
+      });
       this._connects.push({ target: req.url ?? "", headers: req.headers });
       socket.destroy();
     });
@@ -51,6 +57,7 @@ export class ConnectProxyServer {
   }
 
   async close(): Promise<void> {
+    this.server.closeAllConnections();
     await new Promise<void>((resolve, reject) => {
       this.server.close((err) => (err ? reject(err) : resolve()));
     });

--- a/src/__tests__/helpers/connectProxyServer.ts
+++ b/src/__tests__/helpers/connectProxyServer.ts
@@ -1,0 +1,58 @@
+import http from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+
+export type CapturedConnect = {
+  /** "host:port" from the CONNECT request line, e.g. "kintone.invalid:443". */
+  target: string;
+  headers: http.IncomingHttpHeaders;
+};
+
+/**
+ * A minimal HTTP proxy that only understands CONNECT, for asserting that
+ * cli-kintone's httpsProxy option actually reaches the HTTP client as a
+ * proxy agent. It never completes the tunnel -- it records the CONNECT
+ * target and destroys the socket, so the client call fails afterward; tests
+ * using this assert on what the proxy *saw*, not on a response.
+ */
+export class ConnectProxyServer {
+  private readonly server: http.Server;
+  private _connects: CapturedConnect[] = [];
+
+  private constructor() {
+    this.server = http.createServer((_req, res) => {
+      res.writeHead(400);
+      res.end("This proxy only supports CONNECT.");
+    });
+    this.server.on("connect", (req: http.IncomingMessage, socket: Socket) => {
+      this._connects.push({ target: req.url ?? "", headers: req.headers });
+      socket.destroy();
+    });
+  }
+
+  static async start(): Promise<ConnectProxyServer> {
+    const instance = new ConnectProxyServer();
+    await new Promise<void>((resolve) =>
+      instance.server.listen(0, "localhost", resolve),
+    );
+    return instance;
+  }
+
+  get connects(): readonly CapturedConnect[] {
+    return this._connects;
+  }
+
+  reset(): void {
+    this._connects = [];
+  }
+
+  get url(): string {
+    const address = this.server.address() as AddressInfo;
+    return `http://localhost:${address.port}`;
+  }
+
+  async close(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}

--- a/src/__tests__/helpers/httpTestServer.ts
+++ b/src/__tests__/helpers/httpTestServer.ts
@@ -25,6 +25,19 @@ export type HttpTestServerResponse =
       headers?: Record<string, string>;
     }
   | {
+      /**
+       * Sends this string/Buffer exactly as-is, without JSON.stringify.
+       * Use this for a response that is deliberately NOT valid JSON (e.g. an
+       * HTML error page from an intermediary) -- `body` always gets
+       * JSON.stringify'd, so it can only ever produce valid JSON (even a
+       * plain string becomes a valid JSON string literal), which is the
+       * wrong tool for that case.
+       */
+      status: number;
+      rawBody: string | Buffer;
+      headers?: Record<string, string>;
+    }
+  | {
       /** Destroys the socket without writing a response, to simulate a transport-level failure (e.g. connection reset). */
       destroySocket: true;
     };
@@ -40,6 +53,32 @@ const defaultHandler: HttpTestServerHandler = () => {
 };
 
 /**
+ * Merges `overrides` onto `defaults`, treating header names as
+ * case-insensitive (HTTP header names are). A plain `{...defaults,
+ * ...overrides}` spread would leave both `Content-Type` (the default) and a
+ * test-supplied `content-type` on the wire, with Node deciding which one
+ * wins -- this makes the override always win regardless of casing.
+ */
+const mergeHeaders = (
+  defaults: Record<string, string>,
+  overrides?: Record<string, string>,
+): Record<string, string> => {
+  if (!overrides) {
+    return { ...defaults };
+  }
+  const overrideKeysLower = new Set(
+    Object.keys(overrides).map((k) => k.toLowerCase()),
+  );
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries(defaults)) {
+    if (!overrideKeysLower.has(key.toLowerCase())) {
+      merged[key] = value;
+    }
+  }
+  return { ...merged, ...overrides };
+};
+
+/**
  * A real HTTP server (node:http) listening on an ephemeral loopback port,
  * for characterization tests that exercise `@kintone/rest-api-client` end
  * to end -- through a real socket rather than an in-process interceptor --
@@ -49,6 +88,13 @@ const defaultHandler: HttpTestServerHandler = () => {
  * Usage: start once per test file (in beforeAll), setHandler per test to
  * script the response, and inspect `requests` to assert what the client
  * actually sent over the wire.
+ *
+ * Binds and reports "localhost", not "127.0.0.1", deliberately:
+ * KintoneRestAPIClient's own baseUrl validation only allows a plain http://
+ * baseUrl when the hostname is exactly "localhost" (any other hostname,
+ * `127.0.0.1` included, must be https). Using "localhost" for both the bind
+ * address and baseUrl keeps them consistent regardless of which address
+ * family "localhost" resolves to.
  */
 export class HttpTestServer {
   private readonly server: http.Server;
@@ -70,6 +116,16 @@ export class HttpTestServer {
   private onRequest(req: http.IncomingMessage, res: http.ServerResponse) {
     const chunks: Buffer[] = [];
     req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    // Without this, a client that aborts mid-request (e.g. the
+    // destroySocket path exercised from the *other* end, or a client-side
+    // timeout) raises an unhandled 'error' on the request stream, which
+    // crashes the whole test process instead of just failing the assertion.
+    req.on("error", () => {
+      /* client aborted the request; nothing to respond to */
+    });
+    res.on("error", () => {
+      /* client went away before the response was fully written */
+    });
     req.on("end", () => {
       this.handleRequest(req, res, chunks).catch((e: unknown) => {
         res.destroy(e instanceof Error ? e : new Error(String(e)));
@@ -114,13 +170,17 @@ export class HttpTestServer {
         res.destroy();
         return;
       }
-      res.writeHead(result.status, {
-        "Content-Type": "application/json",
-        ...result.headers,
-      });
-      res.end(
-        result.body !== undefined ? JSON.stringify(result.body) : undefined,
+      res.writeHead(
+        result.status,
+        mergeHeaders({ "Content-Type": "application/json" }, result.headers),
       );
+      if ("rawBody" in result) {
+        res.end(result.rawBody);
+      } else {
+        res.end(
+          result.body !== undefined ? JSON.stringify(result.body) : undefined,
+        );
+      }
     } catch (e) {
       res.writeHead(500, { "Content-Type": "application/json" });
       res.end(
@@ -154,73 +214,14 @@ export class HttpTestServer {
   }
 
   async close(): Promise<void> {
+    // This test server is exercised by both axios (keepAlive: false, so
+    // idle sockets close themselves) and, after the planned migration,
+    // fetch/undici (keep-alive by default). Without closeAllConnections(),
+    // close() would wait out the server's keepAliveTimeout (5s default) on
+    // every idle connection once that migration lands.
+    this.server.closeAllConnections();
     await new Promise<void>((resolve, reject) => {
       this.server.close((err) => (err ? reject(err) : resolve()));
     });
   }
 }
-
-export type MultipartPart = {
-  name: string;
-  filename?: string;
-  contentType?: string;
-  data: Buffer;
-};
-
-/**
- * Minimal multipart/form-data parser for assertions -- not a general-purpose
- * decoder. The boundary is random per request (form-data generates it), so
- * tests must extract fields from the parsed parts rather than snapshotting
- * the raw body.
- */
-export const parseMultipartFormData = (
-  req: CapturedRequest,
-): MultipartPart[] => {
-  const contentType = req.headers["content-type"] ?? "";
-  const boundaryMatch = /boundary=(?:"([^"]+)"|([^;]+))/.exec(contentType);
-  if (!boundaryMatch) {
-    throw new Error(`Content-Type has no multipart boundary: ${contentType}`);
-  }
-  const boundaryMarker = Buffer.from(
-    `--${boundaryMatch[1] ?? boundaryMatch[2]}`,
-  );
-  const buffer = req.rawBodyBuffer;
-
-  const parts: MultipartPart[] = [];
-  let boundaryStart = buffer.indexOf(boundaryMarker);
-  while (boundaryStart !== -1) {
-    const partStart = boundaryStart + boundaryMarker.length;
-    const nextBoundaryStart = buffer.indexOf(boundaryMarker, partStart);
-    if (nextBoundaryStart === -1) {
-      break;
-    }
-
-    // The segment between this boundary and the next is "\r\n<headers>\r\n\r\n<body>\r\n".
-    let segment = buffer.subarray(partStart, nextBoundaryStart);
-    if (segment.subarray(0, 2).toString("ascii") === "\r\n") {
-      segment = segment.subarray(2);
-    }
-    if (segment.subarray(-2).toString("ascii") === "\r\n") {
-      segment = segment.subarray(0, -2);
-    }
-
-    const headerEnd = segment.indexOf("\r\n\r\n");
-    if (headerEnd !== -1) {
-      const headerText = segment.subarray(0, headerEnd).toString("utf-8");
-      const data = segment.subarray(headerEnd + 4);
-      const dispositionMatch = /name="([^"]*)"(?:;\s*filename="([^"]*)")?/.exec(
-        headerText,
-      );
-      const contentTypeMatch = /Content-Type:\s*([^\r\n]+)/i.exec(headerText);
-      parts.push({
-        name: dispositionMatch?.[1] ?? "",
-        filename: dispositionMatch?.[2],
-        contentType: contentTypeMatch?.[1],
-        data,
-      });
-    }
-
-    boundaryStart = nextBoundaryStart;
-  }
-  return parts;
-};

--- a/src/__tests__/helpers/httpTestServer.ts
+++ b/src/__tests__/helpers/httpTestServer.ts
@@ -12,7 +12,10 @@ export type CapturedRequest = {
   headers: http.IncomingHttpHeaders;
   /** Parsed as JSON when the request's Content-Type is application/json, otherwise the raw string. */
   body: unknown;
+  /** UTF-8 decoding of rawBodyBuffer, for convenience with text bodies. Lossy for binary bodies -- use rawBodyBuffer for those. */
   rawBody: string;
+  /** The exact bytes received, untouched by any encoding. Required for asserting binary/multipart bodies. */
+  rawBodyBuffer: Buffer;
 };
 
 export type HttpTestServerResponse =
@@ -79,7 +82,8 @@ export class HttpTestServer {
     res: http.ServerResponse,
     chunks: Buffer[],
   ): Promise<void> {
-    const rawBody = Buffer.concat(chunks).toString("utf-8");
+    const rawBodyBuffer = Buffer.concat(chunks);
+    const rawBody = rawBodyBuffer.toString("utf-8");
     const url = new URL(req.url ?? "/", this.baseUrl);
     const contentType = req.headers["content-type"] ?? "";
 
@@ -100,6 +104,7 @@ export class HttpTestServer {
       headers: req.headers,
       body,
       rawBody,
+      rawBodyBuffer,
     };
     this._requests.push(captured);
 
@@ -154,3 +159,68 @@ export class HttpTestServer {
     });
   }
 }
+
+export type MultipartPart = {
+  name: string;
+  filename?: string;
+  contentType?: string;
+  data: Buffer;
+};
+
+/**
+ * Minimal multipart/form-data parser for assertions -- not a general-purpose
+ * decoder. The boundary is random per request (form-data generates it), so
+ * tests must extract fields from the parsed parts rather than snapshotting
+ * the raw body.
+ */
+export const parseMultipartFormData = (
+  req: CapturedRequest,
+): MultipartPart[] => {
+  const contentType = req.headers["content-type"] ?? "";
+  const boundaryMatch = /boundary=(?:"([^"]+)"|([^;]+))/.exec(contentType);
+  if (!boundaryMatch) {
+    throw new Error(`Content-Type has no multipart boundary: ${contentType}`);
+  }
+  const boundaryMarker = Buffer.from(
+    `--${boundaryMatch[1] ?? boundaryMatch[2]}`,
+  );
+  const buffer = req.rawBodyBuffer;
+
+  const parts: MultipartPart[] = [];
+  let boundaryStart = buffer.indexOf(boundaryMarker);
+  while (boundaryStart !== -1) {
+    const partStart = boundaryStart + boundaryMarker.length;
+    const nextBoundaryStart = buffer.indexOf(boundaryMarker, partStart);
+    if (nextBoundaryStart === -1) {
+      break;
+    }
+
+    // The segment between this boundary and the next is "\r\n<headers>\r\n\r\n<body>\r\n".
+    let segment = buffer.subarray(partStart, nextBoundaryStart);
+    if (segment.subarray(0, 2).toString("ascii") === "\r\n") {
+      segment = segment.subarray(2);
+    }
+    if (segment.subarray(-2).toString("ascii") === "\r\n") {
+      segment = segment.subarray(0, -2);
+    }
+
+    const headerEnd = segment.indexOf("\r\n\r\n");
+    if (headerEnd !== -1) {
+      const headerText = segment.subarray(0, headerEnd).toString("utf-8");
+      const data = segment.subarray(headerEnd + 4);
+      const dispositionMatch = /name="([^"]*)"(?:;\s*filename="([^"]*)")?/.exec(
+        headerText,
+      );
+      const contentTypeMatch = /Content-Type:\s*([^\r\n]+)/i.exec(headerText);
+      parts.push({
+        name: dispositionMatch?.[1] ?? "",
+        filename: dispositionMatch?.[2],
+        contentType: contentTypeMatch?.[1],
+        data,
+      });
+    }
+
+    boundaryStart = nextBoundaryStart;
+  }
+  return parts;
+};

--- a/src/__tests__/helpers/httpTestServer.ts
+++ b/src/__tests__/helpers/httpTestServer.ts
@@ -1,0 +1,156 @@
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+/**
+ * A single HTTP request captured by HttpTestServer, already parsed for
+ * convenient assertions.
+ */
+export type CapturedRequest = {
+  method: string;
+  path: string;
+  query: URLSearchParams;
+  headers: http.IncomingHttpHeaders;
+  /** Parsed as JSON when the request's Content-Type is application/json, otherwise the raw string. */
+  body: unknown;
+  rawBody: string;
+};
+
+export type HttpTestServerResponse =
+  | {
+      status: number;
+      body?: unknown;
+      headers?: Record<string, string>;
+    }
+  | {
+      /** Destroys the socket without writing a response, to simulate a transport-level failure (e.g. connection reset). */
+      destroySocket: true;
+    };
+
+export type HttpTestServerHandler = (
+  req: CapturedRequest,
+) => HttpTestServerResponse | Promise<HttpTestServerResponse>;
+
+const defaultHandler: HttpTestServerHandler = () => {
+  throw new Error(
+    "HttpTestServer received a request but no handler is set. Call server.setHandler(...) before exercising the client.",
+  );
+};
+
+/**
+ * A real HTTP server (node:http) listening on an ephemeral loopback port,
+ * for characterization tests that exercise `@kintone/rest-api-client` end
+ * to end -- through a real socket rather than an in-process interceptor --
+ * so the same test keeps passing whether the client is backed by axios or
+ * fetch/undici.
+ *
+ * Usage: start once per test file (in beforeAll), setHandler per test to
+ * script the response, and inspect `requests` to assert what the client
+ * actually sent over the wire.
+ */
+export class HttpTestServer {
+  private readonly server: http.Server;
+  private handler: HttpTestServerHandler = defaultHandler;
+  private _requests: CapturedRequest[] = [];
+
+  private constructor() {
+    this.server = http.createServer((req, res) => this.onRequest(req, res));
+  }
+
+  static async start(): Promise<HttpTestServer> {
+    const instance = new HttpTestServer();
+    await new Promise<void>((resolve) =>
+      instance.server.listen(0, "localhost", resolve),
+    );
+    return instance;
+  }
+
+  private onRequest(req: http.IncomingMessage, res: http.ServerResponse) {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      this.handleRequest(req, res, chunks).catch((e: unknown) => {
+        res.destroy(e instanceof Error ? e : new Error(String(e)));
+      });
+    });
+  }
+
+  private async handleRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    chunks: Buffer[],
+  ): Promise<void> {
+    const rawBody = Buffer.concat(chunks).toString("utf-8");
+    const url = new URL(req.url ?? "/", this.baseUrl);
+    const contentType = req.headers["content-type"] ?? "";
+
+    let body: unknown = rawBody;
+    if (contentType.includes("application/json") && rawBody.length > 0) {
+      try {
+        body = JSON.parse(rawBody);
+      } catch {
+        // Not valid JSON despite the header; keep the raw string so the
+        // assertion surfaces the mismatch instead of the parse error.
+      }
+    }
+
+    const captured: CapturedRequest = {
+      method: req.method ?? "",
+      path: url.pathname,
+      query: url.searchParams,
+      headers: req.headers,
+      body,
+      rawBody,
+    };
+    this._requests.push(captured);
+
+    try {
+      const result = await this.handler(captured);
+      if ("destroySocket" in result) {
+        res.destroy();
+        return;
+      }
+      res.writeHead(result.status, {
+        "Content-Type": "application/json",
+        ...result.headers,
+      });
+      res.end(
+        result.body !== undefined ? JSON.stringify(result.body) : undefined,
+      );
+    } catch (e) {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          code: "TEST_HANDLER_ERROR",
+          message: e instanceof Error ? e.message : String(e),
+        }),
+      );
+    }
+  }
+
+  /** Replaces the response-scripting handler. Call this at the start of each test. */
+  setHandler(handler: HttpTestServerHandler): void {
+    this.handler = handler;
+  }
+
+  /** Requests captured since the server started (or since the last reset()). */
+  get requests(): readonly CapturedRequest[] {
+    return this._requests;
+  }
+
+  /** Clears captured requests and restores the default (throwing) handler. Call between tests. */
+  reset(): void {
+    this._requests = [];
+    this.handler = defaultHandler;
+  }
+
+  get baseUrl(): string {
+    const address = this.server.address() as AddressInfo;
+    return `http://localhost:${address.port}`;
+  }
+
+  async close(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}

--- a/src/__tests__/helpers/multipartFormData.ts
+++ b/src/__tests__/helpers/multipartFormData.ts
@@ -1,0 +1,66 @@
+import type { CapturedRequest } from "./httpTestServer";
+
+export type MultipartPart = {
+  name: string;
+  filename?: string;
+  contentType?: string;
+  data: Buffer;
+};
+
+/**
+ * Minimal multipart/form-data parser for assertions -- not a general-purpose
+ * decoder. The boundary is random per request (form-data generates it), so
+ * tests must extract fields from the parsed parts rather than snapshotting
+ * the raw body.
+ */
+export const parseMultipartFormData = (
+  req: CapturedRequest,
+): MultipartPart[] => {
+  const contentType = req.headers["content-type"] ?? "";
+  const boundaryMatch = /boundary=(?:"([^"]+)"|([^;]+))/.exec(contentType);
+  if (!boundaryMatch) {
+    throw new Error(`Content-Type has no multipart boundary: ${contentType}`);
+  }
+  const boundaryMarker = Buffer.from(
+    `--${boundaryMatch[1] ?? boundaryMatch[2]}`,
+  );
+  const buffer = req.rawBodyBuffer;
+
+  const parts: MultipartPart[] = [];
+  let boundaryStart = buffer.indexOf(boundaryMarker);
+  while (boundaryStart !== -1) {
+    const partStart = boundaryStart + boundaryMarker.length;
+    const nextBoundaryStart = buffer.indexOf(boundaryMarker, partStart);
+    if (nextBoundaryStart === -1) {
+      break;
+    }
+
+    // The segment between this boundary and the next is "\r\n<headers>\r\n\r\n<body>\r\n".
+    let segment = buffer.subarray(partStart, nextBoundaryStart);
+    if (segment.subarray(0, 2).toString("ascii") === "\r\n") {
+      segment = segment.subarray(2);
+    }
+    if (segment.subarray(-2).toString("ascii") === "\r\n") {
+      segment = segment.subarray(0, -2);
+    }
+
+    const headerEnd = segment.indexOf("\r\n\r\n");
+    if (headerEnd !== -1) {
+      const headerText = segment.subarray(0, headerEnd).toString("utf-8");
+      const data = segment.subarray(headerEnd + 4);
+      const dispositionMatch = /name="([^"]*)"(?:;\s*filename="([^"]*)")?/.exec(
+        headerText,
+      );
+      const contentTypeMatch = /Content-Type:\s*([^\r\n]+)/i.exec(headerText);
+      parts.push({
+        name: dispositionMatch?.[1] ?? "",
+        filename: dispositionMatch?.[2],
+        contentType: contentTypeMatch?.[1],
+        data,
+      });
+    }
+
+    boundaryStart = nextBoundaryStart;
+  }
+  return parts;
+};

--- a/src/kintone/__tests__/client.http.test.ts
+++ b/src/kintone/__tests__/client.http.test.ts
@@ -8,12 +8,12 @@ import { ConnectProxyServer } from "../../__tests__/helpers/connectProxyServer";
 import * as packageJson from "../../../package.json";
 
 /**
- * Characterization test for buildRestAPIClient: unlike api.test.ts (which
- * mocks the KintoneRestAPIClient constructor to assert what arguments
- * cli-kintone passes it), this drives a real request through the built
- * client to confirm those arguments actually take effect on the wire --
- * specifically the custom User-Agent, which api.test.ts can only assert
- * was passed as a constructor option.
+ * Characterization test for buildRestAPIClient: unlike
+ * src/__tests__/api.test.ts (which mocks the KintoneRestAPIClient
+ * constructor to assert what arguments cli-kintone passes it), this drives
+ * a real request through the built client to confirm those arguments
+ * actually take effect on the wire -- specifically the custom User-Agent,
+ * which api.test.ts can only assert was passed as a constructor option.
  */
 describe("buildRestAPIClient (HTTP level)", () => {
   let server: HttpTestServer;

--- a/src/kintone/__tests__/client.http.test.ts
+++ b/src/kintone/__tests__/client.http.test.ts
@@ -1,0 +1,108 @@
+import { beforeAll, afterAll, beforeEach } from "vitest";
+import { buildRestAPIClient } from "../client";
+import {
+  HttpTestServer,
+  type CapturedRequest,
+} from "../../__tests__/helpers/httpTestServer";
+import { ConnectProxyServer } from "../../__tests__/helpers/connectProxyServer";
+import * as packageJson from "../../../package.json";
+
+/**
+ * Characterization test for buildRestAPIClient: unlike api.test.ts (which
+ * mocks the KintoneRestAPIClient constructor to assert what arguments
+ * cli-kintone passes it), this drives a real request through the built
+ * client to confirm those arguments actually take effect on the wire --
+ * specifically the custom User-Agent, which api.test.ts can only assert
+ * was passed as a constructor option.
+ */
+describe("buildRestAPIClient (HTTP level)", () => {
+  let server: HttpTestServer;
+
+  beforeAll(async () => {
+    server = await HttpTestServer.start();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  beforeEach(() => {
+    server.reset();
+  });
+
+  it("sends the cli-kintone User-Agent on the actual request", async () => {
+    server.setHandler((_req: CapturedRequest) => ({
+      status: 200,
+      body: { records: [] },
+    }));
+
+    const apiClient = buildRestAPIClient({
+      baseUrl: server.baseUrl,
+      apiToken: "dummy-api-token",
+    });
+
+    await apiClient.record.getAllRecordsWithId({ app: "1", fields: ["$id"] });
+
+    expect(server.requests).toHaveLength(1);
+    // Never assert full equality: the embedded rest-api-client version
+    // changes with the axios -> fetch migration, and the Node/platform
+    // portion varies by machine.
+    expect(server.requests[0].headers["user-agent"]).toContain(
+      `${packageJson.name}@${packageJson.version}`,
+    );
+  });
+});
+
+/**
+ * Characterization test for buildHttpsAgent's proxy path. It cannot use
+ * HttpTestServer: an httpsAgent is only ever selected for https:// targets,
+ * and HttpTestServer only speaks plain http. So instead of a target server,
+ * this points at an unresolvable https:// host (`.invalid` is a reserved
+ * TLD guaranteed never to resolve) with an HttpsProxyAgent attached, and
+ * asserts that the client sends a plaintext `CONNECT host:443` to the proxy
+ * before ever attempting TLS or DNS resolution on the target.
+ *
+ * This is a precise detector for a regression like js-sdk's 0309c872 (a
+ * caller-supplied agent silently dropped): if the agent isn't honored, the
+ * client goes direct, DNS resolution on the .invalid host fails
+ * immediately, and the proxy never sees a CONNECT at all.
+ *
+ * client-cert (pfx) is not covered here: verifying it requires a real TLS
+ * handshake against a server whose certificate the client must trust, and
+ * buildHttpsAgent has no ca/rejectUnauthorized escape hatch -- that needs a
+ * separate vitest project with NODE_EXTRA_CA_CERTS set at process start.
+ * Tracked as a known gap, not attempted in this file.
+ */
+describe("buildRestAPIClient proxy support (HTTP level)", () => {
+  let proxy: ConnectProxyServer;
+
+  beforeAll(async () => {
+    proxy = await ConnectProxyServer.start();
+  });
+
+  afterAll(async () => {
+    await proxy.close();
+  });
+
+  beforeEach(() => {
+    proxy.reset();
+  });
+
+  it("sends a CONNECT for the https target through the configured proxy", async () => {
+    const apiClient = buildRestAPIClient({
+      baseUrl: "https://kintone.invalid",
+      apiToken: "dummy-api-token",
+      httpsProxy: proxy.url,
+    });
+
+    await apiClient.record
+      .getAllRecordsWithId({ app: "1", fields: ["$id"] })
+      .catch(() => {
+        // Expected: the proxy destroys the tunnel before any response, so
+        // the call fails. What matters is what the proxy observed.
+      });
+
+    expect(proxy.connects).toHaveLength(1);
+    expect(proxy.connects[0].target).toBe("kintone.invalid:443");
+  });
+});

--- a/src/record/delete/usecases/__tests__/deleteAll/index.http.test.ts
+++ b/src/record/delete/usecases/__tests__/deleteAll/index.http.test.ts
@@ -117,5 +117,13 @@ describe("deleteAllRecords (HTTP level)", () => {
 
     expect(error).toBeInstanceOf(DeleteAllRecordsError);
     expect(error.detail).toBe("No records are deleted.");
+
+    // Confirms the failure actually came from the scripted 500 response and
+    // not from an unexpected request path hitting the handler's throw
+    // (which HttpTestServer turns into its own 500 with a different body
+    // shape) -- those two failure modes would otherwise be indistinguishable
+    // from the assertions above alone.
+    expect(server.requests).toHaveLength(2);
+    expect(server.requests[1].path).toBe("/k/v1/bulkRequest.json");
   });
 });

--- a/src/record/delete/usecases/__tests__/deleteAll/index.http.test.ts
+++ b/src/record/delete/usecases/__tests__/deleteAll/index.http.test.ts
@@ -1,0 +1,121 @@
+import { beforeAll, afterAll, beforeEach } from "vitest";
+import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import { deleteAllRecords } from "../../deleteAll";
+import { DeleteAllRecordsError } from "../../deleteAll/error";
+import {
+  HttpTestServer,
+  type CapturedRequest,
+} from "../../../../../__tests__/helpers/httpTestServer";
+
+/**
+ * Characterization tests for deleteAllRecords: they pin the exact HTTP
+ * requests `@kintone/rest-api-client` sends and the exact way cli-kintone
+ * reacts to the responses, using a real node:http server instead of an
+ * in-process mock. The point is that this test file keeps passing unchanged
+ * whether the client is backed by axios (current) or fetch/undici (planned
+ * migration) -- a regression in either direction should turn it red.
+ */
+describe("deleteAllRecords (HTTP level)", () => {
+  let server: HttpTestServer;
+  let apiClient: KintoneRestAPIClient;
+
+  beforeAll(async () => {
+    server = await HttpTestServer.start();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  beforeEach(() => {
+    server.reset();
+    apiClient = new KintoneRestAPIClient({
+      baseUrl: server.baseUrl,
+      auth: { apiToken: "dummy-api-token" },
+    });
+  });
+
+  it("fetches record ids then sends a bulkRequest DELETE, and reports success", async () => {
+    server.setHandler((req: CapturedRequest) => {
+      if (req.method === "GET" && req.path === "/k/v1/records.json") {
+        return {
+          status: 200,
+          body: {
+            records: [
+              { $id: { type: "__ID__", value: "1" } },
+              { $id: { type: "__ID__", value: "2" } },
+            ],
+          },
+        };
+      }
+      if (req.method === "POST" && req.path === "/k/v1/bulkRequest.json") {
+        return { status: 200, body: { results: [{}] } };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    await expect(deleteAllRecords(apiClient, "1")).resolves.not.toThrow();
+
+    expect(server.requests).toHaveLength(2);
+
+    const [getRecords, bulkRequest] = server.requests;
+
+    expect(getRecords.method).toBe("GET");
+    expect(getRecords.path).toBe("/k/v1/records.json");
+    expect(getRecords.query.get("app")).toBe("1");
+    expect(getRecords.query.getAll("fields[0]")).toEqual(["$id"]);
+    expect(getRecords.headers["x-cybozu-api-token"]).toBe("dummy-api-token");
+
+    expect(bulkRequest.method).toBe("POST");
+    expect(bulkRequest.path).toBe("/k/v1/bulkRequest.json");
+    expect(bulkRequest.headers["content-type"]).toContain("application/json");
+    expect(bulkRequest.headers["x-cybozu-api-token"]).toBe("dummy-api-token");
+    expect(bulkRequest.body).toStrictEqual({
+      requests: [
+        {
+          api: "/k/v1/records.json",
+          method: "DELETE",
+          payload: { app: "1", ids: [1, 2], revisions: [null, null] },
+        },
+      ],
+    });
+  });
+
+  it("does not call bulkRequest when the app has no records", async () => {
+    server.setHandler((req: CapturedRequest) => {
+      if (req.method === "GET" && req.path === "/k/v1/records.json") {
+        return { status: 200, body: { records: [] } };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    await expect(deleteAllRecords(apiClient, "1")).resolves.not.toThrow();
+
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0].path).toBe("/k/v1/records.json");
+  });
+
+  it("wraps a kintone API error from bulkRequest into DeleteAllRecordsError", async () => {
+    server.setHandler((req: CapturedRequest) => {
+      if (req.method === "GET" && req.path === "/k/v1/records.json") {
+        return { status: 200, body: { records: [{ $id: { value: "1" } }] } };
+      }
+      if (req.method === "POST" && req.path === "/k/v1/bulkRequest.json") {
+        return {
+          status: 500,
+          body: {
+            code: "GAIA_IL22",
+            id: "test-request-id",
+            message: "予期しないエラーが発生しました。",
+          },
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const error = await deleteAllRecords(apiClient, "1").catch((e) => e);
+
+    expect(error).toBeInstanceOf(DeleteAllRecordsError);
+    expect(error.detail).toBe("No records are deleted.");
+  });
+});

--- a/src/record/import/usecases/__tests__/add/index.http.test.ts
+++ b/src/record/import/usecases/__tests__/add/index.http.test.ts
@@ -1,0 +1,148 @@
+import { beforeAll, afterAll, beforeEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { KintoneRestAPIClient } from "@kintone/rest-api-client";
+import type { RecordSchema } from "../../../types/schema";
+import type { LocalRecord } from "../../../types/record";
+import { addRecords } from "../../add";
+import { LocalRecordRepositoryMock } from "../../../repositories/localRecordRepositoryMock";
+import {
+  HttpTestServer,
+  parseMultipartFormData,
+  type CapturedRequest,
+} from "../../../../../__tests__/helpers/httpTestServer";
+
+/**
+ * Characterization test for the FILE field upload path: addRecords ->
+ * apiClient.file.uploadFile -> multipart/form-data POST /k/v1/file.json.
+ * This targets the axios -> fetch migration's riskiest surface for this
+ * repo (js-sdk's fix bd0eb710 "support Stream fields in form-data body for
+ * fetch"): cli-kintone passes a filesystem path, which rest-api-client
+ * turns into a read stream. A large-ish file is used so the body is
+ * genuinely streamed across multiple chunks rather than landing in one.
+ *
+ * Deliberately not asserted: Content-Length vs Transfer-Encoding framing.
+ * A stream body may legitimately switch from a known Content-Length under
+ * axios to chunked transfer-encoding under fetch/undici -- that's a valid
+ * difference in HTTP framing, not a behavioral regression.
+ */
+describe("addRecords file upload (HTTP level)", () => {
+  let server: HttpTestServer;
+  let apiClient: KintoneRestAPIClient;
+  let attachmentsDir: string;
+  let fileBytes: Buffer;
+
+  const RELATIVE_FILE_PATH = path.join("nested", "large-attachment.bin");
+
+  beforeAll(async () => {
+    server = await HttpTestServer.start();
+
+    attachmentsDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "cli-kintone-http-test-"),
+    );
+    fs.mkdirSync(path.join(attachmentsDir, "nested"));
+    // Comfortably over a typical stream highWaterMark (64KB) so the body is
+    // read and forwarded across multiple chunks instead of a single one.
+    fileBytes = Buffer.alloc(256 * 1024);
+    for (let i = 0; i < fileBytes.length; i++) {
+      fileBytes[i] = i % 256;
+    }
+    fs.writeFileSync(path.join(attachmentsDir, RELATIVE_FILE_PATH), fileBytes);
+  });
+
+  afterAll(async () => {
+    await server.close();
+    fs.rmSync(attachmentsDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    server.reset();
+    apiClient = new KintoneRestAPIClient({
+      baseUrl: server.baseUrl,
+      auth: { apiToken: "dummy-api-token" },
+    });
+  });
+
+  it("streams the attachment as multipart/form-data and forwards the returned fileKey", async () => {
+    const schema: RecordSchema = {
+      fields: [
+        {
+          type: "FILE",
+          code: "attachment",
+          label: "attachment",
+          noLabel: false,
+          required: false,
+          thumbnailSize: "150",
+        },
+      ],
+    };
+    const records: LocalRecord[] = [
+      {
+        data: {
+          attachment: {
+            value: [{ localFilePath: RELATIVE_FILE_PATH }],
+          },
+        },
+        metadata: {
+          format: { type: "csv", firstRowIndex: 1, lastRowIndex: 1 },
+        },
+      },
+    ];
+    const repository = new LocalRecordRepositoryMock(records, "csv");
+
+    server.setHandler((req: CapturedRequest) => {
+      if (req.method === "POST" && req.path === "/k/v1/file.json") {
+        return { status: 200, body: { fileKey: "uploaded-file-key" } };
+      }
+      if (req.method === "POST" && req.path === "/k/v1/bulkRequest.json") {
+        return {
+          status: 200,
+          body: { results: [{ ids: ["1"], revisions: ["1"] }] },
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    await expect(
+      addRecords(apiClient, "1", repository, schema, { attachmentsDir }),
+    ).resolves.not.toThrow();
+
+    const uploadRequests = server.requests.filter(
+      (r) => r.path === "/k/v1/file.json",
+    );
+    expect(uploadRequests).toHaveLength(1);
+    const [uploadRequest] = uploadRequests;
+    expect(uploadRequest.headers["content-type"]).toContain(
+      "multipart/form-data",
+    );
+
+    const parts = parseMultipartFormData(uploadRequest);
+    expect(parts).toHaveLength(1);
+    expect(parts[0].name).toBe("file");
+    expect(parts[0].filename).toBe("large-attachment.bin");
+    // The exact bytes the server received must match the source file --
+    // this is the assertion the multipart/stream migration risk is about.
+    expect(Buffer.compare(parts[0].data, fileBytes)).toBe(0);
+
+    const bulkRequests = server.requests.filter(
+      (r) => r.path === "/k/v1/bulkRequest.json",
+    );
+    expect(bulkRequests).toHaveLength(1);
+    const [bulkRequest] = bulkRequests;
+    expect(bulkRequest.body).toStrictEqual({
+      requests: [
+        {
+          api: "/k/v1/records.json",
+          method: "POST",
+          payload: {
+            app: "1",
+            records: [
+              { attachment: { value: [{ fileKey: "uploaded-file-key" }] } },
+            ],
+          },
+        },
+      ],
+    });
+  });
+});

--- a/src/record/import/usecases/__tests__/add/index.http.test.ts
+++ b/src/record/import/usecases/__tests__/add/index.http.test.ts
@@ -9,9 +9,9 @@ import { addRecords } from "../../add";
 import { LocalRecordRepositoryMock } from "../../../repositories/localRecordRepositoryMock";
 import {
   HttpTestServer,
-  parseMultipartFormData,
   type CapturedRequest,
 } from "../../../../../__tests__/helpers/httpTestServer";
+import { parseMultipartFormData } from "../../../../../__tests__/helpers/multipartFormData";
 
 /**
  * Characterization test for the FILE field upload path: addRecords ->
@@ -19,14 +19,48 @@ import {
  * This targets the axios -> fetch migration's riskiest surface for this
  * repo (js-sdk's fix bd0eb710 "support Stream fields in form-data body for
  * fetch"): cli-kintone passes a filesystem path, which rest-api-client
- * turns into a read stream. A large-ish file is used so the body is
- * genuinely streamed across multiple chunks rather than landing in one.
+ * turns into a read stream. A large-ish, non-repeating file is used so the
+ * body is comfortably read across multiple stream chunks (a typical
+ * highWaterMark is 64KB) rather than in one -- though this test only
+ * asserts the resulting bytes are correct on the receiving end, not the
+ * chunking itself (HttpTestServer reassembles the body before exposing it,
+ * so a single-chunk send would look identical here).
  *
  * Deliberately not asserted: Content-Length vs Transfer-Encoding framing.
  * A stream body may legitimately switch from a known Content-Length under
  * axios to chunked transfer-encoding under fetch/undici -- that's a valid
  * difference in HTTP framing, not a behavioral regression.
  */
+
+/**
+ * Deterministic (fixed seed, not Math.random -- Math.random would make a
+ * parser failure unreproducible) pseudo-random bytes, with CRLF and
+ * boundary-like ("--") byte pairs deliberately planted at fixed offsets.
+ * Those two sequences are what a multipart parser can actually trip on
+ * inside file data; a byte stream that never contains them (e.g. a simple
+ * `i % 256` ramp) never exercises that risk regardless of size.
+ */
+const seededPseudoRandomBytes = (length: number): Buffer => {
+  const buffer = Buffer.alloc(length);
+  let state = 0x2463a5c3;
+  for (let i = 0; i < length; i++) {
+    // xorshift32
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    buffer[i] = state & 0xff;
+  }
+  for (let offset = 1000; offset + 1 < length; offset += 4001) {
+    buffer[offset] = 0x0d; // \r
+    buffer[offset + 1] = 0x0a; // \n
+  }
+  for (let offset = 3000; offset + 1 < length; offset += 4001) {
+    buffer[offset] = 0x2d; // -
+    buffer[offset + 1] = 0x2d; // -
+  }
+  return buffer;
+};
+
 describe("addRecords file upload (HTTP level)", () => {
   let server: HttpTestServer;
   let apiClient: KintoneRestAPIClient;
@@ -42,12 +76,13 @@ describe("addRecords file upload (HTTP level)", () => {
       path.join(os.tmpdir(), "cli-kintone-http-test-"),
     );
     fs.mkdirSync(path.join(attachmentsDir, "nested"));
-    // Comfortably over a typical stream highWaterMark (64KB) so the body is
-    // read and forwarded across multiple chunks instead of a single one.
-    fileBytes = Buffer.alloc(256 * 1024);
-    for (let i = 0; i < fileBytes.length; i++) {
-      fileBytes[i] = i % 256;
-    }
+    // Comfortably over a typical stream highWaterMark (64KB). Deterministic
+    // (fixed seed, not Math.random) but not a simple repeating/monotonic
+    // pattern: a multipart parser's actual hazard is a boundary-like byte
+    // sequence or a bare CRLF landing inside the file data, which an `i %
+    // 256` ramp never produces. seededPseudoRandomBytes deliberately mixes
+    // those in.
+    fileBytes = seededPseudoRandomBytes(256 * 1024);
     fs.writeFileSync(path.join(attachmentsDir, RELATIVE_FILE_PATH), fileBytes);
   });
 

--- a/src/utils/__tests__/retry.http.test.ts
+++ b/src/utils/__tests__/retry.http.test.ts
@@ -83,9 +83,13 @@ describe("isRetryableKintoneError (HTTP level)", () => {
   });
 
   it("treats a 502 with a non-JSON (HTML) body from an intermediary as not retryable", async () => {
+    // Deliberately uses `rawBody`, not `body`: `body` always goes through
+    // JSON.stringify, which would turn this HTML into a quoted JSON string
+    // literal -- technically valid JSON, and not what a real intermediary
+    // (proxy/load balancer) sends on a 502. `rawBody` sends the bytes as-is.
     server.setHandler((_req: CapturedRequest) => ({
       status: 502,
-      body: "<html><body>Bad Gateway</body></html>",
+      rawBody: "<html><body>Bad Gateway</body></html>",
       headers: { "Content-Type": "text/html" },
     }));
 

--- a/src/utils/__tests__/retry.http.test.ts
+++ b/src/utils/__tests__/retry.http.test.ts
@@ -82,19 +82,24 @@ describe("isRetryableKintoneError (HTTP level)", () => {
     expect(isRetryableKintoneError(error)).toBe(false);
   });
 
-  it("treats a non-JSON error body from an intermediary as not retryable, without throwing on parse", async () => {
+  it("treats a 502 with a non-JSON (HTML) body from an intermediary as not retryable", async () => {
     server.setHandler((_req: CapturedRequest) => ({
       status: 502,
-      body: undefined,
+      body: "<html><body>Bad Gateway</body></html>",
       headers: { "Content-Type": "text/html" },
     }));
 
     const error = await getAllRecords().catch((e) => e);
 
-    // Whatever shape this ends up being (KintoneRestAPIError or not), the
-    // important invariant is that classifying it never throws and never
-    // reports it as retryable when it isn't a recognized kintone error.
-    expect(() => isRetryableKintoneError(error)).not.toThrow();
+    // A body the client can't parse as a kintone error response means it
+    // never becomes a KintoneRestAPIError -- it stays a plain Error, with
+    // no `status`/`code` for isRetryableKintoneError to key on. That's a
+    // real, user-facing consequence: cli-kintone does NOT retry a 502 from
+    // an intermediary (proxy/load balancer), only 5xx responses that
+    // kintone itself produced as JSON. If this ever flips to true, retries
+    // would silently start happening for a whole new class of errors.
+    expect(error).not.toBeInstanceOf(KintoneRestAPIError);
+    expect(isRetryableKintoneError(error)).toBe(false);
   });
 
   it("does not classify a connection-level failure as a retryable KintoneRestAPIError", async () => {

--- a/src/utils/__tests__/retry.http.test.ts
+++ b/src/utils/__tests__/retry.http.test.ts
@@ -1,0 +1,116 @@
+import { beforeAll, afterAll, beforeEach } from "vitest";
+import {
+  KintoneRestAPIClient,
+  KintoneRestAPIError,
+} from "@kintone/rest-api-client";
+import { isRetryableKintoneError } from "../retry";
+import {
+  HttpTestServer,
+  type CapturedRequest,
+} from "../../__tests__/helpers/httpTestServer";
+
+/**
+ * Characterization tests for isRetryableKintoneError, driven through a real
+ * HTTP round trip rather than a hand-built KintoneRestAPIError. The
+ * hand-built version in retry.test.ts only proves the retry logic is
+ * correct *given* that shape; it can't catch the client itself producing a
+ * different shape after the axios -> fetch migration. These tests pin what
+ * cli-kintone actually receives from `@kintone/rest-api-client` today
+ * (axios-backed), so a change in error shape after the migration turns them
+ * red instead of silently changing retry behavior.
+ */
+describe("isRetryableKintoneError (HTTP level)", () => {
+  let server: HttpTestServer;
+  let apiClient: KintoneRestAPIClient;
+
+  const getAllRecords = () =>
+    apiClient.record.getAllRecordsWithId({ app: "1", fields: ["$id"] });
+
+  beforeAll(async () => {
+    server = await HttpTestServer.start();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  beforeEach(() => {
+    server.reset();
+    apiClient = new KintoneRestAPIClient({
+      baseUrl: server.baseUrl,
+      auth: { apiToken: "dummy-api-token" },
+    });
+  });
+
+  it("treats a 500 kintone error response as retryable", async () => {
+    server.setHandler((_req: CapturedRequest) => ({
+      status: 500,
+      body: { code: "GAIA_IL22", id: "req-1", message: "internal error" },
+    }));
+
+    const error = await getAllRecords().catch((e) => e);
+
+    expect(error).toBeInstanceOf(KintoneRestAPIError);
+    expect(isRetryableKintoneError(error)).toBe(true);
+  });
+
+  it("treats a 400 GAIA_DA02 kintone error response as retryable", async () => {
+    server.setHandler((_req: CapturedRequest) => ({
+      status: 400,
+      body: {
+        code: "GAIA_DA02",
+        id: "req-2",
+        message: "Please wait a while and try again.",
+      },
+    }));
+
+    const error = await getAllRecords().catch((e) => e);
+
+    expect(error).toBeInstanceOf(KintoneRestAPIError);
+    expect(isRetryableKintoneError(error)).toBe(true);
+  });
+
+  it("treats other 4xx kintone error responses as not retryable", async () => {
+    server.setHandler((_req: CapturedRequest) => ({
+      status: 400,
+      body: { code: "GAIA_IL01", id: "req-3", message: "invalid parameter" },
+    }));
+
+    const error = await getAllRecords().catch((e) => e);
+
+    expect(error).toBeInstanceOf(KintoneRestAPIError);
+    expect(isRetryableKintoneError(error)).toBe(false);
+  });
+
+  it("treats a non-JSON error body from an intermediary as not retryable, without throwing on parse", async () => {
+    server.setHandler((_req: CapturedRequest) => ({
+      status: 502,
+      body: undefined,
+      headers: { "Content-Type": "text/html" },
+    }));
+
+    const error = await getAllRecords().catch((e) => e);
+
+    // Whatever shape this ends up being (KintoneRestAPIError or not), the
+    // important invariant is that classifying it never throws and never
+    // reports it as retryable when it isn't a recognized kintone error.
+    expect(() => isRetryableKintoneError(error)).not.toThrow();
+  });
+
+  it("does not classify a connection-level failure as a retryable KintoneRestAPIError", async () => {
+    // Force the socket closed before any HTTP response is written, to
+    // simulate a transport-level failure (as opposed to a kintone API
+    // error response). The concrete error type/message differs between
+    // axios (AxiosError, code ECONNRESET) and fetch (TypeError with a
+    // nested cause) -- that's an expected, known difference of the
+    // migration. What must stay constant is the *classification*: a
+    // transport failure is never a KintoneRestAPIError, so it must never
+    // be treated as retryable by isRetryableKintoneError.
+    server.setHandler((_req: CapturedRequest) => ({ destroySocket: true }));
+
+    const error = await getAllRecords().catch((e) => e);
+
+    expect(error).not.toBeInstanceOf(KintoneRestAPIError);
+    expect(isRetryableKintoneError(error)).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       "src/__tests__/setup.ts",
       "src/plugin/packer/__tests__/helpers/**",
       "src/plugin/init/utils/__tests__/helpers/**",
+      "src/__tests__/helpers/**",
       "**/fixtures/**",
       "src/plugin/init/__e2e__/**",
     ],


### PR DESCRIPTION
## 目的

`@kintone/rest-api-client` は axios → fetch(undici) への移行が計画されている（[kintone/js-sdk#3937](https://github.com/kintone/js-sdk/pull/3937)）。cli-kintone は現在この axios ベースのクライアントに依存しており、この PR はその移行後も cli-kintone の挙動が変わらないことを検証できる**特性化テスト（characterization tests）**を axios ベースのまま先に整備するものです。

### 既存テストで検知できなかったこと

- cli-kintone のユニットテストは `KintoneRestAPIClient` の各メソッド（`record.deleteAllRecords` など）を `vi.fn()` で直接差し替えており、HTTP 層には一切触れていない。
- e2e（cucumber）はビルド済み SEA バイナリを実 kintone 環境に対して実行する形式で、この環境では認証情報がなく実行できない。
- そのため、rest-api-client 内部の HTTP クライアント実装が axios から fetch に変わっても、既存テストは何も検知できない状態だった。

### アプローチ

`node:http` の実サーバーをエフェメラルポートで起動し、`@kintone/rest-api-client` を実ソケット越しに動かす `HttpTestServer` ヘルパーを追加。msw ではなく生ソケットを使っているのは、msw が axios と fetch を別々のコード経路でインターセプトするため、msw ベースの検証では2つのインターセプタ実装を比較するだけになり、js-sdk 側で既に整備されている msw ベースのハーネスと重複してしまうため。

## 追加したテスト

- **`deleteAllRecords`**: `GET /k/v1/records.json` → `POST /k/v1/bulkRequest.json`（DELETE を bulk request 化）という実際のリクエスト列を固定。0件時の早期リターン、kintone エラー時の `DeleteAllRecordsError` 変換も検証。
- **`isRetryableKintoneError`**: 実際の HTTP レスポンス（500 / 400+GAIA_DA02 / その他4xx / 非JSONボディ / トランスポート断）に対してリトライ判定が axios 時代の想定通りになることを検証。特にトランスポート断は axios (`AxiosError`, `ECONNRESET`) と fetch (`TypeError`) で型が変わることを前提に、「型の詳細」ではなく「`KintoneRestAPIError` でない＝リトライ対象外」という不変条件のみを検証する設計。
- **`addRecords` のファイルアップロード**: FILE フィールドの添付ファイルが `multipart/form-data` として `POST /k/v1/file.json` にバイト単位で正しくストリームされることを検証（256KB のファイルで複数チャンクに分割されることを想定）。js-sdk 側の fetch 移行 PR にある `bd0eb710`（"support Stream fields in form-data body for fetch"）が対象にしたリスク領域。
- **`buildRestAPIClient` の User-Agent**: cli-kintone が構築するカスタム User-Agent が実際にワイヤ上に送信されることを確認（コンストラクタ引数の検証だけでは不十分なため）。
- **`buildRestAPIClient` のプロキシ設定**: `httpsProxy` を設定した場合に、実際に `CONNECT <host>:443` がプロキシへ送信されることを検証。`ConnectProxyServer` という最小限の CONNECT 専用プロキシを新規追加。`.invalid` という DNS 解決不能なホストを使うことで、エージェントが握りつぶされて直接接続にフォールバックした場合に確実に検知できる設計（js-sdk 側の `0309c872` のような httpsAgent 回帰を狙い撃ちする）。実際に `httpsProxy` を外すとこのテストが red になることを確認済み。

## 既知のギャップ（未対応）

- クライアント証明書（pfx）の検証は、自己署名証明書を使った実 TLS ハンドシェイクと、プロセス起動時に設定する `NODE_EXTRA_CA_CERTS` が必要なため、別の vitest プロジェクト設定が必要になる。今回は対象外とし、既知のギャップとして残しています。
- レコードエクスポートのカーソルページング（`/k/v1/records/cursor.json`）は cli-kintone で最も呼び出し頻度が高い経路の一つだが未対応。
- リダイレクト時のボディ再送（307/308）も未対応。
- 本 PR は axios ベースでの特性化テストの整備までで、実際に fetch 版の `@kintone/rest-api-client` に差し替えて green のままであることの確認は行っていません（次のステップ）。

## 動作確認

- `pnpm test`（vitest）: 新規追加分は全て green。既存の失敗2件（`lib/` 未ビルドによるもの）は本 PR と無関係で、変更前から同一。
- `pnpm lint:eslint` / `pnpm typecheck`: green。