### PR TITLE
fix(deps): pin browserslist past the prototype write advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,21 +114,5 @@
     "yauzl": "3.2.1",
     "yazl": "3.3.1"
   },
-  "packageManager": "pnpm@10.30.3",
-  "pnpm": {
-    "overrides": {
-      "braces": ">=3.0.3",
-      "undici": ">=7.18.2",
-      "ws": ">=8.21.3",
-      "brace-expansion@^1": ">=1.1.16 <2",
-      "brace-expansion@^2": ">=2.1.2 <3",
-      "brace-expansion@^5": ">=5.0.9",
-      "js-yaml@^4": ">=4.3.2",
-      "shell-quote": ">=1.9.0",
-      "websocket-driver": ">=0.7.5",
-      "fast-uri": ">=4.1.2",
-      "immutable": ">=5.1.9",
-      "svgo": ">=3.3.5"
-    }
-  }
+  "packageManager": "pnpm@10.30.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   ws: '>=8.21.3'
   brace-expansion@^1: '>=1.1.16 <2'
   brace-expansion@^2: '>=2.1.2 <3'
-  brace-expansion@^5: '>=5.0.9'
+  brace-expansion@^5: '>=5.0.9 <6'
   js-yaml@^4: '>=4.3.2'
   shell-quote: '>=1.9.0'
   websocket-driver: '>=0.7.5'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   js-yaml@^4: '>=4.3.2'
   shell-quote: '>=1.9.0'
   websocket-driver: '>=0.7.5'
-  fast-uri: '>=4.1.2'
+  fast-uri: '>=4.1.3'
   immutable: '>=5.1.9'
   svgo: '>=3.3.5'
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   braces: '>=3.0.3'
+  browserslist: '>=4.28.7 <5'
   undici: '>=7.18.2'
   ws: '>=8.21.3'
   brace-expansion@^1: '>=1.1.16 <2'
@@ -3489,8 +3490,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.8.6:
-    resolution: {integrity: sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==}
+  baseline-browser-mapping@2.11.20:
+    resolution: {integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   batch@0.6.1:
@@ -3544,8 +3546,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.26.2:
-    resolution: {integrity: sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3614,6 +3616,9 @@ packages:
 
   caniuse-lite@1.0.30001745:
     resolution: {integrity: sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==}
+
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
@@ -4228,8 +4233,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.223:
-    resolution: {integrity: sha512-qKm55ic6nbEmagFlTFczML33rF90aU+WtrJ9MdTCThrcvDNdUHN4p6QfVN78U06ZmguqXIyMPyYhw2TrbDUwPQ==}
+  electron-to-chromium@1.5.420:
+    resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -5944,8 +5949,9 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-releases@2.0.21:
-    resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
+    engines: {node: '>=18'}
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -7814,11 +7820,11 @@ packages:
   unzipper@0.12.3:
     resolution: {integrity: sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==}
 
-  update-browserslist-db@1.1.3:
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
-      browserslist: '>= 4.21.0'
+      browserslist: '>=4.28.7 <5'
 
   update-notifier@6.0.2:
     resolution: {integrity: sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==}
@@ -8440,7 +8446,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.28.5
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -12262,7 +12268,7 @@ snapshots:
 
   autoprefixer@10.4.21(postcss@8.5.16):
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001745
       fraction.js: 4.3.7
       normalize-range: 0.1.2
@@ -12370,7 +12376,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.8.6: {}
+  baseline-browser-mapping@2.11.20: {}
 
   batch@0.6.1: {}
 
@@ -12451,13 +12457,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.26.2:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.8.6
-      caniuse-lite: 1.0.30001745
-      electron-to-chromium: 1.5.223
-      node-releases: 2.0.21
-      update-browserslist-db: 1.1.3(browserslist@4.26.2)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.420
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
   buffer-crc32@0.2.13: {}
 
@@ -12520,12 +12526,14 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001745
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001745: {}
+
+  caniuse-lite@1.0.30001810: {}
 
   capital-case@1.0.4:
     dependencies:
@@ -12764,7 +12772,7 @@ snapshots:
 
   core-js-compat@3.45.1:
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
 
   core-js@3.45.1: {}
 
@@ -12888,7 +12896,7 @@ snapshots:
   cssnano-preset-advanced@6.1.2(postcss@8.5.16):
     dependencies:
       autoprefixer: 10.4.21(postcss@8.5.16)
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       cssnano-preset-default: 6.1.2(postcss@8.5.16)
       postcss: 8.5.16
       postcss-discard-unused: 6.0.5(postcss@8.5.16)
@@ -12898,7 +12906,7 @@ snapshots:
 
   cssnano-preset-default@6.1.2(postcss@8.5.16):
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       css-declaration-sorter: 7.3.0(postcss@8.5.16)
       cssnano-utils: 4.0.2(postcss@8.5.16)
       postcss: 8.5.16
@@ -13134,7 +13142,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.223: {}
+  electron-to-chromium@1.5.420: {}
 
   emoji-regex@8.0.0: {}
 
@@ -15356,7 +15364,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.21: {}
+  node-releases@2.0.54: {}
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -15695,7 +15703,7 @@ snapshots:
 
   postcss-colormin@6.1.0(postcss@8.5.16):
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.5.16
@@ -15703,7 +15711,7 @@ snapshots:
 
   postcss-convert-values@6.1.0(postcss@8.5.16):
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       postcss: 8.5.16
       postcss-value-parser: 4.2.0
 
@@ -15827,7 +15835,7 @@ snapshots:
 
   postcss-merge-rules@6.1.1(postcss@8.5.16):
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       cssnano-utils: 4.0.2(postcss@8.5.16)
       postcss: 8.5.16
@@ -15847,7 +15855,7 @@ snapshots:
 
   postcss-minify-params@6.1.0(postcss@8.5.16):
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       cssnano-utils: 4.0.2(postcss@8.5.16)
       postcss: 8.5.16
       postcss-value-parser: 4.2.0
@@ -15916,7 +15924,7 @@ snapshots:
 
   postcss-normalize-unicode@6.1.0(postcss@8.5.16):
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       postcss: 8.5.16
       postcss-value-parser: 4.2.0
 
@@ -15993,7 +16001,7 @@ snapshots:
       '@csstools/postcss-trigonometric-functions': 4.0.9(postcss@8.5.16)
       '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.16)
       autoprefixer: 10.4.21(postcss@8.5.16)
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       css-blank-pseudo: 7.0.1(postcss@8.5.16)
       css-has-pseudo: 7.0.3(postcss@8.5.16)
       css-prefers-color-scheme: 10.0.0(postcss@8.5.16)
@@ -16037,7 +16045,7 @@ snapshots:
 
   postcss-reduce-initial@6.1.0(postcss@8.5.16):
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
       postcss: 8.5.16
 
@@ -17089,7 +17097,7 @@ snapshots:
 
   stylehacks@6.1.1(postcss@8.5.16):
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       postcss: 8.5.16
       postcss-selector-parser: 6.1.2
 
@@ -17456,9 +17464,9 @@ snapshots:
       graceful-fs: 4.2.11
       node-int64: 0.4.0
 
-  update-browserslist-db@1.1.3(browserslist@4.26.2):
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -17693,7 +17701,7 @@ snapshots:
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.15.0
       acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.26.2
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.18.3
       es-module-lexer: 1.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,7 @@ minimumReleaseAgeExclude:
 
 overrides:
   braces: ">=3.0.3"
+  browserslist: ">=4.28.7 <5"
   undici: ">=7.18.2"
   ws: ">=8.21.3"
   brace-expansion@^1: ">=1.1.16 <2"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,7 +25,7 @@ overrides:
   ws: ">=8.21.3"
   brace-expansion@^1: ">=1.1.16 <2"
   brace-expansion@^2: ">=2.1.2 <3"
-  brace-expansion@^5: ">=5.0.9"
+  brace-expansion@^5: ">=5.0.9 <6"
   js-yaml@^4: ">=4.3.2"
   shell-quote: ">=1.9.0"
   websocket-driver: ">=0.7.5"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,17 @@ minimumReleaseAgeExclude:
   - "@kintone/rest-api-client@6.2.1"
   # Renovate security update: fast-uri@4.1.2
   - fast-uri@4.1.2
+
+overrides:
+  braces: ">=3.0.3"
+  undici: ">=7.18.2"
+  ws: ">=8.21.3"
+  brace-expansion@^1: ">=1.1.16 <2"
+  brace-expansion@^2: ">=2.1.2 <3"
+  brace-expansion@^5: ">=5.0.9"
+  js-yaml@^4: ">=4.3.2"
+  shell-quote: ">=1.9.0"
+  websocket-driver: ">=0.7.5"
+  fast-uri: ">=4.1.2"
+  immutable: ">=5.1.9"
+  svgo: ">=3.3.5"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,8 +17,6 @@ minimumReleaseAgeExclude:
   - ws@8.21.0
   # First-party package
   - "@kintone/rest-api-client@6.2.1"
-  # Renovate security update: fast-uri@4.1.2
-  - fast-uri@4.1.2
 
 overrides:
   braces: ">=3.0.3"
@@ -31,6 +29,6 @@ overrides:
   js-yaml@^4: ">=4.3.2"
   shell-quote: ">=1.9.0"
   websocket-driver: ">=0.7.5"
-  fast-uri: ">=4.1.2"
+  fast-uri: ">=4.1.3"
   immutable: ">=5.1.9"
   svgo: ">=3.3.5"


### PR DESCRIPTION
## Why

browserslist 4.28.6 and earlier crash or write to the prototype while normalizing custom stats (CVE-2026-73088, GHSA-73wf-gq98-2v4g, CVSS 7.5). The lockfile carried 4.26.2, pulled in through webpack, autoprefixer, postcss and other build-time dependencies.

Nothing was going to fix this on its own. Neither Renovate nor Dependabot opened anything for the advisory, and bumping the parents does not help either, because 4.26.2 already satisfies the `^4` range they declare. The minimum has to be raised by hand.

Pinning it surfaced a second problem. pnpm warns that the `pnpm` field in `package.json` is no longer read and that `pnpm.overrides` is ignored, so the security pins added there were no longer configuration at all — they only survived as values already written into `pnpm-lock.yaml`. A new entry had no effect on resolution, which is why the pin could not simply be appended.

## What

Moved the overrides to `pnpm-workspace.yaml`, where pnpm still reads them, and dropped the `pnpm` field from `package.json`. The lockfile does not change across that commit, which is what confirms the two locations resolve identically. The warning is gone afterwards.

Pinned browserslist to `>=4.28.7 <5` on top of that, which resolves to 4.28.8. The upper bound keeps the override inside major 4 so the pin cannot drag consumers across a major boundary later.

Raised the fast-uri floor from `>=4.1.2` to `>=4.1.3`. The value that #1575 landed is the patched version for CVE-2026-18446, but four later advisories (CVE-2026-76172, CVE-2026-75899, CVE-2026-75975, CVE-2026-75931 — host confusion and SSRF, CVSS 7.5 each) are only patched in 4.1.3. The lockfile already resolved to 4.1.3, so the floor was the only thing still admitting a vulnerable version. The `minimumReleaseAgeExclude` entry for 4.1.2 goes away with it, since no version the override allows matches it; 4.1.3 was published on 2026-08-23 and needs no exclusion of its own.

<details>

<summary>変更・実装における判断</summary>

- Refreshing the lockfile with `pnpm update browserslist --depth Infinity` also reaches 4.28.8, but it leaves nothing pinned and drags unrelated dependencies along inside their existing ranges (rollup, postcss, nanoid, fdir, picomatch), which grows the lockfile diff from 82 to 336 lines. Pinning keeps the change to browserslist and its own dependency tree.
- The advisory is only reachable through custom stats — a `browserslist-stats.json`, the `BROWSERSLIST_STATS` variable, or a query such as `> 5% in my stats`. This repository uses none of them, and browserslist is a build-time dependency here, so this closes an unpatched dependency rather than an exploitable path.
- The overrides move is kept as its own commit so the "lockfile unchanged" property is visible in history rather than mixed into the pin.

</details>

## How to test

```bash
pnpm install --frozen-lockfile
grep -n '^  browserslist@' pnpm-lock.yaml
```

Every match should be 4.28.7 or later; on this branch the only one is 4.28.8. `pnpm` should no longer warn about `pnpm.overrides` being ignored.

Dependencies were not installed locally, so lint, typecheck and test have not been run on this branch and are left to CI.

## Checklist

- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [ ] Passed lint and test on the root directory.
