### PR TITLE
fix(deps): pin svgo below v4 past the removeScripts advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   websocket-driver: '>=0.7.5'
   fast-uri: '>=4.1.3'
   immutable: '>=5.1.9'
-  svgo: '>=3.3.5'
+  svgo: '>=3.3.5 <4'
 
 importers:
 
@@ -3988,8 +3988,8 @@ packages:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
-  css-tree@3.2.1:
-    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+  css-tree@2.3.1:
+    resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-what@6.2.2:
@@ -5626,11 +5626,11 @@ packages:
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
+  mdn-data@2.0.30:
+    resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
   mdn-data@2.23.0:
     resolution: {integrity: sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==}
-
-  mdn-data@2.27.1:
-    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -7519,9 +7519,9 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
-  svgo@4.0.2:
-    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
-    engines: {node: '>=16'}
+  svgo@3.3.5:
+    resolution: {integrity: sha512-8SQMzdrvWaD8deUmrnYB+ASyxBVgWUOilg+A75nE/76WdLpj6LopCwiAVvkzkcqy/9b7t2Mg7faFLjg0ZRcZ3w==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
 
   synckit@0.11.12:
@@ -11430,7 +11430,7 @@ snapshots:
       '@svgr/core': 8.1.0(typescript@5.9.3)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       deepmerge: 4.3.1
-      svgo: 4.0.2
+      svgo: 3.3.5
     transitivePeerDependencies:
       - typescript
 
@@ -12882,9 +12882,9 @@ snapshots:
       mdn-data: 2.0.28
       source-map-js: 1.2.1
 
-  css-tree@3.2.1:
+  css-tree@2.3.1:
     dependencies:
-      mdn-data: 2.27.1
+      mdn-data: 2.0.30
       source-map-js: 1.2.1
 
   css-what@6.2.2: {}
@@ -14914,9 +14914,9 @@ snapshots:
 
   mdn-data@2.0.28: {}
 
-  mdn-data@2.23.0: {}
+  mdn-data@2.0.30: {}
 
-  mdn-data@2.27.1: {}
+  mdn-data@2.23.0: {}
 
   media-typer@0.3.0: {}
 
@@ -16082,7 +16082,7 @@ snapshots:
     dependencies:
       postcss: 8.5.16
       postcss-value-parser: 4.2.0
-      svgo: 4.0.2
+      svgo: 3.3.5
 
   postcss-unique-selectors@6.0.4(postcss@8.5.16):
     dependencies:
@@ -17117,11 +17117,11 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
-  svgo@4.0.2:
+  svgo@3.3.5:
     dependencies:
-      commander: 11.1.0
+      commander: 7.2.0
       css-select: 5.2.2
-      css-tree: 3.2.1
+      css-tree: 2.3.1
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,4 +31,7 @@ overrides:
   websocket-driver: ">=0.7.5"
   fast-uri: ">=4.1.3"
   immutable: ">=5.1.9"
-  svgo: ">=3.3.5"
+  # Upper bound keeps svgo on the v3 line, which both consumers declare:
+  # @svgr/plugin-svgo@8.1.0 and postcss-svgo@6.0.3 depend on `svgo: ^3`.
+  # Drop `<4` once they support v4, or if the v3 line stops receiving backports.
+  svgo: ">=3.3.5 <4"


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

The lockfile resolved `svgo` to 4.0.2, which is affected by two advisories published on 2026-09-01: [GHSA-w27v-7q3p-w38r](https://github.com/advisories/GHSA-w27v-7q3p-w38r) (CVE-2026-84370, high) and a companion moderate one. In both, the opt-in `removeScripts` plugin fails to strip every executable link — namespace-prefixed SVG anchors, URL schemes containing ASCII tabs or newlines, and executable HTML inside `foreignObject`.

Nothing in this repository feeds attacker-controlled SVGs to `svgo`. It reaches us only through the documentation site's build — Docusaurus 3.10.2 pulls it in via `@svgr/plugin-svgo` and `postcss-svgo` — so the practical exposure is low. There is no reason to stay on an affected version either.

## What

The `svgo` override now carries an upper bound, so it resolves to 3.3.5 — the patched release for the v3 line — instead of 4.0.2. The transitive `css-tree`, `mdn-data`, and `commander` follow it back to their v3-era versions; none of them carry advisories of their own.

The previous override, `>=3.3.5`, had no upper bound. Both packages that consume `svgo` here declare `svgo: ^3`, so the unbounded range was quietly pulling in a major version neither of them supports.

<details><summary>Implementation decisions</summary>

**Why the v3 line rather than 4.1.0.** `@svgr/plugin-svgo` (8.1.0) and `postcss-svgo` (6.0.3) both declare `svgo: ^3`, and both arrive through Docusaurus 3.10.2 — their ranges are not ours to widen. Pinning to 4.1.0 would keep the override outside the range its consumers guarantee. That matters more than it looks: SVGO v4 disables `removeViewBox` and `removeTitle` by default, so the optimizer's output differs from v3 even when the build succeeds. Staying inside the declared range removes that silent divergence as well as the advisories.

**Whether the v3 line is a dead end.** SVGO backports security fixes across release lines — 4.1.0, 3.3.5, and 2.8.4 shipped on the same day, as did the 2026-03-04 and 2026-07-11 sets. Only v1 is marked unmaintained. The v3 line still receives the fixes it needs.

**Why the override carries a comment.** pnpm does not warn when an override violates a consumer's declared range, which is why 4.0.2 went unnoticed. The comment records the condition for dropping `<4` so the next person to touch the line does not have to rediscover it.

</details>

## How to test

```sh
pnpm install
pnpm why svgo   # expect 3.3.5

pnpm doc:build  # en and ja both build
pnpm typecheck
pnpm lint
pnpm test
```

Locally: `doc:build` exits 0 for both locales, `typecheck` and `lint` pass, and `test` reports 63 files / 318 passed, 2 skipped.

## Checklist

- [ ] Read [CONTRIBUTING.md](https://github.com/kintone/cli-kintone/blob/main/CONTRIBUTING.md)
- [ ] Updated documentation if it is required.
- [ ] Added/updated tests if it is required. (or tested manually)
- [ ] Passed `pnpm lint` and `pnpm test` on the root directory.